### PR TITLE
Allow to run multiple self-test suites separated by comma

### DIFF
--- a/_tests/QITSelfTests.php
+++ b/_tests/QITSelfTests.php
@@ -41,8 +41,10 @@ try {
 	$test_types = get_test_types();
 
 	if ( ! is_null( Context::$suite ) ) {
-		$test_types = array_filter( $test_types, function ( $test_type_path ) {
-			return basename( $test_type_path ) === Context::$suite;
+		$suites = explode( ',', Context::$suite );
+
+		$test_types = array_filter( $test_types, function ( $test_type_path ) use ( $suites ) {
+			return in_array( basename( $test_type_path ), $suites );
 		} );
 	}
 


### PR DESCRIPTION
This is a small PR that allows a comma-separated list of suites to run a self-test for, eg:

- php QITSelfTests.php update api,e2e

Instead of:
- php QITSelfTests.php update api
- php QITSelfTests.php update e2e