### PR TITLE
Add self-test for PHPCompatibility to not flag attribute usage

### DIFF
--- a/_tests/phpcompatibility/sut_default_php_version/woocommerce-product-feeds/woocommerce-product-feeds.php
+++ b/_tests/phpcompatibility/sut_default_php_version/woocommerce-product-feeds/woocommerce-product-feeds.php
@@ -29,6 +29,22 @@ class Bar {
 	readonly string $foo;
 }
 
+/*
+ * Attributes require PHP 8, but we disabled this check for now because
+ * it is generally backwards compatible, it's only invalid syntax in PHP 7
+ * if it's multi-line (which is rare).
+ *
+ * We are following up in the PHPCompatibility repo and once it can differentiate
+ * between backwards-compatible attribute syntax and invalid syntax, we will re-enable
+ * this check.
+ */
+class MyArrayIterator extends ArrayIterator {
+	#[ReturnTypeWillChange]
+	public function current() {
+		return parent::current();
+	}
+}
+
 // Requires PHP 8.2 (should be flagged since this plugin supports PHP 7.2).
 readonly class Foo {
 

--- a/_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_default_php_version_woo_php_wp_aab4e9b0325ab0d8921f5fb94ffecdac__1.php
+++ b/_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_default_php_version_woo_php_wp_aab4e9b0325ab0d8921f5fb94ffecdac__1.php
@@ -31,7 +31,7 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Errors: 13 Warnings: 5",
+            "test_summary": "Errors: 14 Warnings: 5",
             "debug_log": "",
             "version": "Undefined",
             "update_complete": true,
@@ -44,13 +44,13 @@
                 "tool": {
                     "phpcs": {
                         "totals": {
-                            "errors": 13,
+                            "errors": 14,
                             "warnings": 5,
                             "fixable": 1
                         },
                         "files": {
                             "\\/home\\/runner\\/work\\/qit-runner\\/qit-runner\\/ci\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php": {
-                                "errors": 13,
+                                "errors": 14,
                                 "warnings": 5,
                                 "messages": [
                                     {
@@ -90,12 +90,21 @@
                                         "column": 18
                                     },
                                     {
+                                        "message": "Attributes are not supported in PHP 7.4 or earlier. Found: #[ReturnTypeWillChange]",
+                                        "source": "PHPCompatibility.Attributes.NewAttributes.Found",
+                                        "severity": 5,
+                                        "fixable": false,
+                                        "type": "ERROR",
+                                        "line": 42,
+                                        "column": 2
+                                    },
+                                    {
                                         "message": "Readonly classes are not supported in PHP 8.1 or earlier.",
                                         "source": "PHPCompatibility.Classes.NewReadonlyClasses.Found",
                                         "severity": 5,
                                         "fixable": false,
                                         "type": "ERROR",
-                                        "line": 33,
+                                        "line": 49,
                                         "column": 1
                                     },
                                     {
@@ -104,7 +113,7 @@
                                         "severity": 5,
                                         "fixable": false,
                                         "type": "ERROR",
-                                        "line": 39,
+                                        "line": 55,
                                         "column": 12
                                     },
                                     {
@@ -113,7 +122,7 @@
                                         "severity": 5,
                                         "fixable": false,
                                         "type": "ERROR",
-                                        "line": 43,
+                                        "line": 59,
                                         "column": 1
                                     },
                                     {
@@ -122,7 +131,7 @@
                                         "severity": 5,
                                         "fixable": false,
                                         "type": "ERROR",
-                                        "line": 49,
+                                        "line": 65,
                                         "column": 55
                                     },
                                     {
@@ -131,7 +140,7 @@
                                         "severity": 5,
                                         "fixable": false,
                                         "type": "ERROR",
-                                        "line": 49,
+                                        "line": 65,
                                         "column": 85
                                     },
                                     {
@@ -140,7 +149,7 @@
                                         "severity": 5,
                                         "fixable": false,
                                         "type": "ERROR",
-                                        "line": 53,
+                                        "line": 69,
                                         "column": 1
                                     },
                                     {
@@ -149,7 +158,7 @@
                                         "severity": 5,
                                         "fixable": true,
                                         "type": "ERROR",
-                                        "line": 58,
+                                        "line": 74,
                                         "column": 18
                                     },
                                     {
@@ -158,7 +167,7 @@
                                         "severity": 5,
                                         "fixable": false,
                                         "type": "ERROR",
-                                        "line": 62,
+                                        "line": 78,
                                         "column": 17
                                     },
                                     {
@@ -167,7 +176,7 @@
                                         "severity": 5,
                                         "fixable": false,
                                         "type": "WARNING",
-                                        "line": 66,
+                                        "line": 82,
                                         "column": 35
                                     },
                                     {
@@ -176,7 +185,7 @@
                                         "severity": 5,
                                         "fixable": false,
                                         "type": "WARNING",
-                                        "line": 78,
+                                        "line": 94,
                                         "column": 1
                                     },
                                     {
@@ -185,7 +194,7 @@
                                         "severity": 5,
                                         "fixable": false,
                                         "type": "WARNING",
-                                        "line": 90,
+                                        "line": 106,
                                         "column": 1
                                     },
                                     {
@@ -194,7 +203,7 @@
                                         "severity": 5,
                                         "fixable": false,
                                         "type": "ERROR",
-                                        "line": 94,
+                                        "line": 110,
                                         "column": 8
                                     },
                                     {
@@ -203,7 +212,7 @@
                                         "severity": 5,
                                         "fixable": false,
                                         "type": "WARNING",
-                                        "line": 100,
+                                        "line": 116,
                                         "column": 16
                                     },
                                     {
@@ -212,7 +221,7 @@
                                         "severity": 5,
                                         "fixable": false,
                                         "type": "WARNING",
-                                        "line": 104,
+                                        "line": 120,
                                         "column": 22
                                     }
                                 ]

--- a/_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_default_php_version_woo_php_wp_aab4e9b0325ab0d8921f5fb94ffecdac__1.php
+++ b/_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_default_php_version_woo_php_wp_aab4e9b0325ab0d8921f5fb94ffecdac__1.php
@@ -31,7 +31,7 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Errors: 14 Warnings: 5",
+            "test_summary": "Errors: 13 Warnings: 5",
             "debug_log": "",
             "version": "Undefined",
             "update_complete": true,
@@ -44,13 +44,13 @@
                 "tool": {
                     "phpcs": {
                         "totals": {
-                            "errors": 14,
+                            "errors": 13,
                             "warnings": 5,
                             "fixable": 1
                         },
                         "files": {
                             "\\/home\\/runner\\/work\\/qit-runner\\/qit-runner\\/ci\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php": {
-                                "errors": 14,
+                                "errors": 13,
                                 "warnings": 5,
                                 "messages": [
                                     {
@@ -88,15 +88,6 @@
                                         "type": "ERROR",
                                         "line": 29,
                                         "column": 18
-                                    },
-                                    {
-                                        "message": "Attributes are not supported in PHP 7.4 or earlier. Found: #[ReturnTypeWillChange]",
-                                        "source": "PHPCompatibility.Attributes.NewAttributes.Found",
-                                        "severity": 5,
-                                        "fixable": false,
-                                        "type": "ERROR",
-                                        "line": 42,
-                                        "column": 2
                                     },
                                     {
                                         "message": "Readonly classes are not supported in PHP 8.1 or earlier.",


### PR DESCRIPTION
As discussed in Slack, attributes are usually backwards compatible with PHP 7, for the exception or multi-line attributes.

PHPCompatibility currently cannot differentiate between them and flags all usage of Attributes as invalid if you plan to support PHP 7.

We disabled the Attribute rule in the PHPCompatibility test as it's currently causing more false-positives than bringing benefits, as multi-line attribute usage is very rare in WP plugins, but `ReturnTypeWillChange` is very common, for instance.

We are keeping an eye upstream for when PHPCompatibility have a way to [differentiate](https://github.com/PHPCompatibility/PHPCompatibility/issues/1480) both, and will re-enable this rule.

- We can see that once I added an attribute to the self-test, the attribute was first [flagged](https://github.com/woocommerce/qit-cli/commit/ca7ba659e61274de212389cdaf3dd8d36e03bc65)
- Then we ignored the Attribute rule in QIT
- Then the attribute is [no longer flagged ](https://github.com/woocommerce/qit-cli/commit/4149c111fa65eea3761a26aec2f19e6f77410cc9)