### PR TITLE
Rename woo.com to woocommerce.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![QIT Self-Tests - PHPCompatibilityWP](https://github.com/woocommerce/qit-cli/actions/workflows/qit-self-test-phpcompatibility.yml/badge.svg)](https://github.com/woocommerce/qit-cli/actions/workflows/qit-self-test-phpcompatibility.yml)
 [![QIT Self-Tests - Malware](https://github.com/woocommerce/qit-cli/actions/workflows/qit-self-test-malware.yml/badge.svg)](https://github.com/woocommerce/qit-cli/actions/workflows/qit-self-test-malware.yml)
 
-<p align="center"><img src="https://woo.com/wp-content/themes/woo/images/logo-woocommerce-bubble.svg" alt="WooCommerce" style="width:100px;height:auto;"></p>
+<p align="center"><img src="https://woocommerce.com/wp-content/themes/woo/images/logo-woocommerce-bubble.svg" alt="WooCommerce" style="width:100px;height:auto;"></p>
 
 ## Documentation
 
@@ -43,15 +43,15 @@ QIT is a testing platform for WordPress Plugins and Themes developed by WooComme
 ## Installing QIT
 
 1. Run `composer require woocommerce/qit-cli --dev`
-2. Execute `./vendor/bin/qit` to authenticate with your Woo.com Partner Developer account.
+2. Execute `./vendor/bin/qit` to authenticate with your WooCommerce.com Partner Developer account.
 
 You can use these parameters individually or in combination to create different scenarios for your tests. Run `qit run:<test-type> --help` to see all the available options. Different test types will have different options to choose from.
 
 ## Can I use QIT?
 
-Most features of QIT requires you to log-in as a Partner Developer of the Woo.com Marketplace, but we have plans to open it to all developers in the future.
+Most features of QIT requires you to log-in as a Partner Developer of the WooCommerce.com Marketplace, but we have plans to open it to all developers in the future.
 
-The QIT Local Test Environment does not require you to be connected to Woo.com, although to install Woo.com Premium plugins and themes on your test environment you will need to be connected as a Partner Developer of the Woo.com Marketplace (and have access to the extensions you want to test).
+The QIT Local Test Environment does not require you to be connected to WooCommerce.com, although to install WooCommerce.com Premium plugins and themes on your test environment you will need to be connected as a Partner Developer of the Woo.com Marketplace (and have access to the extensions you want to test).
 
 ## Support
 

--- a/src/src/Commands/Partner/AddPartner.php
+++ b/src/src/Commands/Partner/AddPartner.php
@@ -43,8 +43,8 @@ class AddPartner extends Command {
 		$this
 			->setDescription( 'Configure a new WCCOM Marketplace Partner that the QIT CLI can connect to.' )
 			->setHelp( sprintf( "Configure the QIT CLI to be able to interact with %s on behalf of a given partner.\nAuthenticating documentation: https://qit.woo.com/docs/support/authenticating", get_wccom_url() ) )
-			->addOption( 'user', 'u', InputOption::VALUE_OPTIONAL, '(Optional) Woo.com Partner Developer username.' )
-			->addOption( 'qit_token', 't', InputOption::VALUE_OPTIONAL, '(Optional) Woo.com Partner Developer QIT Token.' )
+			->addOption( 'user', 'u', InputOption::VALUE_OPTIONAL, '(Optional) WooCommerce.com Partner Developer username.' )
+			->addOption( 'qit_token', 't', InputOption::VALUE_OPTIONAL, '(Optional) WooCommerce.com Partner Developer QIT Token.' )
 			->addOption( 'application_password', 'p', InputOption::VALUE_OPTIONAL, '(DEPRECATED) This has been renamed to "QIT Token" and will be removed. A regular application password will not work.' );
 	}
 


### PR DESCRIPTION
To prep for the upcoming domain migration, this PR updates references from woo.com to woocommerce.com.