### PR TITLE
Allow retry on get request

### DIFF
--- a/src/src/Commands/GetCommand.php
+++ b/src/src/Commands/GetCommand.php
@@ -32,6 +32,7 @@ class GetCommand extends Command {
 				->with_post_body( [
 					'test_run_id' => $input->getArgument( 'test_run_id' ),
 				] )
+				->with_retry( 3 )
 				->request();
 		} catch ( \Exception $e ) {
 			$output->writeln( "<error>{$e->getMessage()}</error>" );


### PR DESCRIPTION
Self-tests failed today, upon investigating it seems the request to get the result failed due to 429 (too many requests). This PR allow this request to be retried, which should solve it.