### PR TITLE
Xdebug on QIT tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ _tests/**/*.txt
 dev/
 _build/docker/php83/xdebug/*
 !_build/docker/php83/xdebug/.gitkeep
+!_build/docker/php83/xdebug/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ src-tmp/
 _tests/**/*.zip
 _tests/**/*.txt
 dev/
+_build/docker/php83/xdebug/*
+!_build/docker/php83/xdebug/.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -13,15 +13,16 @@ else
 DOCKER_USER ?= "$(shell id -u):$(shell id -g)"
 endif
 
-## Run a command inside an alpine PHP 7 CLI image.
+## Run a command inside an alpine PHP 8 CLI image.
 ## 1. Command to execute, eg: "./vendor/bin/phpcs" 2. Working dir (optional)
 define execPhpAlpine
-    @docker images -q | grep qit-cli-php-xdebug || docker build --build-arg CI=${CI} -t qit-cli-php-xdebug ./_build/docker/php74
+    @docker image inspect qit-cli-php-xdebug > /dev/null 2>&1 || docker build --build-arg CI=${CI} -t qit-cli-php-xdebug ./_build/docker/php83
     docker run --rm \
         --user $(DOCKER_USER) \
         -v "${PWD}:/app" \
-        -v "${PWD}/_build/docker/php74/ini:/usr/local/etc/php/conf.d/" \
+        -v "${PWD}/_build/docker/php83/ini:/usr/local/etc/php/conf.d/" \
         --env QIT_HOME=/tmp \
+        --env PHP_IDE_CONFIG=serverName=qit_cli \
         --workdir "$(2:=/)" \
         --add-host host.docker.internal:host-gateway \
         qit-cli-php-xdebug \

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 # ROOT       Set this to 1 to run the command as root.
 ##
 ROOT ?= 0
+DEBUG ?= 0
 ARGS ?=
 
 ifeq (1, $(ROOT))
@@ -15,14 +16,16 @@ endif
 ## Run a command inside an alpine PHP 7 CLI image.
 ## 1. Command to execute, eg: "./vendor/bin/phpcs" 2. Working dir (optional)
 define execPhpAlpine
-	@docker images -q | grep qit-cli-php || docker build -t qit-cli-php ./_build/docker/php74
-	docker run --rm \
-		--user $(DOCKER_USER) \
-		-v "${PWD}:/app" \
-		--env QIT_HOME=/tmp \
-		--workdir "$(2:=/)" \
-		qit-cli-php \
-		bash -c "php -d memory_limit=1G $(1)"
+    @docker images -q | grep qit-cli-php-xdebug || docker build --build-arg CI=${CI} -t qit-cli-php-xdebug ./_build/docker/php74
+    docker run --rm \
+        --user $(DOCKER_USER) \
+        -v "${PWD}:/app" \
+        -v "${PWD}/_build/docker/php74/ini:/usr/local/etc/php/conf.d/" \
+        --env QIT_HOME=/tmp \
+        --workdir "$(2:=/)" \
+        --add-host host.docker.internal:host-gateway \
+        qit-cli-php-xdebug \
+        bash -c "php -d xdebug.start_with_request=$(if $(filter 1,$(DEBUG)),yes,no) -d memory_limit=1G $(1)"
 endef
 
 watch:

--- a/_build/docker/php74/Dockerfile
+++ b/_build/docker/php74/Dockerfile
@@ -1,5 +1,12 @@
 FROM php:7.4-cli
 
+ARG CI
+
 RUN apt-get update \
      && apt-get install -y libzip-dev \
      && docker-php-ext-install zip
+
+# Install Xdebug only if not in CI environment
+RUN if [ "$CI" != "true" ]; then \
+        pecl install xdebug && docker-php-ext-enable xdebug; \
+    fi

--- a/_build/docker/php74/ini/xdebug.ini
+++ b/_build/docker/php74/ini/xdebug.ini
@@ -1,0 +1,15 @@
+xdebug.client_host = host.docker.internal
+xdebug.client_port = 9003
+xdebug.idekey = qit_ci
+xdebug.output_dir = /tmp/xdebug/output
+xdebug.log = /tmp/xdebug/xdebug.log
+# Enabled at runtime with DEBUG=1
+xdebug.start_with_request = no
+# https://xdebug.org/docs/all_settings#trace_output_name
+xdebug.profiler_output_name = cachegrind.out.%R.%s
+
+; Choose between debug or profile.
+; If choosing "profile", the cachegrind files will be saved in the "www" directory.
+; You can analyze them with PHPStorm, KCacheGrind, QCachegrind, WinCacheGrind, Webgrind, etc.
+xdebug.mode = debug
+;xdebug.mode=profile

--- a/_build/docker/php83/Dockerfile
+++ b/_build/docker/php83/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-cli
+FROM php:8.3-cli
 
 ARG CI
 

--- a/_build/docker/php83/ini/xdebug.ini
+++ b/_build/docker/php83/ini/xdebug.ini
@@ -1,12 +1,16 @@
+zend_extension=xdebug.so
 xdebug.client_host = host.docker.internal
 xdebug.client_port = 9003
-xdebug.idekey = qit_ci
-xdebug.output_dir = /tmp/xdebug/output
-xdebug.log = /tmp/xdebug/xdebug.log
+xdebug.output_dir = /app/_build/docker/php83/xdebug/output
+xdebug.log = /app/_build/docker/php83/xdebug/xdebug.log
 # Enabled at runtime with DEBUG=1
-xdebug.start_with_request = no
+xdebug.start_with_request = yes
+
 # https://xdebug.org/docs/all_settings#trace_output_name
 xdebug.profiler_output_name = cachegrind.out.%R.%s
+
+# Having issues? Set this to 7 and check the xdebug.log
+xdebug.log_level = 0
 
 ; Choose between debug or profile.
 ; If choosing "profile", the cachegrind files will be saved in the "www" directory.

--- a/_build/docker/php83/ini/xdebug.ini
+++ b/_build/docker/php83/ini/xdebug.ini
@@ -4,7 +4,7 @@ xdebug.client_port = 9003
 xdebug.output_dir = /app/_build/docker/php83/xdebug/output
 xdebug.log = /app/_build/docker/php83/xdebug/xdebug.log
 # Enabled at runtime with DEBUG=1
-xdebug.start_with_request = yes
+xdebug.start_with_request = no
 
 # https://xdebug.org/docs/all_settings#trace_output_name
 xdebug.profiler_output_name = cachegrind.out.%R.%s

--- a/_build/docker/php83/ini/zip.ini
+++ b/_build/docker/php83/ini/zip.ini
@@ -1,0 +1,2 @@
+# Enable zip extension
+extension=zip.so

--- a/_build/docker/php83/xdebug/README.md
+++ b/_build/docker/php83/xdebug/README.md
@@ -1,0 +1,10 @@
+## Xdebug instructions
+
+### PHPStorm
+
+- Settings -> Servers -> + (Add)
+  - Name: `qit_cli`
+  - Host: `-` (Any value)
+  - [X] Use path mappings
+    - File/Directory: The root dir of this project
+    - Absolute path on the server: `/app`


### PR DESCRIPTION
This PR adds Xdebug to `make phpunit`

### Testing instructions
- Follow the Xdebug [README](https://github.com/woocommerce/qit-cli/blob/e6cb8ad67a687f90cf5967ee2b4a254b4dc17bb2/_build/docker/php83/xdebug/README.md) instructions
- Add a breakpoint on a unit test
- Run `make phpunit DEBUG=1` and see that Xdebug works