### PR TITLE
Disable Mac test, add Validation workflow

### DIFF
--- a/.github/workflows/qit-environment-test-mac.yml
+++ b/.github/workflows/qit-environment-test-mac.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   mac_environment_test:
     runs-on: ${{ matrix.os }}
+    if: false # Docker on Mac in GitHub Actions is broken. We need to wait. https://github.com/douglascamata/setup-docker-macos-action/issues/37
     strategy:
       matrix:
         os: [ macos-13 ]

--- a/.github/workflows/qit-self-test-validation.yml
+++ b/.github/workflows/qit-self-test-validation.yml
@@ -1,0 +1,23 @@
+name: QIT Self-Tests - Validation
+
+on:
+  # Every day at 11am and 11pm UTC (6am and 6pm ET)
+  schedule:
+    - cron: '0 11 * * *'
+    - cron: '0 23 * * *'
+  # Manually
+  workflow_dispatch:
+  # On push to trunk
+  push:
+    branches:
+      - trunk
+
+jobs:
+  validation_tests:
+    uses: ./.github/workflows/self-test-template.yml
+    with:
+      test_type: validation
+    secrets:
+      QIT_USER: ${{ secrets.QIT_USER }}
+      QIT_ACCESS_TOKEN: ${{ secrets.QIT_ACCESS_TOKEN }}
+      QIT_STAGING_SECRET: ${{ secrets.QIT_STAGING_SECRET }}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![QIT Self-Tests - Security](https://github.com/woocommerce/qit-cli/actions/workflows/qit-self-test-security.yml/badge.svg)](https://github.com/woocommerce/qit-cli/actions/workflows/qit-self-test-security.yml)
 [![QIT Self-Tests - PHPCompatibilityWP](https://github.com/woocommerce/qit-cli/actions/workflows/qit-self-test-phpcompatibility.yml/badge.svg)](https://github.com/woocommerce/qit-cli/actions/workflows/qit-self-test-phpcompatibility.yml)
 [![QIT Self-Tests - Malware](https://github.com/woocommerce/qit-cli/actions/workflows/qit-self-test-malware.yml/badge.svg)](https://github.com/woocommerce/qit-cli/actions/workflows/qit-self-test-malware.yml)
+[![QIT Self-Tests - Validation](https://github.com/woocommerce/qit-cli/actions/workflows/qit-self-test-validation.yml/badge.svg)](https://github.com/woocommerce/qit-cli/actions/workflows/qit-self-test-validation.yml)
 
 #### Custom Tests
 
@@ -19,7 +20,6 @@
 #### Test Environment
 
 [![QIT Environment Test - Linux](https://github.com/woocommerce/qit-cli/actions/workflows/qit-environment-test-linux.yml/badge.svg)](https://github.com/woocommerce/qit-cli/actions/workflows/qit-environment-test-linux.yml)
-[![QIT Environment Test - Mac (non M1)](https://github.com/woocommerce/qit-cli/actions/workflows/qit-environment-test-mac.yml/badge.svg)](https://github.com/woocommerce/qit-cli/actions/workflows/qit-environment-test-mac.yml)
 [![QIT Environment Dangling Test](https://github.com/woocommerce/qit-cli/actions/workflows/qit-environment-dangling-test.yml/badge.svg)](https://github.com/woocommerce/qit-cli/actions/workflows/qit-environment-dangling-test.yml)
 
 <p align="center"><img src="https://woocommerce.com/wp-content/themes/woo/images/logo-woocommerce-bubble.svg" alt="WooCommerce" style="width:100px;height:auto;"></p>


### PR DESCRIPTION
The Mac workflow has been broken for a couple of days. 

It seems something in the GitHub pipeline broke the integration, they are looking into it: https://github.com/douglascamata/setup-docker-macos-action/issues/37

Disabling that workflow for now and removing it from the README.

Also adding Validation Workflow because it had self-tests but no Workflow.