### PR TITLE
When doing a retry, throw some randomness into the mix

### DIFF
--- a/src/src/RequestBuilder.php
+++ b/src/src/RequestBuilder.php
@@ -362,6 +362,8 @@ class RequestBuilder {
 		// And no longer than 60 seconds.
 		$retry_after = min( $max_wait, $retry_after );
 
+		$retry_after += rand( 0, 5 ); // Add a random number of seconds to avoid all clients retrying at the same time.
+
 		return $retry_after;
 	}
 


### PR DESCRIPTION
Minor improvement to the retry logic, especially useful for our parallel tests.

### What this fixes:

- We dispatch everything in parallel
- We hit a 429
- Server ask us to retry after 10 seconds
- Then we retry every request that hit a 429 after 10 seconds, which can incur into another 429

This PR throws some randomness into the mix, waiting the specified `Retry-After` specified by the server, and adding between 0 and 5 seconds of additional wait, to avoid all retries being done in the same time.

In the current behavior, we can see that several requests hit 429 at 12:34:17, and retried at 12:34:27.

![image](https://github.com/woocommerce/qit-cli/assets/9341686/642da886-ee45-4e78-b9e9-0ef3fa1dade4)
