### PR TITLE
Test snapshots for 8.6.0 rc.1

### DIFF
--- a/_tests/ParallelOutput.php
+++ b/_tests/ParallelOutput.php
@@ -46,7 +46,11 @@ class ParallelOutput {
 			$this->displayBufferedOutputs();
 		}
 
-		$this->updateProcessStatus( $process, $out ); // You need to implement this method
+		if ( \PHP_VERSION_ID >= 80300 ) {
+			// This can break on PHP less than 8.3 until this is merged:
+			// https://github.com/symfony/symfony/pull/53821
+			$this->updateProcessStatus( $process, $out );
+		}
 	}
 
 	protected function updateProcessStatus( Process $process, $output ) {

--- a/_tests/QITSelfTests.php
+++ b/_tests/QITSelfTests.php
@@ -223,7 +223,12 @@ function generate_test_runs( array $test_types ): array {
 									$env_matches = $value === $env[ $key ];
 									break;
 							}
+
+							if ( ! $env_matches ) {
+								break;
+							}
 						}
+
 						if ( ! $env_matches ) {
 							$GLOBALS['parallelOutput']->addRawOutput( sprintf( "Skipping %s, does not match env filters\n", basename( $test ) ) );
 							continue;

--- a/_tests/QITSelfTests.php
+++ b/_tests/QITSelfTests.php
@@ -76,7 +76,6 @@ foreach (
 
 require_once __DIR__ . '/test-result-parser.php';
 require_once __DIR__ . '/ParallelOutput.php';
-require_once __DIR__ . '/ProcessManager.php';
 
 register_shutdown_function( function () {
 	$to_delete = array_unique( Context::$to_delete );

--- a/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82_woorc_php82_wprc_3352128ddc0d4673fd435b1c6c1e9d15__1.php
+++ b/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82_woorc_php82_wprc_3352128ddc0d4673fd435b1c6c1e9d15__1.php
@@ -12,7 +12,7 @@
             "additional_woo_plugins": [],
             "additional_wp_plugins": [],
             "test_log": "",
-            "status": "failed",
+            "status": "success",
             "test_result_aws_url": "https:\\/\\/test-results-aws.com",
             "test_result_aws_expiration": 1234567890,
             "is_development": true,
@@ -31,7 +31,7 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Test Suites: 0 skipped, 1 failed, 73 passed, 74 total | Tests: 14 skipped, 1 failed, 274 passed, 289 total.",
+            "test_summary": "Test Suites: 0 skipped, 0 failed, 74 passed, 74 total | Tests: 15 skipped, 0 failed, 274 passed, 289 total.",
             "version": "Undefined",
             "update_complete": true,
             "ai_suggestion_status": "none",
@@ -41,13 +41,13 @@
         },
         {
             "test_result_json": {
-                "numFailedTestSuites": 1,
-                "numPassedTestSuites": 73,
+                "numFailedTestSuites": 0,
+                "numPassedTestSuites": 74,
                 "numPendingTestSuites": 0,
                 "numTotalTestSuites": 74,
-                "numFailedTests": 1,
+                "numFailedTests": 0,
                 "numPassedTests": 274,
-                "numPendingTests": 14,
+                "numPendingTests": 15,
                 "numTotalTests": 289,
                 "testResults": [
                     {
@@ -1518,8 +1518,8 @@
                     },
                     {
                         "file": "shopper\\/checkout.spec.js",
-                        "status": "failed",
-                        "has_pending": false,
+                        "status": "passed",
+                        "has_pending": true,
                         "tests": {
                             "Checkout page": [
                                 {
@@ -1544,7 +1544,7 @@
                                 },
                                 {
                                     "title": "allows guest customer to place an order",
-                                    "status": "failed"
+                                    "status": "pending"
                                 },
                                 {
                                     "title": "allows existing customer to place order",
@@ -1912,7 +1912,7 @@
                         }
                     }
                 ],
-                "summary": "Test Suites: 0 skipped, 1 failed, 73 passed, 74 total | Tests: 14 skipped, 1 failed, 274 passed, 289 total."
+                "summary": "Test Suites: 0 skipped, 0 failed, 74 passed, 74 total | Tests: 15 skipped, 0 failed, 274 passed, 289 total."
             }
         },
         {

--- a/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82_woorc_php82_wprc_3352128ddc0d4673fd435b1c6c1e9d15__1.php
+++ b/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82_woorc_php82_wprc_3352128ddc0d4673fd435b1c6c1e9d15__1.php
@@ -12,7 +12,7 @@
             "additional_woo_plugins": [],
             "additional_wp_plugins": [],
             "test_log": "",
-            "status": "success",
+            "status": "failed",
             "test_result_aws_url": "https:\\/\\/test-results-aws.com",
             "test_result_aws_expiration": 1234567890,
             "is_development": true,
@@ -31,7 +31,7 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Test Suites: 0 skipped, 0 failed, 74 passed, 74 total | Tests: 15 skipped, 0 failed, 274 passed, 289 total.",
+            "test_summary": "Test Suites: 0 skipped, 1 failed, 73 passed, 74 total | Tests: 14 skipped, 1 failed, 274 passed, 289 total.",
             "version": "Undefined",
             "update_complete": true,
             "ai_suggestion_status": "none",
@@ -41,13 +41,13 @@
         },
         {
             "test_result_json": {
-                "numFailedTestSuites": 0,
-                "numPassedTestSuites": 74,
+                "numFailedTestSuites": 1,
+                "numPassedTestSuites": 73,
                 "numPendingTestSuites": 0,
                 "numTotalTestSuites": 74,
-                "numFailedTests": 0,
+                "numFailedTests": 1,
                 "numPassedTests": 274,
-                "numPendingTests": 15,
+                "numPendingTests": 14,
                 "numTotalTests": 289,
                 "testResults": [
                     {
@@ -1518,8 +1518,8 @@
                     },
                     {
                         "file": "shopper\\/checkout.spec.js",
-                        "status": "passed",
-                        "has_pending": true,
+                        "status": "failed",
+                        "has_pending": false,
                         "tests": {
                             "Checkout page": [
                                 {
@@ -1544,7 +1544,7 @@
                                 },
                                 {
                                     "title": "allows guest customer to place an order",
-                                    "status": "pending"
+                                    "status": "failed"
                                 },
                                 {
                                     "title": "allows existing customer to place order",
@@ -1912,7 +1912,7 @@
                         }
                     }
                 ],
-                "summary": "Test Suites: 0 skipped, 0 failed, 74 passed, 74 total | Tests: 15 skipped, 0 failed, 274 passed, 289 total."
+                "summary": "Test Suites: 0 skipped, 1 failed, 73 passed, 74 total | Tests: 14 skipped, 1 failed, 274 passed, 289 total."
             }
         },
         {

--- a/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82_woorc_php82_wprc_3352128ddc0d4673fd435b1c6c1e9d15__1.php
+++ b/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82_woorc_php82_wprc_3352128ddc0d4673fd435b1c6c1e9d15__1.php
@@ -12,7 +12,7 @@
             "additional_woo_plugins": [],
             "additional_wp_plugins": [],
             "test_log": "",
-            "status": "success",
+            "status": "failed",
             "test_result_aws_url": "https:\\/\\/test-results-aws.com",
             "test_result_aws_expiration": 1234567890,
             "is_development": true,
@@ -31,7 +31,7 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Test Suites: 0 skipped, 0 failed, 74 passed, 74 total | Tests: 14 skipped, 0 failed, 275 passed, 289 total.",
+            "test_summary": "Test Suites: 0 skipped, 1 failed, 73 passed, 74 total | Tests: 14 skipped, 1 failed, 274 passed, 289 total.",
             "version": "Undefined",
             "update_complete": true,
             "ai_suggestion_status": "none",
@@ -41,12 +41,12 @@
         },
         {
             "test_result_json": {
-                "numFailedTestSuites": 0,
-                "numPassedTestSuites": 74,
+                "numFailedTestSuites": 1,
+                "numPassedTestSuites": 73,
                 "numPendingTestSuites": 0,
                 "numTotalTestSuites": 74,
-                "numFailedTests": 0,
-                "numPassedTests": 275,
+                "numFailedTests": 1,
+                "numPassedTests": 274,
                 "numPendingTests": 14,
                 "numTotalTests": 289,
                 "testResults": [
@@ -1518,7 +1518,7 @@
                     },
                     {
                         "file": "shopper\\/checkout.spec.js",
-                        "status": "passed",
+                        "status": "failed",
                         "has_pending": false,
                         "tests": {
                             "Checkout page": [
@@ -1544,7 +1544,7 @@
                                 },
                                 {
                                     "title": "allows guest customer to place an order",
-                                    "status": "passed"
+                                    "status": "failed"
                                 },
                                 {
                                     "title": "allows existing customer to place order",
@@ -1912,16 +1912,11 @@
                         }
                     }
                 ],
-                "summary": "Test Suites: 0 skipped, 0 failed, 74 passed, 74 total | Tests: 14 skipped, 0 failed, 275 passed, 289 total."
+                "summary": "Test Suites: 0 skipped, 1 failed, 73 passed, 74 total | Tests: 14 skipped, 1 failed, 274 passed, 289 total."
             }
         },
         {
-            "debug_log": [
-                {
-                    "count": "3",
-                    "message": "PHP Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in \\/var\\/www\\/html\\/wp-includes\\/formatting.php on line 3771"
-                }
-            ]
+            "debug_log": []
         }
     ]
 ]';

--- a/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82_woostable_php82_wprc_ae506535d29d54780f2157e86026a711__1.php
+++ b/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82_woostable_php82_wprc_ae506535d29d54780f2157e86026a711__1.php
@@ -12,7 +12,7 @@
             "additional_woo_plugins": [],
             "additional_wp_plugins": [],
             "test_log": "",
-            "status": "failed",
+            "status": "success",
             "test_result_aws_url": "https:\\/\\/test-results-aws.com",
             "test_result_aws_expiration": 1234567890,
             "is_development": true,
@@ -31,7 +31,7 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Test Suites: 0 skipped, 1 failed, 67 passed, 68 total | Tests: 8 skipped, 1 failed, 245 passed, 254 total.",
+            "test_summary": "Test Suites: 0 skipped, 0 failed, 68 passed, 68 total | Tests: 9 skipped, 0 failed, 245 passed, 254 total.",
             "version": "Undefined",
             "update_complete": true,
             "ai_suggestion_status": "none",
@@ -41,13 +41,13 @@
         },
         {
             "test_result_json": {
-                "numFailedTestSuites": 1,
-                "numPassedTestSuites": 67,
+                "numFailedTestSuites": 0,
+                "numPassedTestSuites": 68,
                 "numPendingTestSuites": 0,
                 "numTotalTestSuites": 68,
-                "numFailedTests": 1,
+                "numFailedTests": 0,
                 "numPassedTests": 245,
-                "numPendingTests": 8,
+                "numPendingTests": 9,
                 "numTotalTests": 254,
                 "testResults": [
                     {
@@ -1276,8 +1276,8 @@
                     },
                     {
                         "file": "shopper\\/checkout-coupons.spec.js",
-                        "status": "failed",
-                        "has_pending": false,
+                        "status": "passed",
+                        "has_pending": true,
                         "tests": {
                             "Checkout coupons": [
                                 {
@@ -1298,7 +1298,7 @@
                                 },
                                 {
                                     "title": "allows checkout to apply multiple coupons",
-                                    "status": "failed"
+                                    "status": "pending"
                                 },
                                 {
                                     "title": "restores checkout total when coupons are removed",
@@ -1716,7 +1716,7 @@
                         }
                     }
                 ],
-                "summary": "Test Suites: 0 skipped, 1 failed, 67 passed, 68 total | Tests: 8 skipped, 1 failed, 245 passed, 254 total."
+                "summary": "Test Suites: 0 skipped, 0 failed, 68 passed, 68 total | Tests: 9 skipped, 0 failed, 245 passed, 254 total."
             }
         },
         {

--- a/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82_woostable_php82_wprc_ae506535d29d54780f2157e86026a711__1.php
+++ b/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82_woostable_php82_wprc_ae506535d29d54780f2157e86026a711__1.php
@@ -12,7 +12,7 @@
             "additional_woo_plugins": [],
             "additional_wp_plugins": [],
             "test_log": "",
-            "status": "success",
+            "status": "failed",
             "test_result_aws_url": "https:\\/\\/test-results-aws.com",
             "test_result_aws_expiration": 1234567890,
             "is_development": true,
@@ -31,7 +31,7 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Test Suites: 0 skipped, 0 failed, 68 passed, 68 total | Tests: 8 skipped, 0 failed, 246 passed, 254 total.",
+            "test_summary": "Test Suites: 0 skipped, 1 failed, 67 passed, 68 total | Tests: 8 skipped, 1 failed, 245 passed, 254 total.",
             "version": "Undefined",
             "update_complete": true,
             "ai_suggestion_status": "none",
@@ -41,12 +41,12 @@
         },
         {
             "test_result_json": {
-                "numFailedTestSuites": 0,
-                "numPassedTestSuites": 68,
+                "numFailedTestSuites": 1,
+                "numPassedTestSuites": 67,
                 "numPendingTestSuites": 0,
                 "numTotalTestSuites": 68,
-                "numFailedTests": 0,
-                "numPassedTests": 246,
+                "numFailedTests": 1,
+                "numPassedTests": 245,
                 "numPendingTests": 8,
                 "numTotalTests": 254,
                 "testResults": [
@@ -1276,7 +1276,7 @@
                     },
                     {
                         "file": "shopper\\/checkout-coupons.spec.js",
-                        "status": "passed",
+                        "status": "failed",
                         "has_pending": false,
                         "tests": {
                             "Checkout coupons": [
@@ -1298,7 +1298,7 @@
                                 },
                                 {
                                     "title": "allows checkout to apply multiple coupons",
-                                    "status": "passed"
+                                    "status": "failed"
                                 },
                                 {
                                     "title": "restores checkout total when coupons are removed",
@@ -1716,7 +1716,7 @@
                         }
                     }
                 ],
-                "summary": "Test Suites: 0 skipped, 0 failed, 68 passed, 68 total | Tests: 8 skipped, 0 failed, 246 passed, 254 total."
+                "summary": "Test Suites: 0 skipped, 1 failed, 67 passed, 68 total | Tests: 8 skipped, 1 failed, 245 passed, 254 total."
             }
         },
         {

--- a/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82_woostable_php82_wprc_ae506535d29d54780f2157e86026a711__1.php
+++ b/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_php82_woostable_php82_wprc_ae506535d29d54780f2157e86026a711__1.php
@@ -12,7 +12,7 @@
             "additional_woo_plugins": [],
             "additional_wp_plugins": [],
             "test_log": "",
-            "status": "failed",
+            "status": "success",
             "test_result_aws_url": "https:\\/\\/test-results-aws.com",
             "test_result_aws_expiration": 1234567890,
             "is_development": true,
@@ -31,7 +31,7 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Test Suites: 0 skipped, 1 failed, 67 passed, 68 total | Tests: 8 skipped, 1 failed, 245 passed, 254 total.",
+            "test_summary": "Test Suites: 0 skipped, 0 failed, 68 passed, 68 total | Tests: 8 skipped, 0 failed, 246 passed, 254 total.",
             "version": "Undefined",
             "update_complete": true,
             "ai_suggestion_status": "none",
@@ -41,12 +41,12 @@
         },
         {
             "test_result_json": {
-                "numFailedTestSuites": 1,
-                "numPassedTestSuites": 67,
+                "numFailedTestSuites": 0,
+                "numPassedTestSuites": 68,
                 "numPendingTestSuites": 0,
                 "numTotalTestSuites": 68,
-                "numFailedTests": 1,
-                "numPassedTests": 245,
+                "numFailedTests": 0,
+                "numPassedTests": 246,
                 "numPendingTests": 8,
                 "numTotalTests": 254,
                 "testResults": [
@@ -1276,7 +1276,7 @@
                     },
                     {
                         "file": "shopper\\/checkout-coupons.spec.js",
-                        "status": "failed",
+                        "status": "passed",
                         "has_pending": false,
                         "tests": {
                             "Checkout coupons": [
@@ -1298,7 +1298,7 @@
                                 },
                                 {
                                     "title": "allows checkout to apply multiple coupons",
-                                    "status": "failed"
+                                    "status": "passed"
                                 },
                                 {
                                     "title": "restores checkout total when coupons are removed",
@@ -1716,7 +1716,7 @@
                         }
                     }
                 ],
-                "summary": "Test Suites: 0 skipped, 1 failed, 67 passed, 68 total | Tests: 8 skipped, 1 failed, 245 passed, 254 total."
+                "summary": "Test Suites: 0 skipped, 0 failed, 68 passed, 68 total | Tests: 8 skipped, 0 failed, 246 passed, 254 total."
             }
         },
         {

--- a/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_woorc_php74_wprc_3ca3234b24887d2b86c56ac59b5b4ceb__1.php
+++ b/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_woorc_php74_wprc_3ca3234b24887d2b86c56ac59b5b4ceb__1.php
@@ -12,7 +12,7 @@
             "additional_woo_plugins": [],
             "additional_wp_plugins": [],
             "test_log": "",
-            "status": "failed",
+            "status": "success",
             "test_result_aws_url": "https:\\/\\/test-results-aws.com",
             "test_result_aws_expiration": 1234567890,
             "is_development": true,
@@ -31,7 +31,7 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Test Suites: 0 skipped, 1 failed, 73 passed, 74 total | Tests: 14 skipped, 1 failed, 274 passed, 289 total.",
+            "test_summary": "Test Suites: 0 skipped, 0 failed, 74 passed, 74 total | Tests: 15 skipped, 0 failed, 274 passed, 289 total.",
             "version": "Undefined",
             "update_complete": true,
             "ai_suggestion_status": "none",
@@ -41,13 +41,13 @@
         },
         {
             "test_result_json": {
-                "numFailedTestSuites": 1,
-                "numPassedTestSuites": 73,
+                "numFailedTestSuites": 0,
+                "numPassedTestSuites": 74,
                 "numPendingTestSuites": 0,
                 "numTotalTestSuites": 74,
-                "numFailedTests": 1,
+                "numFailedTests": 0,
                 "numPassedTests": 274,
-                "numPendingTests": 14,
+                "numPendingTests": 15,
                 "numTotalTests": 289,
                 "testResults": [
                     {
@@ -1518,8 +1518,8 @@
                     },
                     {
                         "file": "shopper\\/checkout.spec.js",
-                        "status": "failed",
-                        "has_pending": false,
+                        "status": "passed",
+                        "has_pending": true,
                         "tests": {
                             "Checkout page": [
                                 {
@@ -1544,7 +1544,7 @@
                                 },
                                 {
                                     "title": "allows guest customer to place an order",
-                                    "status": "failed"
+                                    "status": "pending"
                                 },
                                 {
                                     "title": "allows existing customer to place order",
@@ -1912,7 +1912,7 @@
                         }
                     }
                 ],
-                "summary": "Test Suites: 0 skipped, 1 failed, 73 passed, 74 total | Tests: 14 skipped, 1 failed, 274 passed, 289 total."
+                "summary": "Test Suites: 0 skipped, 0 failed, 74 passed, 74 total | Tests: 15 skipped, 0 failed, 274 passed, 289 total."
             }
         },
         {

--- a/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_woorc_php74_wprc_3ca3234b24887d2b86c56ac59b5b4ceb__1.php
+++ b/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_woorc_php74_wprc_3ca3234b24887d2b86c56ac59b5b4ceb__1.php
@@ -12,7 +12,7 @@
             "additional_woo_plugins": [],
             "additional_wp_plugins": [],
             "test_log": "",
-            "status": "success",
+            "status": "failed",
             "test_result_aws_url": "https:\\/\\/test-results-aws.com",
             "test_result_aws_expiration": 1234567890,
             "is_development": true,
@@ -31,7 +31,7 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Test Suites: 0 skipped, 0 failed, 74 passed, 74 total | Tests: 15 skipped, 0 failed, 274 passed, 289 total.",
+            "test_summary": "Test Suites: 0 skipped, 1 failed, 73 passed, 74 total | Tests: 14 skipped, 1 failed, 274 passed, 289 total.",
             "version": "Undefined",
             "update_complete": true,
             "ai_suggestion_status": "none",
@@ -41,13 +41,13 @@
         },
         {
             "test_result_json": {
-                "numFailedTestSuites": 0,
-                "numPassedTestSuites": 74,
+                "numFailedTestSuites": 1,
+                "numPassedTestSuites": 73,
                 "numPendingTestSuites": 0,
                 "numTotalTestSuites": 74,
-                "numFailedTests": 0,
+                "numFailedTests": 1,
                 "numPassedTests": 274,
-                "numPendingTests": 15,
+                "numPendingTests": 14,
                 "numTotalTests": 289,
                 "testResults": [
                     {
@@ -1518,8 +1518,8 @@
                     },
                     {
                         "file": "shopper\\/checkout.spec.js",
-                        "status": "passed",
-                        "has_pending": true,
+                        "status": "failed",
+                        "has_pending": false,
                         "tests": {
                             "Checkout page": [
                                 {
@@ -1544,7 +1544,7 @@
                                 },
                                 {
                                     "title": "allows guest customer to place an order",
-                                    "status": "pending"
+                                    "status": "failed"
                                 },
                                 {
                                     "title": "allows existing customer to place order",
@@ -1912,7 +1912,7 @@
                         }
                     }
                 ],
-                "summary": "Test Suites: 0 skipped, 0 failed, 74 passed, 74 total | Tests: 15 skipped, 0 failed, 274 passed, 289 total."
+                "summary": "Test Suites: 0 skipped, 1 failed, 73 passed, 74 total | Tests: 14 skipped, 1 failed, 274 passed, 289 total."
             }
         },
         {

--- a/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_woorc_php74_wprc_3ca3234b24887d2b86c56ac59b5b4ceb__1.php
+++ b/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_woorc_php74_wprc_3ca3234b24887d2b86c56ac59b5b4ceb__1.php
@@ -12,7 +12,7 @@
             "additional_woo_plugins": [],
             "additional_wp_plugins": [],
             "test_log": "",
-            "status": "success",
+            "status": "failed",
             "test_result_aws_url": "https:\\/\\/test-results-aws.com",
             "test_result_aws_expiration": 1234567890,
             "is_development": true,
@@ -31,7 +31,7 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Test Suites: 0 skipped, 0 failed, 74 passed, 74 total | Tests: 14 skipped, 0 failed, 275 passed, 289 total.",
+            "test_summary": "Test Suites: 0 skipped, 1 failed, 73 passed, 74 total | Tests: 14 skipped, 1 failed, 274 passed, 289 total.",
             "version": "Undefined",
             "update_complete": true,
             "ai_suggestion_status": "none",
@@ -41,12 +41,12 @@
         },
         {
             "test_result_json": {
-                "numFailedTestSuites": 0,
-                "numPassedTestSuites": 74,
+                "numFailedTestSuites": 1,
+                "numPassedTestSuites": 73,
                 "numPendingTestSuites": 0,
                 "numTotalTestSuites": 74,
-                "numFailedTests": 0,
-                "numPassedTests": 275,
+                "numFailedTests": 1,
+                "numPassedTests": 274,
                 "numPendingTests": 14,
                 "numTotalTests": 289,
                 "testResults": [
@@ -1518,7 +1518,7 @@
                     },
                     {
                         "file": "shopper\\/checkout.spec.js",
-                        "status": "passed",
+                        "status": "failed",
                         "has_pending": false,
                         "tests": {
                             "Checkout page": [
@@ -1544,7 +1544,7 @@
                                 },
                                 {
                                     "title": "allows guest customer to place an order",
-                                    "status": "passed"
+                                    "status": "failed"
                                 },
                                 {
                                     "title": "allows existing customer to place order",
@@ -1912,7 +1912,7 @@
                         }
                     }
                 ],
-                "summary": "Test Suites: 0 skipped, 0 failed, 74 passed, 74 total | Tests: 14 skipped, 0 failed, 275 passed, 289 total."
+                "summary": "Test Suites: 0 skipped, 1 failed, 73 passed, 74 total | Tests: 14 skipped, 1 failed, 274 passed, 289 total."
             }
         },
         {

--- a/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_woostable_php74_wprc_a9c30cbd9b7ec3a64233707209e2c66a__1.php
+++ b/_tests/tests/__snapshots__/E2eTest__test_e2e_no_op_woostable_php74_wprc_a9c30cbd9b7ec3a64233707209e2c66a__1.php
@@ -31,7 +31,7 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Test Suites: 0 skipped, 0 failed, 68 passed, 68 total | Tests: 8 skipped, 0 failed, 246 passed, 254 total.",
+            "test_summary": "Test Suites: 0 skipped, 0 failed, 68 passed, 68 total | Tests: 9 skipped, 0 failed, 245 passed, 254 total.",
             "version": "Undefined",
             "update_complete": true,
             "ai_suggestion_status": "none",
@@ -46,8 +46,8 @@
                 "numPendingTestSuites": 0,
                 "numTotalTestSuites": 68,
                 "numFailedTests": 0,
-                "numPassedTests": 246,
-                "numPendingTests": 8,
+                "numPassedTests": 245,
+                "numPendingTests": 9,
                 "numTotalTests": 254,
                 "testResults": [
                     {
@@ -1277,7 +1277,7 @@
                     {
                         "file": "shopper\\/checkout-coupons.spec.js",
                         "status": "passed",
-                        "has_pending": false,
+                        "has_pending": true,
                         "tests": {
                             "Checkout coupons": [
                                 {
@@ -1298,7 +1298,7 @@
                                 },
                                 {
                                     "title": "allows checkout to apply multiple coupons",
-                                    "status": "passed"
+                                    "status": "pending"
                                 },
                                 {
                                     "title": "restores checkout total when coupons are removed",
@@ -1716,7 +1716,7 @@
                         }
                     }
                 ],
-                "summary": "Test Suites: 0 skipped, 0 failed, 68 passed, 68 total | Tests: 8 skipped, 0 failed, 246 passed, 254 total."
+                "summary": "Test Suites: 0 skipped, 0 failed, 68 passed, 68 total | Tests: 9 skipped, 0 failed, 245 passed, 254 total."
             }
         },
         {


### PR DESCRIPTION
This PR has the snapshot changes for 8.6.0-rc.1

It also adds a `--env_filter=` parameter, that you can use like this to run specific self-tests:

```
php QITSelfTests.php update e2e no_op_php82 --env_filter=woo=stable --env_filter=wp=rc
```

This will run:
- `e2e` test type
- `no_op_php82` scenario
- Only when env `woo` is `stable`
- And env `wp` is `rc`

This can be used to run a self-test against a specific scenario to regenerate snapshots when a single self-test fail.