### PR TITLE
Zip parameter without value

### DIFF
--- a/src/tests/__snapshots__/RunTestsTest__test_run_with_additional_woo_plugins__1.json
+++ b/src/tests/__snapshots__/RunTestsTest__test_run_with_additional_woo_plugins__1.json
@@ -3,7 +3,6 @@
     "method": "POST",
     "post_body": {
         "additional_woo_plugins": "456,789",
-        "zip": false,
         "woo_id": 123,
         "event": "cli_published_extension_test"
     },

--- a/src/tests/__snapshots__/RunTestsTest__test_run_with_additional_woo_plugins__2.json
+++ b/src/tests/__snapshots__/RunTestsTest__test_run_with_additional_woo_plugins__2.json
@@ -3,7 +3,6 @@
     "method": "POST",
     "post_body": {
         "additional_woo_plugins": "456,789",
-        "zip": false,
         "woo_id": "123",
         "event": "cli_published_extension_test"
     },

--- a/src/tests/__snapshots__/RunTestsTest__test_run_with_additional_woo_plugins__3.json
+++ b/src/tests/__snapshots__/RunTestsTest__test_run_with_additional_woo_plugins__3.json
@@ -3,7 +3,6 @@
     "method": "POST",
     "post_body": {
         "additional_woo_plugins": "456,789",
-        "zip": false,
         "woo_id": 123,
         "event": "cli_published_extension_test"
     },


### PR DESCRIPTION
Allow to pass `--zip` without a filename/path, this will default to the slug/ID of the extension, eg:

- `qit run:security my-extension --zip`
 
Is the same as:

- `qit run:security my-extension --zip=my-extension.zip`

And

- `qit run:security 123 --zip`
 
Is the same as:

- `qit run:security 123 --zip=123.zip`

It's still possible to pass a path in zip, eg: `qit run:security my-extension --zip=/some/path/my-extension.zip`
