### PR TITLE
Normalize order of security test result JSON for snapshot testing

### DIFF
--- a/_tests/tests/QITE2ETestCase.php
+++ b/_tests/tests/QITE2ETestCase.php
@@ -18,6 +18,19 @@ class QITE2ETestCase extends TestCase {
 			$this->fail( 'Test result file is not a JSON: ' . $file_path );
 		}
 
+		/*
+		 * Sort 'phpcs' and 'semgrep' files in security tests,
+		 * so that the order in which the files are scanned do
+		 * not change the JSON of the test.
+		 */
+		if ( isset( $json_data['test_result_json']['tool']['phpcs']['files'] ) ) {
+			uksort( $json_data['test_result_json']['tool']['phpcs']['files'], 'strcmp' );
+		}
+
+		if ( isset( $json_data['test_result_json']['tool']['semgrep']['files'] ) ) {
+			uksort( $json_data['test_result_json']['tool']['semgrep']['files'], 'strcmp' );
+		}
+
 		$rules = [
 			'run_id'                          => [
 				'normalize' => 123456,

--- a/_tests/tests/__snapshots__/SecurityTest__test_security_exclusions__1.php
+++ b/_tests/tests/__snapshots__/SecurityTest__test_security_exclusions__1.php
@@ -41,7 +41,7 @@
                             "fixable": 0
                         },
                         "files": {
-                            "\\/home\\/runner\\/work\\/compatibility-dashboard\\/compatibility-dashboard\\/ci\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php": {
+                            "\\/home\\/runner\\/work\\/compatibility-dashboard\\/compatibility-dashboard\\/ci\\/plugins\\/woocommerce-product-feeds\\/exclude-escaped-output\\/woocommerce-product-feeds.php": {
                                 "errors": 2,
                                 "warnings": 3,
                                 "messages": [
@@ -92,7 +92,7 @@
                                     }
                                 ]
                             },
-                            "\\/home\\/runner\\/work\\/compatibility-dashboard\\/compatibility-dashboard\\/ci\\/plugins\\/woocommerce-product-feeds\\/exclude-escaped-output\\/woocommerce-product-feeds.php": {
+                            "\\/home\\/runner\\/work\\/compatibility-dashboard\\/compatibility-dashboard\\/ci\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php": {
                                 "errors": 2,
                                 "warnings": 3,
                                 "messages": [


### PR DESCRIPTION
This PR solves flakiness in self-tests of security tests, by ordering the list of tested files before doing a snapshot assertion.