### PR TITLE
Set Result Dir using ENV vat

### DIFF
--- a/src/src/LocalTests/E2E/Result/TestResult.php
+++ b/src/src/LocalTests/E2E/Result/TestResult.php
@@ -25,15 +25,15 @@ class TestResult {
 	}
 
 	public static function init_from( E2EEnvInfo $env_info ): TestResult {
-		$instance              = new self();
-		$instance->status      = 'pending';
-		$instance->env_info    = $env_info;
+		$instance           = new self();
+		$instance->status   = 'pending';
+		$instance->env_info = $env_info;
 
-        if ( ! empty( getenv( 'RESULTS_DIR' ) ) ) {
-            $instance->results_dir = normalize_path( getenv( 'RESULTS_DIR' ) );
-        } else {
-            $instance->results_dir = normalize_path( sys_get_temp_dir() ) . "qit-results-{$env_info->env_id}";
-        }
+		if ( ! empty( getenv( 'RESULTS_DIR' ) ) ) {
+			$instance->results_dir = normalize_path( getenv( 'RESULTS_DIR' ) );
+		} else {
+			$instance->results_dir = normalize_path( sys_get_temp_dir() ) . "qit-results-{$env_info->env_id}";
+		}
 
 		if ( ! mkdir( $instance->results_dir, 0755, false ) ) {
 			throw new \RuntimeException( sprintf( 'Could not create the results directory: %s', $instance->results_dir ) );

--- a/src/src/LocalTests/E2E/Result/TestResult.php
+++ b/src/src/LocalTests/E2E/Result/TestResult.php
@@ -29,8 +29,8 @@ class TestResult {
 		$instance->status   = 'pending';
 		$instance->env_info = $env_info;
 
-		if ( ! empty( getenv( 'RESULTS_DIR' ) ) ) {
-			$instance->results_dir = normalize_path( getenv( 'RESULTS_DIR' ) );
+		if ( ! empty( getenv( 'QIT_RESULTS_DIR' ) ) ) {
+			$instance->results_dir = normalize_path( getenv( 'QIT_RESULTS_DIR' ) );
 		} else {
 			$instance->results_dir = normalize_path( sys_get_temp_dir() ) . "qit-results-{$env_info->env_id}";
 		}

--- a/src/src/LocalTests/E2E/Result/TestResult.php
+++ b/src/src/LocalTests/E2E/Result/TestResult.php
@@ -28,7 +28,12 @@ class TestResult {
 		$instance              = new self();
 		$instance->status      = 'pending';
 		$instance->env_info    = $env_info;
-		$instance->results_dir = normalize_path( sys_get_temp_dir() ) . "qit-results-{$env_info->env_id}";
+
+        if ( ! empty( getenv( 'RESULTS_DIR' ) ) ) {
+            $instance->results_dir = normalize_path( getenv( 'RESULTS_DIR' ) );
+        } else {
+            $instance->results_dir = normalize_path( sys_get_temp_dir() ) . "qit-results-{$env_info->env_id}";
+        }
 
 		if ( ! mkdir( $instance->results_dir, 0755, false ) ) {
 			throw new \RuntimeException( sprintf( 'Could not create the results directory: %s', $instance->results_dir ) );


### PR DESCRIPTION
Based on our slack discussion @Luc45. This PR allows us to specify the results for the e2e tests using a `RESULT_DIR` env var.


### Testing instructions
1. Checkout this branch
2. Run the following command and confirm that the results gets added to a temporary directory.
`php ./src/qit-cli.php run:e2e woocommerce-amazon-s3-storage ./<e2e-directory>`
3. Run the following command and confirm that the results get added to the directory specified.
`RESULTS_DIR="./results" php ./src/qit-cli.php run:e2e woocommerce-amazon-s3-storage ./<e2e-directory>`