### PR TITLE
Added nonJsonOutput property

### DIFF
--- a/_tests/ParallelOutput.php
+++ b/_tests/ParallelOutput.php
@@ -8,7 +8,6 @@ class ParallelOutput {
 	private $headers;
 	private $processStatus;
 	private $startTimes;
-
 	private $nonJsonOutput;
 
 	public function __construct() {

--- a/_tests/ParallelOutput.php
+++ b/_tests/ParallelOutput.php
@@ -9,6 +9,8 @@ class ParallelOutput {
 	private $processStatus;
 	private $startTimes;
 
+	private $nonJsonOutput;
+
 	public function __construct() {
 		$this->rawOutput     = '';
 		$this->outputBuffer  = [];


### PR DESCRIPTION
This PR adds the `nonJsonOutput` property in `ParallelOutput.php` to address the following PHP deprecated warning:

```php
Stderr: PHP Deprecated:  Creation of dynamic property ParallelOutput::$nonJsonOutput is deprecated in qit-cli/_tests/ParallelOutput.php on line 18
```