### PR TITLE
Update Self Tests

### DIFF
--- a/_tests/api/valid_features/env.php
+++ b/_tests/api/valid_features/env.php
@@ -1,0 +1,7 @@
+<?php
+return [
+	'php'      => '7.4',
+	'wp'       => 'stable',
+	'woo'      => 'stable',
+	'features' => 'hpos,new_product_editor',
+];

--- a/_tests/api/valid_features/woocommerce-product-feeds/woocommerce-product-feeds.php
+++ b/_tests/api/valid_features/woocommerce-product-feeds/woocommerce-product-feeds.php
@@ -4,7 +4,7 @@
  * Plugin name: API - Log that the  New Product Editor is enabled.
  */
 
- add_action( 'woocommerce_admin_get_feature_config', static function( $features ) {
+ add_filter( 'woocommerce_admin_get_feature_config', static function( $features ) {
 	if ( 
 		array_key_exists( 'new-product-management-experience', $features ) &&
 		$features['new-product-management-experience'] === true

--- a/_tests/api/valid_features/woocommerce-product-feeds/woocommerce-product-feeds.php
+++ b/_tests/api/valid_features/woocommerce-product-feeds/woocommerce-product-feeds.php
@@ -11,4 +11,6 @@
 	) {
 		trigger_error( "New Product Editor is enabled as expected." );
 	}
+
+	return $features;
 }, 99 );

--- a/_tests/api/valid_features/woocommerce-product-feeds/woocommerce-product-feeds.php
+++ b/_tests/api/valid_features/woocommerce-product-feeds/woocommerce-product-feeds.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * Plugin name: API - Trigger failure when New Product Editor is not enabled.
+ */
+
+ add_action( 'woocommerce_admin_get_feature_config', static function( $features ) {
+	$features_controller = wc_get_container()->get( 'Automattic\WooCommerce\Internal\Features\FeaturesController' );
+	if ( 
+		array_key_exists( 'new-product-management-experience', $features ) &&
+		$features['new-product-management-experience'] === true
+	) {
+		trigger_error( "New Product Editor is enabled as expected." );
+	}
+}, 99 );

--- a/_tests/api/valid_features/woocommerce-product-feeds/woocommerce-product-feeds.php
+++ b/_tests/api/valid_features/woocommerce-product-feeds/woocommerce-product-feeds.php
@@ -5,7 +5,6 @@
  */
 
  add_action( 'woocommerce_admin_get_feature_config', static function( $features ) {
-	$features_controller = wc_get_container()->get( 'Automattic\WooCommerce\Internal\Features\FeaturesController' );
 	if ( 
 		array_key_exists( 'new-product-management-experience', $features ) &&
 		$features['new-product-management-experience'] === true

--- a/_tests/api/valid_features/woocommerce-product-feeds/woocommerce-product-feeds.php
+++ b/_tests/api/valid_features/woocommerce-product-feeds/woocommerce-product-feeds.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Plugin name: API - Trigger failure when New Product Editor is not enabled.
+ * Plugin name: API - Log that the  New Product Editor is enabled.
  */
 
  add_action( 'woocommerce_admin_get_feature_config', static function( $features ) {

--- a/_tests/tests/__snapshots__/ActivationTest__test_activation_generic__1.php
+++ b/_tests/tests/__snapshots__/ActivationTest__test_activation_generic__1.php
@@ -23,7 +23,7 @@
             "event": "cli_development_extension_test",
             "optional_features": {
                 "hpos": false,
-                "cc_blocks": false
+                "new_product_editor": false
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,

--- a/_tests/tests/__snapshots__/ActivationTest__test_activation_genericphp74wp62__1.php
+++ b/_tests/tests/__snapshots__/ActivationTest__test_activation_genericphp74wp62__1.php
@@ -23,7 +23,7 @@
             "event": "cli_development_extension_test",
             "optional_features": {
                 "hpos": false,
-                "cc_blocks": false
+                "new_product_editor": false
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,

--- a/_tests/tests/__snapshots__/ActivationTest__test_activation_php81__1.php
+++ b/_tests/tests/__snapshots__/ActivationTest__test_activation_php81__1.php
@@ -23,7 +23,7 @@
             "event": "cli_development_extension_test",
             "optional_features": {
                 "hpos": false,
-                "cc_blocks": false
+                "new_product_editor": false
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,

--- a/_tests/tests/__snapshots__/ActivationTest__test_activation_php82__1.php
+++ b/_tests/tests/__snapshots__/ActivationTest__test_activation_php82__1.php
@@ -23,7 +23,7 @@
             "event": "cli_development_extension_test",
             "optional_features": {
                 "hpos": false,
-                "cc_blocks": false
+                "new_product_editor": false
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,

--- a/_tests/tests/__snapshots__/ApiTest__test_api_delete_products__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_delete_products__1.php
@@ -23,7 +23,7 @@
             "event": "cli_development_extension_test",
             "optional_features": {
                 "hpos": false,
-                "cc_blocks": false
+                "new_product_editor": false
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,

--- a/_tests/tests/__snapshots__/ApiTest__test_api_no_op_php82__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_no_op_php82__1.php
@@ -23,7 +23,7 @@
             "event": "cli_development_extension_test",
             "optional_features": {
                 "hpos": false,
-                "cc_blocks": false
+                "new_product_editor": false
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,

--- a/_tests/tests/__snapshots__/ApiTest__test_api_order_cache_bug__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_order_cache_bug__1.php
@@ -23,7 +23,7 @@
             "event": "cli_development_extension_test",
             "optional_features": {
                 "hpos": true,
-                "cc_blocks": false
+                "new_product_editor": false
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,

--- a/_tests/tests/__snapshots__/ApiTest__test_api_valid_features__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_valid_features__1.php
@@ -1379,32 +1379,8 @@
         {
             "debug_log": [
                 {
-                    "count": "4287",
-                    "message": "PHP Warning: array_filter() expects parameter 1 to be array, null given in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce\\/src\\/Internal\\/Admin\\/FeaturePlugin.php on line 211"
-                },
-                {
-                    "count": "4287",
-                    "message": "PHP Warning: array_keys() expects parameter 1 to be array, null given in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce\\/src\\/Internal\\/Admin\\/FeaturePlugin.php on line 211"
-                },
-                {
-                    "count": "3676",
-                    "message": "PHP Warning: array_diff(): Expected parameter 1 to be an array, null given in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce\\/src\\/Admin\\/Features\\/Features.php on line 184"
-                },
-                {
-                    "count": "3676",
-                    "message": "PHP Warning: array_values() expects parameter 1 to be array, null given in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce\\/src\\/Admin\\/Features\\/Features.php on line 184"
-                },
-                {
-                    "count": "3676",
-                    "message": "PHP Warning: in_array() expects parameter 2 to be array, null given in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce\\/src\\/Admin\\/Features\\/Features.php on line 195"
-                },
-                {
-                    "count": "611",
-                    "message": "PHP Warning: Invalid argument supplied for foreach() in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce\\/src\\/Admin\\/Features\\/Features.php on line 135"
-                },
-                {
-                    "count": "4251",
-                    "message": "PHP Notice: New Product Editor is enabled as expected. in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 13"
+                    "count": "607",
+                    "message": "PHP Notice: New Product Editor is enabled as expected. in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 12"
                 },
                 {
                     "count": "3",

--- a/_tests/tests/__snapshots__/ApiTest__test_api_valid_features__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_valid_features__1.php
@@ -22,8 +22,8 @@
             "client": "qit_cli",
             "event": "cli_development_extension_test",
             "optional_features": {
-                "hpos": false,
-                "new_product_editor": false
+                "hpos": true,
+                "new_product_editor": true
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
@@ -1378,6 +1378,34 @@
         },
         {
             "debug_log": [
+                {
+                    "count": "4287",
+                    "message": "PHP Warning: array_filter() expects parameter 1 to be array, null given in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce\\/src\\/Internal\\/Admin\\/FeaturePlugin.php on line 211"
+                },
+                {
+                    "count": "4287",
+                    "message": "PHP Warning: array_keys() expects parameter 1 to be array, null given in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce\\/src\\/Internal\\/Admin\\/FeaturePlugin.php on line 211"
+                },
+                {
+                    "count": "3676",
+                    "message": "PHP Warning: array_diff(): Expected parameter 1 to be an array, null given in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce\\/src\\/Admin\\/Features\\/Features.php on line 184"
+                },
+                {
+                    "count": "3676",
+                    "message": "PHP Warning: array_values() expects parameter 1 to be array, null given in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce\\/src\\/Admin\\/Features\\/Features.php on line 184"
+                },
+                {
+                    "count": "3676",
+                    "message": "PHP Warning: in_array() expects parameter 2 to be array, null given in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce\\/src\\/Admin\\/Features\\/Features.php on line 195"
+                },
+                {
+                    "count": "611",
+                    "message": "PHP Warning: Invalid argument supplied for foreach() in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce\\/src\\/Admin\\/Features\\/Features.php on line 135"
+                },
+                {
+                    "count": "4251",
+                    "message": "PHP Notice: New Product Editor is enabled as expected. in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 13"
+                },
                 {
                     "count": "3",
                     "message": "The wc_get_min_max_price_meta_query() function is deprecated since version 3.6."

--- a/_tests/tests/__snapshots__/E2eTest__test_e2e_delete_products__1.php
+++ b/_tests/tests/__snapshots__/E2eTest__test_e2e_delete_products__1.php
@@ -23,7 +23,7 @@
             "event": "cli_development_extension_test",
             "optional_features": {
                 "hpos": false,
-                "cc_blocks": false
+                "new_product_editor": false
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,

--- a/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op__1.php
+++ b/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op__1.php
@@ -9,7 +9,7 @@
             "additional_woo_plugins": [],
             "additional_wp_plugins": [],
             "test_log": "",
-            "status": "failed",
+            "status": "success",
             "test_result_aws_url": "https:\\/\\/test-results-aws.com",
             "test_result_aws_expiration": 1234567890,
             "is_development": true,
@@ -27,20 +27,20 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Test Suites: 0 skipped, 1 failed, 41 passed, 42 total | Tests: 7 skipped, 3 failed, 177 passed, 187 total.",
+            "test_summary": "Test Suites: 0 skipped, 0 failed, 42 passed, 42 total | Tests: 8 skipped, 0 failed, 179 passed, 187 total.",
             "version": "Zip",
             "test_result_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"
         },
         {
             "test_result_json": {
-                "numFailedTestSuites": 1,
-                "numPassedTestSuites": 41,
+                "numFailedTestSuites": 0,
+                "numPassedTestSuites": 42,
                 "numPendingTestSuites": 0,
                 "numTotalTestSuites": 42,
-                "numFailedTests": 3,
-                "numPassedTests": 177,
-                "numPendingTests": 7,
+                "numFailedTests": 0,
+                "numPassedTests": 179,
+                "numPendingTests": 8,
                 "numTotalTests": 187,
                 "testResults": [
                     {
@@ -805,32 +805,32 @@
                     },
                     {
                         "file": "new-product-editor\\/new-product-editor.spec.js",
-                        "status": "failed",
+                        "status": "passed",
                         "has_pending": true,
                         "tests": {
                             "New product editor": [],
                             "New product editor > Default (disabled)": [
                                 {
                                     "title": "is feature flag disabled",
-                                    "status": "pending"
+                                    "status": "passed"
                                 },
                                 {
                                     "title": "is not hooked up to sidebar \\"Add New\\"",
-                                    "status": "pending"
+                                    "status": "passed"
                                 }
                             ],
                             "New product editor > Enabled": [
                                 {
                                     "title": "is feature flag enabled",
-                                    "status": "failed"
+                                    "status": "pending"
                                 },
                                 {
                                     "title": "is hooked up to sidebar \\"Add New\\"",
-                                    "status": "failed"
+                                    "status": "pending"
                                 },
                                 {
                                     "title": "can be disabled from the header",
-                                    "status": "failed"
+                                    "status": "pending"
                                 },
                                 {
                                     "title": "can be disabled from the feedback footer",
@@ -1199,13 +1199,13 @@
                         }
                     }
                 ],
-                "summary": "Test Suites: 0 skipped, 1 failed, 41 passed, 42 total | Tests: 7 skipped, 3 failed, 177 passed, 187 total."
+                "summary": "Test Suites: 0 skipped, 0 failed, 42 passed, 42 total | Tests: 8 skipped, 0 failed, 179 passed, 187 total."
             }
         },
         {
             "debug_log": [
                 {
-                    "count": "20",
+                    "count": "16",
                     "message": "The Automattic\\\\WooCommerce\\\\Admin\\\\API\\\\Options::get_options function is deprecated since version 3.1."
                 }
             ]

--- a/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op__1.php
+++ b/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op__1.php
@@ -9,7 +9,7 @@
             "additional_woo_plugins": [],
             "additional_wp_plugins": [],
             "test_log": "",
-            "status": "success",
+            "status": "failed",
             "test_result_aws_url": "https:\\/\\/test-results-aws.com",
             "test_result_aws_expiration": 1234567890,
             "is_development": true,
@@ -23,24 +23,24 @@
             "event": "cli_development_extension_test",
             "optional_features": {
                 "hpos": false,
-                "cc_blocks": false
+                "new_product_editor": false
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Test Suites: 0 skipped, 0 failed, 42 passed, 42 total | Tests: 8 skipped, 0 failed, 179 passed, 187 total.",
+            "test_summary": "Test Suites: 0 skipped, 1 failed, 41 passed, 42 total | Tests: 7 skipped, 3 failed, 177 passed, 187 total.",
             "version": "Zip",
             "test_result_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"
         },
         {
             "test_result_json": {
-                "numFailedTestSuites": 0,
-                "numPassedTestSuites": 42,
+                "numFailedTestSuites": 1,
+                "numPassedTestSuites": 41,
                 "numPendingTestSuites": 0,
                 "numTotalTestSuites": 42,
-                "numFailedTests": 0,
-                "numPassedTests": 179,
-                "numPendingTests": 8,
+                "numFailedTests": 3,
+                "numPassedTests": 177,
+                "numPendingTests": 7,
                 "numTotalTests": 187,
                 "testResults": [
                     {
@@ -805,32 +805,32 @@
                     },
                     {
                         "file": "new-product-editor\\/new-product-editor.spec.js",
-                        "status": "passed",
+                        "status": "failed",
                         "has_pending": true,
                         "tests": {
                             "New product editor": [],
                             "New product editor > Default (disabled)": [
                                 {
                                     "title": "is feature flag disabled",
-                                    "status": "passed"
+                                    "status": "pending"
                                 },
                                 {
                                     "title": "is not hooked up to sidebar \\"Add New\\"",
-                                    "status": "passed"
+                                    "status": "pending"
                                 }
                             ],
                             "New product editor > Enabled": [
                                 {
                                     "title": "is feature flag enabled",
-                                    "status": "pending"
+                                    "status": "failed"
                                 },
                                 {
                                     "title": "is hooked up to sidebar \\"Add New\\"",
-                                    "status": "pending"
+                                    "status": "failed"
                                 },
                                 {
                                     "title": "can be disabled from the header",
-                                    "status": "pending"
+                                    "status": "failed"
                                 },
                                 {
                                     "title": "can be disabled from the feedback footer",
@@ -1199,13 +1199,13 @@
                         }
                     }
                 ],
-                "summary": "Test Suites: 0 skipped, 0 failed, 42 passed, 42 total | Tests: 8 skipped, 0 failed, 179 passed, 187 total."
+                "summary": "Test Suites: 0 skipped, 1 failed, 41 passed, 42 total | Tests: 7 skipped, 3 failed, 177 passed, 187 total."
             }
         },
         {
             "debug_log": [
                 {
-                    "count": "16",
+                    "count": "20",
                     "message": "The Automattic\\\\WooCommerce\\\\Admin\\\\API\\\\Options::get_options function is deprecated since version 3.1."
                 }
             ]

--- a/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82__1.php
+++ b/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82__1.php
@@ -9,7 +9,7 @@
             "additional_woo_plugins": [],
             "additional_wp_plugins": [],
             "test_log": "",
-            "status": "success",
+            "status": "failed",
             "test_result_aws_url": "https:\\/\\/test-results-aws.com",
             "test_result_aws_expiration": 1234567890,
             "is_development": true,
@@ -23,23 +23,23 @@
             "event": "cli_development_extension_test",
             "optional_features": {
                 "hpos": false,
-                "cc_blocks": false
+                "new_product_editor": false
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Test Suites: 0 skipped, 0 failed, 42 passed, 42 total | Tests: 8 skipped, 0 failed, 179 passed, 187 total.",
+            "test_summary": "Test Suites: 0 skipped, 1 failed, 41 passed, 42 total | Tests: 7 skipped, 3 failed, 177 passed, 187 total.",
             "version": "Zip",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {
             "test_result_json": {
-                "numFailedTestSuites": 0,
-                "numPassedTestSuites": 42,
+                "numFailedTestSuites": 1,
+                "numPassedTestSuites": 41,
                 "numPendingTestSuites": 0,
                 "numTotalTestSuites": 42,
-                "numFailedTests": 0,
-                "numPassedTests": 179,
-                "numPendingTests": 8,
+                "numFailedTests": 3,
+                "numPassedTests": 177,
+                "numPendingTests": 7,
                 "numTotalTests": 187,
                 "testResults": [
                     {
@@ -804,32 +804,32 @@
                     },
                     {
                         "file": "new-product-editor\\/new-product-editor.spec.js",
-                        "status": "passed",
+                        "status": "failed",
                         "has_pending": true,
                         "tests": {
                             "New product editor": [],
                             "New product editor > Default (disabled)": [
                                 {
                                     "title": "is feature flag disabled",
-                                    "status": "passed"
+                                    "status": "pending"
                                 },
                                 {
                                     "title": "is not hooked up to sidebar \\"Add New\\"",
-                                    "status": "passed"
+                                    "status": "pending"
                                 }
                             ],
                             "New product editor > Enabled": [
                                 {
                                     "title": "is feature flag enabled",
-                                    "status": "pending"
+                                    "status": "failed"
                                 },
                                 {
                                     "title": "is hooked up to sidebar \\"Add New\\"",
-                                    "status": "pending"
+                                    "status": "failed"
                                 },
                                 {
                                     "title": "can be disabled from the header",
-                                    "status": "pending"
+                                    "status": "failed"
                                 },
                                 {
                                     "title": "can be disabled from the feedback footer",
@@ -1198,7 +1198,7 @@
                         }
                     }
                 ],
-                "summary": "Test Suites: 0 skipped, 0 failed, 42 passed, 42 total | Tests: 8 skipped, 0 failed, 179 passed, 187 total."
+                "summary": "Test Suites: 0 skipped, 1 failed, 41 passed, 42 total | Tests: 7 skipped, 3 failed, 177 passed, 187 total."
             }
         }
     ]

--- a/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82__1.php
+++ b/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82__1.php
@@ -9,7 +9,7 @@
             "additional_woo_plugins": [],
             "additional_wp_plugins": [],
             "test_log": "",
-            "status": "failed",
+            "status": "success",
             "test_result_aws_url": "https:\\/\\/test-results-aws.com",
             "test_result_aws_expiration": 1234567890,
             "is_development": true,
@@ -27,19 +27,19 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Test Suites: 0 skipped, 1 failed, 41 passed, 42 total | Tests: 7 skipped, 3 failed, 177 passed, 187 total.",
+            "test_summary": "Test Suites: 0 skipped, 0 failed, 42 passed, 42 total | Tests: 8 skipped, 0 failed, 179 passed, 187 total.",
             "version": "Zip",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {
             "test_result_json": {
-                "numFailedTestSuites": 1,
-                "numPassedTestSuites": 41,
+                "numFailedTestSuites": 0,
+                "numPassedTestSuites": 42,
                 "numPendingTestSuites": 0,
                 "numTotalTestSuites": 42,
-                "numFailedTests": 3,
-                "numPassedTests": 177,
-                "numPendingTests": 7,
+                "numFailedTests": 0,
+                "numPassedTests": 179,
+                "numPendingTests": 8,
                 "numTotalTests": 187,
                 "testResults": [
                     {
@@ -804,32 +804,32 @@
                     },
                     {
                         "file": "new-product-editor\\/new-product-editor.spec.js",
-                        "status": "failed",
+                        "status": "passed",
                         "has_pending": true,
                         "tests": {
                             "New product editor": [],
                             "New product editor > Default (disabled)": [
                                 {
                                     "title": "is feature flag disabled",
-                                    "status": "pending"
+                                    "status": "passed"
                                 },
                                 {
                                     "title": "is not hooked up to sidebar \\"Add New\\"",
-                                    "status": "pending"
+                                    "status": "passed"
                                 }
                             ],
                             "New product editor > Enabled": [
                                 {
                                     "title": "is feature flag enabled",
-                                    "status": "failed"
+                                    "status": "pending"
                                 },
                                 {
                                     "title": "is hooked up to sidebar \\"Add New\\"",
-                                    "status": "failed"
+                                    "status": "pending"
                                 },
                                 {
                                     "title": "can be disabled from the header",
-                                    "status": "failed"
+                                    "status": "pending"
                                 },
                                 {
                                     "title": "can be disabled from the feedback footer",
@@ -1198,7 +1198,7 @@
                         }
                     }
                 ],
-                "summary": "Test Suites: 0 skipped, 1 failed, 41 passed, 42 total | Tests: 7 skipped, 3 failed, 177 passed, 187 total."
+                "summary": "Test Suites: 0 skipped, 0 failed, 42 passed, 42 total | Tests: 8 skipped, 0 failed, 179 passed, 187 total."
             }
         }
     ]

--- a/_tests/tests/__snapshots__/PhpstanTest__test_phpstan_main__1.php
+++ b/_tests/tests/__snapshots__/PhpstanTest__test_phpstan_main__1.php
@@ -23,7 +23,7 @@
             "event": "cli_development_extension_test",
             "optional_features": {
                 "hpos": false,
-                "cc_blocks": false
+                "new_product_editor": false
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,

--- a/_tests/tests/__snapshots__/SecurityTest__test_security_exclusions__1.php
+++ b/_tests/tests/__snapshots__/SecurityTest__test_security_exclusions__1.php
@@ -23,7 +23,7 @@
             "event": "cli_development_extension_test",
             "optional_features": {
                 "hpos": false,
-                "cc_blocks": false
+                "new_product_editor": false
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,

--- a/_tests/tests/__snapshots__/SecurityTest__test_security_main__1.php
+++ b/_tests/tests/__snapshots__/SecurityTest__test_security_main__1.php
@@ -23,7 +23,7 @@
             "event": "cli_development_extension_test",
             "optional_features": {
                 "hpos": false,
-                "cc_blocks": false
+                "new_product_editor": false
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,


### PR DESCRIPTION
This PR adds an api self test to ensure that the `new_product_editor` feature can be enabled correctly. It also updates the existing snapshots based on the changes in https://github.com/Automattic/compatibility-dashboard/pull/414