### PR TITLE
Add self-tests to PHPStan ignoring vendor directory

### DIFF
--- a/_tests/phpstan/with_vendor/env.php
+++ b/_tests/phpstan/with_vendor/env.php
@@ -1,0 +1,2 @@
+<?php
+return [];

--- a/_tests/phpstan/with_vendor/woocommerce-product-feeds/vendor-prefixed/Bar/Bar.php
+++ b/_tests/phpstan/with_vendor/woocommerce-product-feeds/vendor-prefixed/Bar/Bar.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SomePrefixedVendor;
+
+class Bar {
+	public function get_foo() {
+		return 'foo';
+	}
+}
+
+$baz = new PHPStanShouldNotFlagThis2();

--- a/_tests/phpstan/with_vendor/woocommerce-product-feeds/woocommerce-product-feeds.php
+++ b/_tests/phpstan/with_vendor/woocommerce-product-feeds/woocommerce-product-feeds.php
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * Plugin name: PHPStan - Vendor Analysed but Excluded from Analysis.
+ */
+
+require __DIR__ . '/vendor/Foo/Foo.php';
+require __DIR__ . '/vendor-prefixed/Bar/Bar.php';
+
+$foo = new SomeVendor\Foo();
+$bar = new SomePrefixedVendor\Bar();
+$baz = new SomeUnexistingClassThatPHPStanShouldFlag();

--- a/_tests/tests/__snapshots__/PhpstanTest__test_phpstan_with_vendor__1.php
+++ b/_tests/tests/__snapshots__/PhpstanTest__test_phpstan_with_vendor__1.php
@@ -1,0 +1,57 @@
+<?php return '[
+    [
+        {
+            "run_id": 123456,
+            "test_type": "phpstan",
+            "wordpress_version": "6.0.0-normalized",
+            "woocommerce_version": "6.0.0-normalized",
+            "php_version": "7.4",
+            "additional_woo_plugins": [],
+            "additional_wp_plugins": [],
+            "test_log": "",
+            "status": "failed",
+            "test_result_aws_url": "https:\\/\\/test-results-aws.com",
+            "test_result_aws_expiration": 1234567890,
+            "is_development": true,
+            "send_notifications": false,
+            "woo_extension": {
+                "id": 18619,
+                "host": "wccom",
+                "name": "Google Product Feed"
+            },
+            "client": "qit_cli",
+            "event": "cli_development_extension_test",
+            "optional_features": {
+                "hpos": false,
+                "new_product_editor": false
+            },
+            "test_results_manager_url": "https:\\/\\/test-results-manager.com",
+            "test_results_manager_expiration": 1234567890,
+            "test_summary": "Errors: 0, File Errors: 1",
+            "debug_log": "",
+            "version": "Undefined",
+            "test_result_json_extracted": "{EXTRACTED}"
+        },
+        {
+            "test_result_json": {
+                "totals": {
+                    "errors": 0,
+                    "file_errors": 1
+                },
+                "files": {
+                    "\\/home\\/runner\\/work\\/compatibility-dashboard\\/compatibility-dashboard\\/ci\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php": {
+                        "errors": 1,
+                        "messages": [
+                            {
+                                "message": "Instantiated class SomeUnexistingClassThatPHPStanShouldFlag not found.",
+                                "line": 12,
+                                "ignorable": true
+                            }
+                        ]
+                    }
+                },
+                "errors": []
+            }
+        }
+    ]
+]';


### PR DESCRIPTION
Closes https://github.com/woocommerce/qit-cli/issues/47

This PR tweaks PHPStan tests so that it discovers the symbols in the vendor directories, but don't analyse the code on vendor directory.

Self-tests were added as part of this PR, the expected behavior is:

- `Foo` and `Bar` are found by PHPStan (not flagged as non-existing)
- `SomeUnexistingClassThatPHPStanShouldFlag` is flagged as non-existing as expected
- Violations on `PHPStanShouldNotFlagThis` and `PHPStanShouldNotFlagThis2` in the vendor directories are not flagged as expected.

[Related issue on PHPStan](https://github.com/phpstan/phpstan/issues/3749#issuecomment-756240488)