### PR TITLE
9.6.0-beta.2 sync

### DIFF
--- a/_tests/managed_tests/tests/QITE2ETestCase.php
+++ b/_tests/managed_tests/tests/QITE2ETestCase.php
@@ -217,10 +217,6 @@ class QITE2ETestCase extends TestCase {
 			],
 			'debug_log'                       => [
 				'normalize' => function ( $value ) use ( $file_path ) {
-					if ( ! is_array( $value ) ) {
-						return $value;
-					}
-
 					if ( stripos( $file_path, 'woo-e2e/delete_products' ) !== false || stripos( $file_path, 'woo-api/delete_products' ) !== false ) {
 						return [
 							[
@@ -228,6 +224,10 @@ class QITE2ETestCase extends TestCase {
 								'message' => 'Debug log is ignored for woo-e2e/delete_products tests.',
 							],
 						];
+					}
+
+					if ( ! is_array( $value ) ) {
+						return $value;
 					}
 
 					$normalize_custom_tests_debug_log = function ( $debug_log ) {

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_delete_products_woorc_php74_wprc_b153920e11128a2003ccfabb5a1c2b66__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_delete_products_woorc_php74_wprc_b153920e11128a2003ccfabb5a1c2b66__1.php
@@ -33,6 +33,7 @@
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
             "test_summary": "Delete_Products Normalized Summary",
+            "debug_log": "",
             "version": "Undefined",
             "update_complete": true,
             "ai_suggestion_status": "none",
@@ -40,19 +41,10 @@
             "workflow_id": "1234567890",
             "runner": "normalized",
             "test_media": [],
-            "test_result_json_extracted": "{EXTRACTED}",
-            "debug_log_extracted": "{EXTRACTED}"
+            "test_result_json_extracted": "{EXTRACTED}"
         },
         {
             "test_result_json": []
-        },
-        {
-            "debug_log": [
-                {
-                    "count": "0",
-                    "message": "Debug log is ignored for woo-e2e\\/delete_products tests."
-                }
-            ]
         }
     ]
 ]';

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_delete_products_woorc_php74_wprc_b153920e11128a2003ccfabb5a1c2b66__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_delete_products_woorc_php74_wprc_b153920e11128a2003ccfabb5a1c2b66__1.php
@@ -33,7 +33,12 @@
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
             "test_summary": "Delete_Products Normalized Summary",
-            "debug_log": "",
+            "debug_log": [
+                {
+                    "count": "0",
+                    "message": "Debug log is ignored for woo-e2e\\/delete_products tests."
+                }
+            ],
             "version": "Undefined",
             "update_complete": true,
             "ai_suggestion_status": "none",

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_delete_products_woostable_php74_wprc_2a952a960085a76868033dc54aa96159__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_delete_products_woostable_php74_wprc_2a952a960085a76868033dc54aa96159__1.php
@@ -33,6 +33,7 @@
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
             "test_summary": "Delete_Products Normalized Summary",
+            "debug_log": "",
             "version": "Undefined",
             "update_complete": true,
             "ai_suggestion_status": "none",
@@ -40,19 +41,10 @@
             "workflow_id": "1234567890",
             "runner": "normalized",
             "test_media": [],
-            "test_result_json_extracted": "{EXTRACTED}",
-            "debug_log_extracted": "{EXTRACTED}"
+            "test_result_json_extracted": "{EXTRACTED}"
         },
         {
             "test_result_json": []
-        },
-        {
-            "debug_log": [
-                {
-                    "count": "0",
-                    "message": "Debug log is ignored for woo-e2e\\/delete_products tests."
-                }
-            ]
         }
     ]
 ]';

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_delete_products_woostable_php74_wprc_2a952a960085a76868033dc54aa96159__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_delete_products_woostable_php74_wprc_2a952a960085a76868033dc54aa96159__1.php
@@ -33,7 +33,12 @@
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
             "test_summary": "Delete_Products Normalized Summary",
-            "debug_log": "",
+            "debug_log": [
+                {
+                    "count": "0",
+                    "message": "Debug log is ignored for woo-e2e\\/delete_products tests."
+                }
+            ],
             "version": "Undefined",
             "update_complete": true,
             "ai_suggestion_status": "none",


### PR DESCRIPTION
No snapshot changes, except for debug log changes in `delete_products` test that we always ignore. Since we always ignore it, this PR makes no distinction between debug log in these tests being empty or having something and being ignored.