### PR TITLE
Use 'raw' download URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can install QIT in three different ways:
 
 ### Globally Using `wget`
 
-1. Run `wget https://github.com/woocommerce/qit-cli/blob/trunk/qit`
+1. Run `wget https://github.com/woocommerce/qit-cli/raw/trunk/qit`
 2. Execute `chmod +x qit`
 3. Move the file to a directory in your PATH, such as `sudo mv qit /usr/local/bin/qit`
 4. Run `qit` to authenticate with your WooCommerce.com Partner Developer account.


### PR DESCRIPTION
Hi! Minor thing:

```
1. Run `wget https://github.com/woocommerce/qit-cli/blob/trunk/qit`
```

This fails because it is the URL of a webpage. If we want to fetch the binary with Wget/Curl etc we probably need to use [`https://github.com/woocommerce/qit-cli/raw/trunk/qit`](https://github.com/woocommerce/qit-cli/raw/trunk/qit).

### Testing instructions

1. Try following the updated instructions to install globally using `wget`.
2. Try to run the `qit` binary. It should work!