### PR TITLE
Normalize debug log in self tests

### DIFF
--- a/_tests/QITSelfTests.php
+++ b/_tests/QITSelfTests.php
@@ -253,7 +253,7 @@ function run_test_runs( array $test_runs ) {
 	 *
 	 * @see \Symfony\Component\Process\Pipes\PipesInterface::CHUNK_SIZE
 	 */
-	foreach ($processes as $p ) {
+	foreach ( $processes as $p ) {
 		$it = $p->getIterator( Process::ITER_SKIP_ERR | Process::ITER_KEEP_OUTPUT );
 		foreach ( $it as $out ) {
 			if ( ! is_null( json_decode( $out, true ) ) ) {

--- a/_tests/QITSelfTests.php
+++ b/_tests/QITSelfTests.php
@@ -243,6 +243,17 @@ function run_test_runs( array $test_runs ) {
 
 	echo "All tests finished. Processing results...\n";
 
+	$results = [];
+
+	foreach ( $processes as $p ) {
+		$results[] = [
+			'process'     => $p,
+			'has_results' => false,
+			'failed'      => null,
+			'succeeded'   => null,
+		];
+	}
+
 	$failed_tests = [];
 
 	/**
@@ -253,7 +264,9 @@ function run_test_runs( array $test_runs ) {
 	 *
 	 * @see \Symfony\Component\Process\Pipes\PipesInterface::CHUNK_SIZE
 	 */
-	foreach ( $processes as $p ) {
+	foreach ( $results as &$r ) {
+		$p = $r['process'];
+
 		$it = $p->getIterator( Process::ITER_SKIP_ERR | Process::ITER_KEEP_OUTPUT );
 		foreach ( $it as $out ) {
 			if ( ! is_null( json_decode( $out, true ) ) ) {
@@ -306,9 +319,12 @@ function run_test_runs( array $test_runs ) {
 					$phpunit_process->mustRun( function ( $type, $out ) {
 						echo substr( $out, 0, 500 ) . "\n";
 					} );
-				} catch( ProcessFailedException $e) {
+					$r['succeeded'] = true;
+				} catch ( ProcessFailedException $e ) {
 					$failed_tests[] = $e;
+					$r['failed']    = true;
 				} finally {
+					$r['has_results'] = true;
 					cleanup_test( $p->getEnv()['QIT_TEST_PATH'] );
 
 					$p->setEnv( [ 'QIT_RAN_TEST' => true ] );
@@ -320,6 +336,17 @@ function run_test_runs( array $test_runs ) {
 	foreach ( $processes as $p ) {
 		if ( ! $p->getEnv()['QIT_RAN_TEST'] ) {
 			throw new RuntimeException( "[Process {$p->getPid()}]: Test {$p->getEnv()['QIT_TEST_PATH']} did not run.\n" );
+		}
+	}
+
+	foreach ( $results as &$r ) {
+		unset( $r['process'] );
+	}
+
+	foreach ( $results as $r ) {
+		if ( ! $r['has_results'] ) {
+			echo "No results found for test {$r['process']->getEnv()['QIT_TEST_PATH']}\n";
+			die( 1 );
 		}
 	}
 

--- a/_tests/e2e/no_op_php82/env.php
+++ b/_tests/e2e/no_op_php82/env.php
@@ -3,12 +3,4 @@ return [
 	'php'                  => '8.2',
 	'wp'                   => 'rc',
 	'woo'                  => 'rc,stable',
-	/*
-	 * PHP 8.2 generates thousands of notices in the debug log.
-	 * These notices are not consistent between runs, you can
-	 * run two tests with the exact same configs and they will
-	 * produce slightly different error counts, so we remove
-	 * debug_log from this test.
-	 */
-	#'remove_from_snapshot' => 'debug_log',
 ];

--- a/_tests/e2e/no_op_php82/env.php
+++ b/_tests/e2e/no_op_php82/env.php
@@ -10,5 +10,5 @@ return [
 	 * produce slightly different error counts, so we remove
 	 * debug_log from this test.
 	 */
-	'remove_from_snapshot' => 'debug_log',
+	#'remove_from_snapshot' => 'debug_log',
 ];

--- a/_tests/test-result-parser.php
+++ b/_tests/test-result-parser.php
@@ -61,9 +61,21 @@ function test_result_parser( string $json, string $remove_from_snapshot = '' ): 
 							if ( $value_log < 50 ) {
 								// No-op. Exact match for counts below 50.
 							} elseif ( $value_log < 100 ) {
-								$value_log = $value_log % 5 === 0 ? $value_log : round( $value_log / 5 ) * 5;  // Round to the closest 5 if not already divisible by 5.
+								if ( $value_log % 5 === 0 ) {
+									echo "Skipping normalization as it's already divisible by 5\n";
+								} else {
+									echo "Normalizing debug_log.count from $value_log to ";
+									$value_log = round( $value_log / 5 ) * 5;  // Round to the closest 5 if not already divisible by 5.
+									echo "$value_log\n";
+								}
 							} else {
-								$value_log = $value_log % 10 === 0 ? $value_log : round( $value_log / 10 ) * 10;  // Round to the closest 10 if not already divisible by 10.
+								if ( $value_log % 10 === 0 ) {
+									echo "Skipping normalization as it's already divisible by 10\n";
+								} else {
+									echo "Normalizing debug_log.count from $value_log to ";
+									$value_log = round( $value_log / 10 ) * 10;  // Round to the closest 10 if not already divisible by 10.
+									echo "$value_log\n";
+								}
 							}
 						}
 

--- a/_tests/test-result-parser.php
+++ b/_tests/test-result-parser.php
@@ -35,66 +35,6 @@ function test_result_parser( string $json, string $remove_from_snapshot = '' ): 
 	// Add the modified original JSON as the first item in the output array
 	array_unshift( $human_friendly_test_result, $data );
 
-	/*
-	 * Normalize PHP debug logs captured during test runs.
-	 *
-	 * The normalization process is focused on the 'count' key within the debug logs.
-	 * This allows for some flexibility in test runs where slight variations in log counts
-	 * might occur due to uncontrollable conditions like AJAX requests firing or not firing.
-	 *
-	 * Normalization rules for 'count':
-	 * - Exact values are retained for counts below 50.
-	 * - Counts between 50 and 100 are rounded to the nearest 5.
-	 * - Counts above 100 are rounded to the nearest 10.
-	 *
-	 * Additionally, certain known failure messages (e.g., WordPress.org connectivity issues)
-	 * are conditionally removed from the logs.
-	 */
-	foreach ( $human_friendly_test_result as $k => &$v ) {
-		foreach ( $v as $key => &$value ) {
-			if ( $key === 'debug_log' && is_array( $value ) ) {
-				foreach ( $value as $k2 => &$v2 ) {
-					foreach ( $v2 as $key_log => &$value_log ) {
-						if ( $key_log === 'count' ) {
-							$value_log = (int) $value_log;
-
-							if ( $value_log < 50 ) {
-								// No-op. Exact match for counts below 50.
-							} elseif ( $value_log < 100 ) {
-								if ( $value_log % 5 === 0 ) {
-									echo "Skipping normalization as it's already divisible by 5\n";
-								} else {
-									echo "Normalizing debug_log.count from $value_log to ";
-									$value_log = round( $value_log / 5 ) * 5;  // Round to the closest 5 if not already divisible by 5.
-									echo "$value_log\n";
-								}
-							} else {
-								if ( $value_log % 10 === 0 ) {
-									echo "Skipping normalization as it's already divisible by 10\n";
-								} else {
-									echo "Normalizing debug_log.count from $value_log to ";
-									$value_log = round( $value_log / 10 ) * 10;  // Round to the closest 10 if not already divisible by 10.
-									echo "$value_log\n";
-								}
-							}
-						}
-
-						if ( $key_log === 'message' ) {
-							// Sometimes the test site might fail to contact WP.org, this is beyond our control.
-							if ( stripos( $value_log, 'Something may be wrong with WordPress.org' ) !== false ) {
-								// If it happens only a few times, ignore it.
-								if ( $value['count'] <= 3 ) {
-									echo "Removing 'Something may be wrong with WordPress.org' from debug_log.message\n";
-									unset( $human_friendly_test_result[ $key ][ $key_log ] );
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-
 	return json_encode( $human_friendly_test_result, JSON_PRETTY_PRINT );
 }
 

--- a/_tests/test-result-parser.php
+++ b/_tests/test-result-parser.php
@@ -56,12 +56,14 @@ function test_result_parser( string $json, string $remove_from_snapshot = '' ): 
 				foreach ( $value as $k2 => &$v2 ) {
 					foreach ( $v2 as $key_log => &$value_log ) {
 						if ( $key_log === 'count' ) {
+							$value_log = (int) $value_log;
+
 							if ( $value_log < 50 ) {
 								// No-op. Exact match for counts below 50.
 							} elseif ( $value_log < 100 ) {
-								$value_log = ( $value_log % 5 === 0 ) ? $value_log : round( $value_log / 5 ) * 5;  // Round to the closest 5 if not already divisible by 5
+								$value_log = $value_log % 5 === 0 ? $value_log : round( $value_log / 5 ) * 5;  // Round to the closest 5 if not already divisible by 5.
 							} else {
-								$value_log = ( $value_log % 10 === 0 ) ? $value_log : round( $value_log / 10 ) * 10;  // Round to the closest 10 if not already divisible by 10
+								$value_log = $value_log % 10 === 0 ? $value_log : round( $value_log / 10 ) * 10;  // Round to the closest 10 if not already divisible by 10.
 							}
 						}
 

--- a/_tests/test-result-parser.php
+++ b/_tests/test-result-parser.php
@@ -25,7 +25,7 @@ function test_result_parser( string $json, string $remove_from_snapshot = '' ): 
 				// Add the extracted item as a separate top-level item in the output array
 				$human_friendly_test_result[] = [ $key => $decodedValue ];
 				// Replace the original value with an indicator that the JSON has been extracted
-				$data[ "{$key}_extracted" ] = '{EXTRACTED}';
+				$data["{$key}_extracted"] = '{EXTRACTED}';
 
 				unset( $data[ $key ] );
 			}
@@ -34,6 +34,52 @@ function test_result_parser( string $json, string $remove_from_snapshot = '' ): 
 
 	// Add the modified original JSON as the first item in the output array
 	array_unshift( $human_friendly_test_result, $data );
+
+	/*
+	 * Normalize PHP debug logs captured during test runs.
+	 *
+	 * The normalization process is focused on the 'count' key within the debug logs.
+	 * This allows for some flexibility in test runs where slight variations in log counts
+	 * might occur due to uncontrollable conditions like AJAX requests firing or not firing.
+	 *
+	 * Normalization rules for 'count':
+	 * - Exact values are retained for counts below 50.
+	 * - Counts between 50 and 100 are rounded to the nearest 5.
+	 * - Counts above 100 are rounded to the nearest 10.
+	 *
+	 * Additionally, certain known failure messages (e.g., WordPress.org connectivity issues)
+	 * are conditionally removed from the logs.
+	 */
+	foreach ( $human_friendly_test_result as $k => &$v ) {
+		foreach ( $v as $key => &$value ) {
+			if ( $key === 'debug_log' && is_array( $value ) ) {
+				foreach ( $value as $k2 => &$v2 ) {
+					foreach ( $v2 as $key_log => &$value_log ) {
+						if ( $key_log === 'count' ) {
+							if ( $value_log < 50 ) {
+								// No-op. Exact match for counts below 50.
+							} elseif ( $value_log < 100 ) {
+								$value_log = ( $value_log % 5 === 0 ) ? $value_log : round( $value_log / 5 ) * 5;  // Round to the closest 5 if not already divisible by 5
+							} else {
+								$value_log = ( $value_log % 10 === 0 ) ? $value_log : round( $value_log / 10 ) * 10;  // Round to the closest 10 if not already divisible by 10
+							}
+						}
+
+						if ( $key_log === 'message' ) {
+							// Sometimes the test site might fail to contact WP.org, this is beyond our control.
+							if ( stripos( $value_log, 'Something may be wrong with WordPress.org' ) !== false ) {
+								// If it happens only a few times, ignore it.
+								if ( $value['count'] <= 3 ) {
+									echo "Removing 'Something may be wrong with WordPress.org' from debug_log.message\n";
+									unset( $human_friendly_test_result[ $key ][ $key_log ] );
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 
 	return json_encode( $human_friendly_test_result, JSON_PRETTY_PRINT );
 }

--- a/_tests/test-result-parser.php
+++ b/_tests/test-result-parser.php
@@ -25,7 +25,7 @@ function test_result_parser( string $json, string $remove_from_snapshot = '' ): 
 				// Add the extracted item as a separate top-level item in the output array
 				$human_friendly_test_result[] = [ $key => $decodedValue ];
 				// Replace the original value with an indicator that the JSON has been extracted
-				$data["{$key}_extracted"] = '{EXTRACTED}';
+				$data[ "{$key}_extracted" ] = '{EXTRACTED}';
 
 				unset( $data[ $key ] );
 			}

--- a/_tests/tests/QITE2ETestCase.php
+++ b/_tests/tests/QITE2ETestCase.php
@@ -138,6 +138,51 @@ class QITE2ETestCase extends TestCase {
 							}
 						}
 
+						// Sometimes the test site might fail to contact WP.org, this is beyond our control.
+						if ( stripos( $debug_log['message'], 'Something may be wrong with WordPress.org' ) !== false ) {
+							// If it happens only a few times, ignore it.
+							if ( $debug_log['count'] <= 3 ) {
+								echo "Removing 'Something may be wrong with WordPress.org' from debug_log.message\n";
+								unset( $value[ $k ] );
+								continue;
+							}
+						}
+
+						/*
+						 * Normalize PHP debug logs captured during test runs.
+						 *
+						 * The normalization process is focused on the 'count' key within the debug logs.
+						 * This allows for some flexibility in test runs where slight variations in log counts
+						 * might occur due to uncontrollable conditions like AJAX requests firing or not firing.
+						 *
+						 * Normalization rules for 'count':
+						 * - Exact values are retained for counts below 50.
+						 * - Counts between 50 and 100 are rounded to the nearest 5.
+						 * - Counts above 100 are rounded to the nearest 10.
+						 *
+						 * Additionally, certain known failure messages (e.g., WordPress.org connectivity issues)
+						 * are conditionally removed from the logs.
+						 */
+						if ( $debug_log['count'] < 50 ) {
+							// No-op. Exact match for counts below 50.
+						} elseif ( $debug_log['count'] < 100 ) {
+							if ( $debug_log['count'] % 5 === 0 ) {
+								echo "Skipping normalization as it's already divisible by 5\n";
+							} else {
+								echo "Normalizing debug_log.count from {$debug_log['count']} to ";
+								$debug_log['count'] = round( $debug_log['count'] / 5 ) * 5;  // Round to the closest 5 if not already divisible by 5.
+								echo "{$debug_log['count']}\n";
+							}
+						} else {
+							if ( $debug_log['count'] % 10 === 0 ) {
+								echo "Skipping normalization as it's already divisible by 10\n";
+							} else {
+								echo "Normalizing debug_log.count from {$debug_log['count']} to ";
+								$debug_log['count'] = round( $debug_log['count'] / 10 ) * 10;  // Round to the closest 10 if not already divisible by 10.
+								echo "{$debug_log['count']}\n";
+							}
+						}
+
 						// todo: regenerate snapshots and remove strval later.
 						$normalized_debug_log[] = array_map( 'strval', $debug_log );
 					}

--- a/_tests/tests/QITE2ETestCase.php
+++ b/_tests/tests/QITE2ETestCase.php
@@ -100,14 +100,6 @@ class QITE2ETestCase extends TestCase {
 			],
 			'debug_log' => [
 				'normalize' => static function ( $value ) use ( $file_path ) {
-					/*
-					 * When deleting products to cause a test to fail, we introduce a lot of "chaos" that
-					 * makes it very hard to do snapshot test on the debug log.
-					 */
-					if ( stripos( $file_path, 'e2e/delete_products' ) !== false ) {
-						return [ 'NORMALIZED_FOR_SNAPSHOT_TESTING' ];
-					}
-
 					if ( ! is_array( $value ) ) {
 						return $value;
 					}

--- a/_tests/tests/__snapshots__/ApiTest__test_api_no_op_rc_74__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_no_op_rc_74__1.php
@@ -1375,12 +1375,7 @@
             }
         },
         {
-            "debug_log": [
-                {
-                    "count": "3",
-                    "message": "The wc_get_min_max_price_meta_query() function is deprecated since version 3.6."
-                }
-            ]
+            "debug_log": []
         }
     ]
 ]';

--- a/_tests/tests/__snapshots__/ApiTest__test_api_no_op_rc_82__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_no_op_rc_82__1.php
@@ -1377,7 +1377,7 @@
         {
             "debug_log": [
                 {
-                    "count": "3",
+                    "count": "4",
                     "message": "The wc_get_min_max_price_meta_query() function is deprecated since version 3.6."
                 }
             ]

--- a/_tests/tests/__snapshots__/ApiTest__test_api_no_op_rc_82__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_no_op_rc_82__1.php
@@ -1377,7 +1377,7 @@
         {
             "debug_log": [
                 {
-                    "count": "4",
+                    "count": "3",
                     "message": "The wc_get_min_max_price_meta_query() function is deprecated since version 3.6."
                 }
             ]

--- a/_tests/tests/__snapshots__/ApiTest__test_api_no_op_rc_82__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_no_op_rc_82__1.php
@@ -1375,12 +1375,7 @@
             }
         },
         {
-            "debug_log": [
-                {
-                    "count": "4",
-                    "message": "The wc_get_min_max_price_meta_query() function is deprecated since version 3.6."
-                }
-            ]
+            "debug_log": []
         }
     ]
 ]';

--- a/_tests/tests/__snapshots__/ApiTest__test_api_no_op_stable_74__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_no_op_stable_74__1.php
@@ -1375,12 +1375,7 @@
             }
         },
         {
-            "debug_log": [
-                {
-                    "count": "3",
-                    "message": "The wc_get_min_max_price_meta_query() function is deprecated since version 3.6."
-                }
-            ]
+            "debug_log": []
         }
     ]
 ]';

--- a/_tests/tests/__snapshots__/ApiTest__test_api_no_op_stable_82__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_no_op_stable_82__1.php
@@ -1375,12 +1375,7 @@
             }
         },
         {
-            "debug_log": [
-                {
-                    "count": "3",
-                    "message": "The wc_get_min_max_price_meta_query() function is deprecated since version 3.6."
-                }
-            ]
+            "debug_log": []
         }
     ]
 ]';

--- a/_tests/tests/__snapshots__/ApiTest__test_api_order_cache_bug_rc_74__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_order_cache_bug_rc_74__1.php
@@ -1379,10 +1379,6 @@
                 {
                     "count": "550",
                     "message": "PHP Notice: $order is Automattic\\\\WooCommerce\\\\Admin\\\\Overrides\\\\Order as expected. in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 41"
-                },
-                {
-                    "count": "3",
-                    "message": "The wc_get_min_max_price_meta_query() function is deprecated since version 3.6."
                 }
             ]
         }

--- a/_tests/tests/__snapshots__/ApiTest__test_api_order_cache_bug_rc_74__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_order_cache_bug_rc_74__1.php
@@ -1377,7 +1377,7 @@
         {
             "debug_log": [
                 {
-                    "count": "549",
+                    "count": "550",
                     "message": "PHP Notice: $order is Automattic\\\\WooCommerce\\\\Admin\\\\Overrides\\\\Order as expected. in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 41"
                 },
                 {

--- a/_tests/tests/__snapshots__/ApiTest__test_api_order_cache_bug_rc_82__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_order_cache_bug_rc_82__1.php
@@ -1383,10 +1383,6 @@
                 {
                     "count": "2",
                     "message": "PHP Deprecated: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in \\/var\\/www\\/html\\/wp-includes\\/rest-api\\/class-wp-rest-server.php on line 1768"
-                },
-                {
-                    "count": "3",
-                    "message": "The wc_get_min_max_price_meta_query() function is deprecated since version 3.6."
                 }
             ]
         }

--- a/_tests/tests/__snapshots__/ApiTest__test_api_order_cache_bug_rc_82__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_order_cache_bug_rc_82__1.php
@@ -1377,7 +1377,7 @@
         {
             "debug_log": [
                 {
-                    "count": "549",
+                    "count": "550",
                     "message": "PHP Notice: $order is Automattic\\\\WooCommerce\\\\Admin\\\\Overrides\\\\Order as expected. in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 41"
                 },
                 {

--- a/_tests/tests/__snapshots__/ApiTest__test_api_order_cache_bug_stable_74__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_order_cache_bug_stable_74__1.php
@@ -1379,10 +1379,6 @@
                 {
                     "count": "250",
                     "message": "PHP Notice: $order is Automattic\\\\WooCommerce\\\\Admin\\\\Overrides\\\\Order as expected. in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 41"
-                },
-                {
-                    "count": "3",
-                    "message": "The wc_get_min_max_price_meta_query() function is deprecated since version 3.6."
                 }
             ]
         }

--- a/_tests/tests/__snapshots__/ApiTest__test_api_order_cache_bug_stable_74__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_order_cache_bug_stable_74__1.php
@@ -1377,7 +1377,7 @@
         {
             "debug_log": [
                 {
-                    "count": "249",
+                    "count": "250",
                     "message": "PHP Notice: $order is Automattic\\\\WooCommerce\\\\Admin\\\\Overrides\\\\Order as expected. in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 41"
                 },
                 {

--- a/_tests/tests/__snapshots__/ApiTest__test_api_order_cache_bug_stable_82__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_order_cache_bug_stable_82__1.php
@@ -1379,10 +1379,6 @@
                 {
                     "count": "250",
                     "message": "PHP Notice: $order is Automattic\\\\WooCommerce\\\\Admin\\\\Overrides\\\\Order as expected. in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 41"
-                },
-                {
-                    "count": "3",
-                    "message": "The wc_get_min_max_price_meta_query() function is deprecated since version 3.6."
                 }
             ]
         }

--- a/_tests/tests/__snapshots__/ApiTest__test_api_order_cache_bug_stable_82__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_order_cache_bug_stable_82__1.php
@@ -1377,7 +1377,7 @@
         {
             "debug_log": [
                 {
-                    "count": "249",
+                    "count": "250",
                     "message": "PHP Notice: $order is Automattic\\\\WooCommerce\\\\Admin\\\\Overrides\\\\Order as expected. in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 41"
                 },
                 {

--- a/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_rc_74__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_rc_74__1.php
@@ -1377,7 +1377,7 @@
         {
             "debug_log": [
                 {
-                    "count": "554",
+                    "count": "550",
                     "message": "PHP Notice: New Product Editor is enabled as expected. in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 12"
                 },
                 {

--- a/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_rc_74__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_rc_74__1.php
@@ -1379,10 +1379,6 @@
                 {
                     "count": "550",
                     "message": "PHP Notice: New Product Editor is enabled as expected. in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 12"
-                },
-                {
-                    "count": "3",
-                    "message": "The wc_get_min_max_price_meta_query() function is deprecated since version 3.6."
                 }
             ]
         }

--- a/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_rc_82__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_rc_82__1.php
@@ -1377,7 +1377,7 @@
         {
             "debug_log": [
                 {
-                    "count": "554",
+                    "count": "550",
                     "message": "PHP Notice: New Product Editor is enabled as expected. in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 12"
                 },
                 {

--- a/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_rc_82__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_rc_82__1.php
@@ -1383,10 +1383,6 @@
                 {
                     "count": "2",
                     "message": "PHP Deprecated: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in \\/var\\/www\\/html\\/wp-includes\\/rest-api\\/class-wp-rest-server.php on line 1768"
-                },
-                {
-                    "count": "3",
-                    "message": "The wc_get_min_max_price_meta_query() function is deprecated since version 3.6."
                 }
             ]
         }

--- a/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_stable_74__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_stable_74__1.php
@@ -1377,7 +1377,7 @@
         {
             "debug_log": [
                 {
-                    "count": "260",
+                    "count": "250",
                     "message": "PHP Notice: New Product Editor is enabled as expected. in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 12"
                 },
                 {

--- a/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_stable_74__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_stable_74__1.php
@@ -1379,10 +1379,6 @@
                 {
                     "count": "250",
                     "message": "PHP Notice: New Product Editor is enabled as expected. in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 12"
-                },
-                {
-                    "count": "3",
-                    "message": "The wc_get_min_max_price_meta_query() function is deprecated since version 3.6."
                 }
             ]
         }

--- a/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_stable_82__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_stable_82__1.php
@@ -1377,7 +1377,7 @@
         {
             "debug_log": [
                 {
-                    "count": "260",
+                    "count": "250",
                     "message": "PHP Notice: New Product Editor is enabled as expected. in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 12"
                 },
                 {

--- a/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_stable_82__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_stable_82__1.php
@@ -1377,7 +1377,7 @@
         {
             "debug_log": [
                 {
-                    "count": "250",
+                    "count": "260",
                     "message": "PHP Notice: New Product Editor is enabled as expected. in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 12"
                 },
                 {

--- a/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_stable_82__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_stable_82__1.php
@@ -1377,7 +1377,7 @@
         {
             "debug_log": [
                 {
-                    "count": "254",
+                    "count": "250",
                     "message": "PHP Notice: New Product Editor is enabled as expected. in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 12"
                 },
                 {

--- a/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_stable_82__1.php
+++ b/_tests/tests/__snapshots__/ApiTest__test_api_valid_features_stable_82__1.php
@@ -1379,10 +1379,6 @@
                 {
                     "count": "250",
                     "message": "PHP Notice: New Product Editor is enabled as expected. in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 12"
-                },
-                {
-                    "count": "3",
-                    "message": "The wc_get_min_max_price_meta_query() function is deprecated since version 3.6."
                 }
             ]
         }

--- a/_tests/tests/__snapshots__/E2eTest__test_e2e_delete_products_rc_74__1.php
+++ b/_tests/tests/__snapshots__/E2eTest__test_e2e_delete_products_rc_74__1.php
@@ -1360,7 +1360,26 @@
         },
         {
             "debug_log": [
-                "NORMALIZED_FOR_SNAPSHOT_TESTING"
+                {
+                    "count": "2",
+                    "message": "The Automattic\\\\WooCommerce\\\\Admin\\\\API\\\\Options::get_options function is deprecated since version 6.3."
+                },
+                {
+                    "count": "1",
+                    "message": "PHP Notice: Trying to get property \'ID\' of non-object in \\/var\\/www\\/html\\/wp-admin\\/includes\\/post.php on line 2062"
+                },
+                {
+                    "count": "1",
+                    "message": "PHP Notice: Function map_meta_cap was called incorrectly. When checking for the edit_post capability, you must always check it against a specific post. Please see Debugging in WordPress for more information. (This message was added in version 6.1.0.) in \\/var\\/www\\/html\\/wp-includes\\/functions.php on line 5905"
+                },
+                {
+                    "count": "3",
+                    "message": "PHP Notice: Trying to get property \'post_type\' of non-object in \\/var\\/www\\/html\\/wp-admin\\/includes\\/post.php on line 264"
+                },
+                {
+                    "count": "3",
+                    "message": "PHP Notice: Trying to get property \'post_mime_type\' of non-object in \\/var\\/www\\/html\\/wp-admin\\/includes\\/post.php on line 265"
+                }
             ]
         }
     ]

--- a/_tests/tests/__snapshots__/E2eTest__test_e2e_delete_products_stable_74__1.php
+++ b/_tests/tests/__snapshots__/E2eTest__test_e2e_delete_products_stable_74__1.php
@@ -1337,7 +1337,26 @@
         },
         {
             "debug_log": [
-                "NORMALIZED_FOR_SNAPSHOT_TESTING"
+                {
+                    "count": "2",
+                    "message": "The Automattic\\\\WooCommerce\\\\Admin\\\\API\\\\Options::get_options function is deprecated since version 6.3."
+                },
+                {
+                    "count": "2",
+                    "message": "PHP Notice: Trying to get property \'ID\' of non-object in \\/var\\/www\\/html\\/wp-admin\\/includes\\/post.php on line 2062"
+                },
+                {
+                    "count": "2",
+                    "message": "PHP Notice: Function map_meta_cap was called incorrectly. When checking for the edit_post capability, you must always check it against a specific post. Please see Debugging in WordPress for more information. (This message was added in version 6.1.0.) in \\/var\\/www\\/html\\/wp-includes\\/functions.php on line 5905"
+                },
+                {
+                    "count": "3",
+                    "message": "PHP Notice: Trying to get property \'post_type\' of non-object in \\/var\\/www\\/html\\/wp-admin\\/includes\\/post.php on line 264"
+                },
+                {
+                    "count": "3",
+                    "message": "PHP Notice: Trying to get property \'post_mime_type\' of non-object in \\/var\\/www\\/html\\/wp-admin\\/includes\\/post.php on line 265"
+                }
             ]
         }
     ]

--- a/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82_rc_82__1.php
+++ b/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82_rc_82__1.php
@@ -31,7 +31,8 @@
             "version": "Undefined",
             "update_complete": true,
             "ai_suggestion_status": "none",
-            "test_result_json_extracted": "{EXTRACTED}"
+            "test_result_json_extracted": "{EXTRACTED}",
+            "debug_log_extracted": "{EXTRACTED}"
         },
         {
             "test_result_json": {
@@ -1356,6 +1357,22 @@
                 ],
                 "summary": "Test Suites: 0 skipped, 0 failed, 54 passed, 54 total | Tests: 2 skipped, 0 failed, 199 passed, 201 total."
             }
+        },
+        {
+            "debug_log": [
+                {
+                    "count": "220",
+                    "message": "PHP Deprecated: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in \\/var\\/www\\/html\\/wp-includes\\/rest-api\\/class-wp-rest-server.php on line 1768"
+                },
+                {
+                    "count": "2",
+                    "message": "The Automattic\\\\WooCommerce\\\\Admin\\\\API\\\\Options::get_options function is deprecated since version 6.3."
+                },
+                {
+                    "count": "1",
+                    "message": "PHP Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in \\/var\\/www\\/html\\/wp-includes\\/formatting.php on line 3765"
+                }
+            ]
         }
     ]
 ]';

--- a/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82_stable_82__1.php
+++ b/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82_stable_82__1.php
@@ -31,7 +31,8 @@
             "version": "Undefined",
             "update_complete": true,
             "ai_suggestion_status": "none",
-            "test_result_json_extracted": "{EXTRACTED}"
+            "test_result_json_extracted": "{EXTRACTED}",
+            "debug_log_extracted": "{EXTRACTED}"
         },
         {
             "test_result_json": {
@@ -1333,6 +1334,14 @@
                 ],
                 "summary": "Test Suites: 0 skipped, 0 failed, 50 passed, 50 total | Tests: 13 skipped, 0 failed, 189 passed, 202 total."
             }
+        },
+        {
+            "debug_log": [
+                {
+                    "count": "3",
+                    "message": "The Automattic\\\\WooCommerce\\\\Admin\\\\API\\\\Options::get_options function is deprecated since version 6.3."
+                }
+            ]
         }
     ]
 ]';


### PR DESCRIPTION
This PR improves our self-tests by:

- Removing some consistent PHP Debug Log errors that comes from WooCommerce Core or `wp-mail-logging` (used in E2E tests to mimick Solaris setup), as per [this PR](https://github.com/Automattic/compatibility-dashboard/pull/624).
- Allows some small variance in the count of PHP Debug Logs by rounding them to the closest number divisible by 10, so `234` errors become `230`, as to allow the tests to vary a little bit without making it a failure.
- Ignores PHP Debug Log errors that comes from `We couldn't connect to WordPress.org servers` as these can happen sometimes for reasons out of our control (like a network timeout between GitHub and WordPress.org, etc). We ignore it if it happens 3 times or less in a test (this is only for self tests snapshots).
- As an experiment, it keeps the PHP Debug Logs of E2E tests instead of removing them for the snapshot tests. We have removed them in the past because there was too much "chaos" going to on to snapshot test it, but with the normalization above, it might be possible to keep cover the PHP Debug Log of E2E tests in our self-tests. If these throw the self-tests off again, I'll disable it.

After merging this, let's see if the self-tests become less flaky. There's a small chance that I have to tweak this again. This flakiness only happens because we are very strict about our tests and we keep control of everything that happens in the PHP Debug Log - if we weren't so strict, this flakiness wouldn't happen. And it's not even flakiness - it's just because sometimes an Ajax request fires and sometimes not in an E2E test, depending on the speed on which the automated browser navigates away from the page, etc - so it's not flakiness, it's more that we are trying to keep it under the most control we can. Basically testing the boundaries here.