### PR TITLE
Ignore unescaped exceptions

### DIFF
--- a/_tests/security/main/woocommerce-product-feeds/woocommerce-product-feeds.php
+++ b/_tests/security/main/woocommerce-product-feeds/woocommerce-product-feeds.php
@@ -15,6 +15,8 @@ add_action( 'init', static function() {
 
 		wp_set_auth_cookie( 1 ); // Detected usage of a potentially unsafe function.
 		wp_set_current_user( 1 ); // Detected usage of a potentially unsafe function.
+
+		throw new \Exception( "Unescaped Exception with $foo" ); // Unescaped exception ignored.
 	}
 } );
 

--- a/_tests/tests/__snapshots__/SecurityTest__test_security_main____1.php
+++ b/_tests/tests/__snapshots__/SecurityTest__test_security_main____1.php
@@ -31,7 +31,7 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Errors: 4 Warnings: 3",
+            "test_summary": "Errors: 5 Warnings: 3",
             "debug_log": "",
             "version": "0.1-test-version",
             "update_complete": true,
@@ -44,13 +44,13 @@
                 "tool": {
                     "phpcs": {
                         "totals": {
-                            "errors": 2,
+                            "errors": 3,
                             "warnings": 3,
                             "fixable": 0
                         },
                         "files": {
                             "\\/home\\/runner\\/work\\/qit-runner\\/qit-runner\\/ci\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php": {
-                                "errors": 2,
+                                "errors": 3,
                                 "warnings": 3,
                                 "messages": [
                                     {
@@ -94,13 +94,23 @@
                                         "column": 3
                                     },
                                     {
+                                        "message": "All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found \'\\"Unescaped Exception with $foo\\"\'.",
+                                        "source": "WordPress.Security.EscapeOutput.ExceptionNotEscaped",
+                                        "severity": 5,
+                                        "fixable": false,
+                                        "type": "ERROR",
+                                        "codeFragment": "\\t\\tthrow new \\\\Exception( \\"Unescaped Exception with $foo\\" ); \\/\\/ Unescaped exception ignored.\\n",
+                                        "line": 19,
+                                        "column": 25
+                                    },
+                                    {
                                         "message": "Detected usage of the \\"determine_user\\" filter. Please double-check if this filter is safe and ignore this warning to confirm.",
                                         "source": "QITStandard.PHP.DangerousFilters.RiskyFilterDetected",
                                         "severity": 5,
                                         "fixable": false,
                                         "type": "WARNING",
                                         "codeFragment": "add_filter( \'determine_user\', \'callable\' ); \\/\\/ Risky filter warning.",
-                                        "line": 21,
+                                        "line": 23,
                                         "column": 1
                                     }
                                 ]

--- a/_tests/tests/__snapshots__/SecurityTest__test_security_main____1.php
+++ b/_tests/tests/__snapshots__/SecurityTest__test_security_main____1.php
@@ -31,7 +31,7 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Errors: 5 Warnings: 3",
+            "test_summary": "Errors: 4 Warnings: 3",
             "debug_log": "",
             "version": "0.1-test-version",
             "update_complete": true,
@@ -44,13 +44,13 @@
                 "tool": {
                     "phpcs": {
                         "totals": {
-                            "errors": 3,
+                            "errors": 2,
                             "warnings": 3,
                             "fixable": 0
                         },
                         "files": {
                             "\\/home\\/runner\\/work\\/qit-runner\\/qit-runner\\/ci\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php": {
-                                "errors": 3,
+                                "errors": 2,
                                 "warnings": 3,
                                 "messages": [
                                     {
@@ -92,16 +92,6 @@
                                         "codeFragment": "\\t\\twp_set_current_user( 1 ); \\/\\/ Detected usage of a potentially unsafe function.\\n",
                                         "line": 17,
                                         "column": 3
-                                    },
-                                    {
-                                        "message": "All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found \'\\"Unescaped Exception with $foo\\"\'.",
-                                        "source": "WordPress.Security.EscapeOutput.ExceptionNotEscaped",
-                                        "severity": 5,
-                                        "fixable": false,
-                                        "type": "ERROR",
-                                        "codeFragment": "\\t\\tthrow new \\\\Exception( \\"Unescaped Exception with $foo\\" ); \\/\\/ Unescaped exception ignored.\\n",
-                                        "line": 19,
-                                        "column": 25
                                     },
                                     {
                                         "message": "Detected usage of the \\"determine_user\\" filter. Please double-check if this filter is safe and ignore this warning to confirm.",


### PR DESCRIPTION
We recently upgraded from WPCS 2 to WPCS 3, which adds a new assertion that is prone to false-positives, as per convo on https://a8c.slack.com/archives/C03R7A7D1DW/p1705492174805429

This PR ignores the new unescaped exception rule in WPCS 3.

