### PR TITLE
Adds ignoring to the log parsing for some common deprecation warnings

### DIFF
--- a/src/src/LocalTests/PrepareDebugLog.php
+++ b/src/src/LocalTests/PrepareDebugLog.php
@@ -68,7 +68,7 @@ class PrepareDebugLog {
 					continue;
 				}
 
-				// Some compatbility extension set issues:
+				// Some compatbility extension set issues.
 
 				// Ignore a deprecation warning from Jetpack about itself.
 				$is_jetpack_geo_deprecation = stripos( $line, 'Class Jetpack_Geo_Location is' ) !== false;
@@ -76,7 +76,7 @@ class PrepareDebugLog {
 				// Ignore a deprecated core filter for now, since subs and payments both include it in shared code.
 				// Only if we're not testing one of those though.
 				$is_woocommerce_get_price_deprecation = stripos( $line, 'Use woocommerce_product_get_price instead' ) !== false;
-				$is_testing_payments_or_subs = in_array( $sut_slug, [ 'woocommerce-payments', 'woocommerce-subscriptions' ] );
+				$is_testing_payments_or_subs = in_array( $sut_slug, [ 'woocommerce-payments', 'woocommerce-subscriptions' ], true );
 
 				if (
 					$is_jetpack_geo_deprecation

--- a/src/src/LocalTests/PrepareDebugLog.php
+++ b/src/src/LocalTests/PrepareDebugLog.php
@@ -68,6 +68,25 @@ class PrepareDebugLog {
 					continue;
 				}
 
+				// Some compatbility extension set issues:
+
+				// Ignore a deprecation warning from Jetpack about itself.
+				$is_jetpack_geo_deprecation = stripos( $line, 'Class Jetpack_Geo_Location is' ) !== false;
+
+				// Ignore a deprecated core filter for now, since subs and payments both include it in shared code.
+				// Only if we're not testing one of those though.
+				$is_woocommerce_get_price_deprecation = stripos( $line, 'Use woocommerce_product_get_price instead' ) !== false;
+				$is_testing_payments_or_subs = in_array( $sut_slug, [ 'woocommerce-payments', 'woocommerce-subscriptions' ] );
+
+				if (
+					$is_jetpack_geo_deprecation
+					|| ( $is_woocommerce_get_price_deprecation && ! $is_testing_payments_or_subs )
+				) {
+					continue;
+				}
+
+				// End compatibility extension set issues.
+
 				/*
 				 * If we are running PHP 8+ on WordPress 6.1 or lower, ignore the following notices.
 				 * @link https://core.trac.wordpress.org/ticket/54504

--- a/src/tests/PartnerManagementTest.php
+++ b/src/tests/PartnerManagementTest.php
@@ -50,7 +50,27 @@ class PartnerManagementTest extends QITTestCase {
 		 * suitable for snapshot testing.
 		 */
 
-		return preg_replace( '#"expire":\s?\d+,#', '"expire": 1234567890,', $json );
+		$json = preg_replace( '#"expire":\s?\d+,#', '"expire": 1234567890,', $json );
+
+		// Normalize known keys if the value looks like a version.
+		$version_keys = '/"(wordpress_version|woocommerce_version|stable|rc|rc_unsynced|default|playwright_version)":\s?"([^"]+)"/';
+
+		$json = preg_replace_callback( $version_keys, function ( $matches ) {
+			$key   = $matches[1];
+			$value = $matches[2];
+
+			// Simple check: starts with digits, then optionally .digits repeated,
+			// then optionally a dash with alphanumeric parts (beta, rc, etc).
+			$isVersion = preg_match( '/^\d+(?:\.\d+)*(?:-[A-Za-z0-9.\-_]+)?$/', $value );
+
+			if ( $isVersion ) {
+				$value = 'X.X.X';
+			}
+
+			return "\"{$key}\": \"{$value}\"";
+		}, $json );
+
+		return $json;
 	}
 
 	public function test_add_partner() {

--- a/src/tests/RunTestsTest.php
+++ b/src/tests/RunTestsTest.php
@@ -19,6 +19,24 @@ class RunTestsTest extends \QIT_CLI_Tests\QITTestCase {
 		} );
 	}
 
+	protected function get_last_request() {
+		$request = App::getVar( 'mocked_request' );
+
+		if ( ! is_array( $request ) ) {
+			return $request;
+		}
+
+		if ( ! empty( $request['post_body']['wordpress_version'] ) ) {
+			$request['post_body']['wordpress_version'] = 'X.X.X';
+		}
+
+		if ( ! empty( $request['post_body']['woocommerce_version'] ) ) {
+			$request['post_body']['woocommerce_version'] = 'X.X.X';
+		}
+
+		return $request;
+	}
+
 	public function test_run_with_additional_plugins() {
 		App::setVar( sprintf( 'mock_%s', get_manager_url() . '/wp-json/cd/v1/enqueue-woo-e2e' ), json_encode( [
 			'test_run_id'              => 123456,
@@ -26,36 +44,36 @@ class RunTestsTest extends \QIT_CLI_Tests\QITTestCase {
 		] ) );
 
 		$this->application_tester->run( [
-			'command'                  => 'run:woo-e2e',
-			'woo_extension'            => 'foo-extension', // Using slug.
+			'command'              => 'run:woo-e2e',
+			'woo_extension'        => 'foo-extension', // Using slug.
 			'--additional_plugins' => '456,789', // Using IDs.
 		], [ 'capture_stderr_separately' => true ] );
 
 		$this->assertCommandIsSuccessful( $this->application_tester );
-		$this->assertMatchesJsonSnapshot( App::getVar( 'mocked_request' ) );
+		$this->assertMatchesJsonSnapshot( $this->get_last_request() );
 
 		$this->application_tester->run( [
-			'command'                  => 'run:woo-e2e',
-			'woo_extension'            => '123', // Using ID.
+			'command'              => 'run:woo-e2e',
+			'woo_extension'        => '123', // Using ID.
 			'--additional_plugins' => 'bar-extension,baz-extension', // Using Slugs.
 		], [ 'capture_stderr_separately' => true ] );
 
 		// If this fails, debug "$this->application_tester->getDisplay()".
 		$this->assertCommandIsSuccessful( $this->application_tester );
-		$this->assertMatchesJsonSnapshot( App::getVar( 'mocked_request' ) );
+		$this->assertMatchesJsonSnapshot( $this->get_last_request() );
 
 		$this->application_tester->run( [
-			'command'                  => 'run:woo-e2e',
-			'woo_extension'            => 'foo-extension', // Using ID.
+			'command'              => 'run:woo-e2e',
+			'woo_extension'        => 'foo-extension', // Using ID.
 			'--additional_plugins' => '456,baz-extension', // Using mixed.
 		], [ 'capture_stderr_separately' => true ] );
 
 		$this->assertCommandIsSuccessful( $this->application_tester );
-		$this->assertMatchesJsonSnapshot( App::getVar( 'mocked_request' ) );
+		$this->assertMatchesJsonSnapshot( $this->get_last_request() );
 
 		$this->application_tester->run( [
-			'command'                  => 'run:woo-e2e',
-			'woo_extension'            => 'foo-extension',
+			'command'              => 'run:woo-e2e',
+			'woo_extension'        => 'foo-extension',
 			'--additional_plugins' => '1234567890', // If the user passes an invalid ID, the Manager should flag that.
 		], [ 'capture_stderr_separately' => true ] );
 
@@ -73,7 +91,7 @@ class RunTestsTest extends \QIT_CLI_Tests\QITTestCase {
 				'woo_extension' => 'non-existing-extension',
 			], [ 'capture_stderr_separately' => true ] );
 		} catch ( \Exception $e ) {
-			$this->assertStringContainsString('Could not find Woo Extension with slug non-existing-extension.', $e->getMessage() );
+			$this->assertStringContainsString( 'Could not find Woo Extension with slug non-existing-extension.', $e->getMessage() );
 
 			throw $e;
 		}

--- a/src/tests/__snapshots__/PartnerManagementTest__test_add_partner__1.json
+++ b/src/tests/__snapshots__/PartnerManagementTest__test_add_partner__1.json
@@ -47,7 +47,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -60,7 +60,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -99,6 +99,52 @@
                             "description": "Whether this is a product update test run.",
                             "type": "boolean",
                             "default": false
+                        },
+                        "additional_plugins": {
+                            "description": "A comma-separated list of additional plugins to activate in the environment. Accepts: WordPress.org plugin slugs, Woo.com Product Slugs or Woo.com Product IDs.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "minimum": 1
+                            }
+                        },
+                        "additional_woo_plugins": {
+                            "description": "[Deprecated] A comma-separated list of Additional WooCommerce Extension IDs.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "integer",
+                                "minimum": 1
+                            }
+                        },
+                        "additional_wordpress_plugins": {
+                            "description": "[Deprecated] A comma-separated list of Additional WordPress plugin slugs.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "minimum": 1
+                            }
+                        },
+                        "phpstan_level": {
+                            "description": "The PHPStan level to use for the test run.",
+                            "type": "integer",
+                            "required": true,
+                            "default": 2,
+                            "enum": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10
+                            ]
                         }
                     }
                 },
@@ -116,7 +162,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -129,7 +175,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -143,7 +189,7 @@
                             ]
                         },
                         "php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The PHP version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -215,7 +261,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -228,7 +274,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -400,7 +446,7 @@
                             "default": false
                         },
                         "min_php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The minimum PHP version to test an extension's compatibility against.",
                             "type": "string",
                             "enum": [
@@ -415,7 +461,7 @@
                             ]
                         },
                         "max_php_version": {
-                            "default": "8.4",
+                            "default": "X.X.X",
                             "description": "The maximum PHP version to test an extension's compatibility against.",
                             "type": "string",
                             "enum": [
@@ -494,7 +540,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -507,7 +553,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -628,7 +674,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -641,7 +687,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -761,7 +807,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -774,7 +820,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -788,7 +834,7 @@
                             ]
                         },
                         "php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The PHP version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -906,7 +952,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -919,7 +965,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -933,7 +979,7 @@
                             ]
                         },
                         "php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The PHP version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -1219,7 +1265,7 @@
                         "php_version": {
                             "description": "The PHP version to use in the test.",
                             "type": "string",
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "enum": [
                                 "7.4",
                                 "8.0",
@@ -1230,7 +1276,7 @@
                             ]
                         },
                         "min_php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The minimum PHP version to use in a PHPCompatibility.",
                             "type": "string",
                             "enum": [
@@ -1245,7 +1291,7 @@
                             ]
                         },
                         "max_php_version": {
-                            "default": "8.4",
+                            "default": "X.X.X",
                             "description": "The maximum PHP version to use in a PHPCompatibility.",
                             "type": "string",
                             "enum": [
@@ -1344,6 +1390,13 @@
                                 "plugin",
                                 "theme"
                             ]
+                        },
+                        "extension_set": {
+                            "description": "The predefined set of extensions to include in the mass test.",
+                            "type": "string",
+                            "enum": [
+                                "compatibility"
+                            ]
                         }
                     }
                 }
@@ -1383,17 +1436,35 @@
             },
             "versions": {
                 "woocommerce": {
-                    "stable": "9.6.0",
-                    "rc": "9.7.0-beta.1",
-                    "rc_unsynced": "9.7.0-beta.1"
+                    "stable": "X.X.X",
+                    "rc": "X.X.X",
+                    "rc_unsynced": "X.X.X"
                 },
                 "wordpress": {
-                    "stable": "6.7.1",
-                    "rc": "6.7.1"
+                    "stable": "X.X.X",
+                    "rc": "X.X.X"
                 }
             },
             "hide_e2e": false,
-            "playwright_version": "1.49.1"
+            "playwright_version": "X.X.X",
+            "extension_sets": {
+                "compatibility": [
+                    "gift-cards",
+                    "woocommerce-product-add-ons",
+                    "woocommerce-min-max-quantities",
+                    "woocommerce-product-bundles",
+                    "woocommerce-product-recommendations",
+                    "woocommerce-payments",
+                    "automatewoo",
+                    "woocommerce-shipping",
+                    "woocommerce-subscriptions",
+                    "woocommerce-composite-products",
+                    "woocommerce-services",
+                    "woocommerce-google-analytics-integration",
+                    "mailpoet",
+                    "jetpack"
+                ]
+            }
         }
     }
 }

--- a/src/tests/__snapshots__/PartnerManagementTest__test_add_partner_email__1.json
+++ b/src/tests/__snapshots__/PartnerManagementTest__test_add_partner_email__1.json
@@ -47,7 +47,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -60,7 +60,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -99,6 +99,52 @@
                             "description": "Whether this is a product update test run.",
                             "type": "boolean",
                             "default": false
+                        },
+                        "additional_plugins": {
+                            "description": "A comma-separated list of additional plugins to activate in the environment. Accepts: WordPress.org plugin slugs, Woo.com Product Slugs or Woo.com Product IDs.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "minimum": 1
+                            }
+                        },
+                        "additional_woo_plugins": {
+                            "description": "[Deprecated] A comma-separated list of Additional WooCommerce Extension IDs.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "integer",
+                                "minimum": 1
+                            }
+                        },
+                        "additional_wordpress_plugins": {
+                            "description": "[Deprecated] A comma-separated list of Additional WordPress plugin slugs.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "minimum": 1
+                            }
+                        },
+                        "phpstan_level": {
+                            "description": "The PHPStan level to use for the test run.",
+                            "type": "integer",
+                            "required": true,
+                            "default": 2,
+                            "enum": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10
+                            ]
                         }
                     }
                 },
@@ -116,7 +162,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -129,7 +175,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -143,7 +189,7 @@
                             ]
                         },
                         "php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The PHP version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -215,7 +261,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -228,7 +274,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -400,7 +446,7 @@
                             "default": false
                         },
                         "min_php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The minimum PHP version to test an extension's compatibility against.",
                             "type": "string",
                             "enum": [
@@ -415,7 +461,7 @@
                             ]
                         },
                         "max_php_version": {
-                            "default": "8.4",
+                            "default": "X.X.X",
                             "description": "The maximum PHP version to test an extension's compatibility against.",
                             "type": "string",
                             "enum": [
@@ -494,7 +540,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -507,7 +553,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -628,7 +674,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -641,7 +687,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -761,7 +807,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -774,7 +820,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -788,7 +834,7 @@
                             ]
                         },
                         "php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The PHP version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -906,7 +952,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -919,7 +965,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -933,7 +979,7 @@
                             ]
                         },
                         "php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The PHP version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -1219,7 +1265,7 @@
                         "php_version": {
                             "description": "The PHP version to use in the test.",
                             "type": "string",
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "enum": [
                                 "7.4",
                                 "8.0",
@@ -1230,7 +1276,7 @@
                             ]
                         },
                         "min_php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The minimum PHP version to use in a PHPCompatibility.",
                             "type": "string",
                             "enum": [
@@ -1245,7 +1291,7 @@
                             ]
                         },
                         "max_php_version": {
-                            "default": "8.4",
+                            "default": "X.X.X",
                             "description": "The maximum PHP version to use in a PHPCompatibility.",
                             "type": "string",
                             "enum": [
@@ -1344,6 +1390,13 @@
                                 "plugin",
                                 "theme"
                             ]
+                        },
+                        "extension_set": {
+                            "description": "The predefined set of extensions to include in the mass test.",
+                            "type": "string",
+                            "enum": [
+                                "compatibility"
+                            ]
                         }
                     }
                 }
@@ -1383,17 +1436,35 @@
             },
             "versions": {
                 "woocommerce": {
-                    "stable": "9.6.0",
-                    "rc": "9.7.0-beta.1",
-                    "rc_unsynced": "9.7.0-beta.1"
+                    "stable": "X.X.X",
+                    "rc": "X.X.X",
+                    "rc_unsynced": "X.X.X"
                 },
                 "wordpress": {
-                    "stable": "6.7.1",
-                    "rc": "6.7.1"
+                    "stable": "X.X.X",
+                    "rc": "X.X.X"
                 }
             },
             "hide_e2e": false,
-            "playwright_version": "1.49.1"
+            "playwright_version": "X.X.X",
+            "extension_sets": {
+                "compatibility": [
+                    "gift-cards",
+                    "woocommerce-product-add-ons",
+                    "woocommerce-min-max-quantities",
+                    "woocommerce-product-bundles",
+                    "woocommerce-product-recommendations",
+                    "woocommerce-payments",
+                    "automatewoo",
+                    "woocommerce-shipping",
+                    "woocommerce-subscriptions",
+                    "woocommerce-composite-products",
+                    "woocommerce-services",
+                    "woocommerce-google-analytics-integration",
+                    "mailpoet",
+                    "jetpack"
+                ]
+            }
         }
     }
 }

--- a/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner__1.json
+++ b/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner__1.json
@@ -47,7 +47,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -60,7 +60,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -99,6 +99,52 @@
                             "description": "Whether this is a product update test run.",
                             "type": "boolean",
                             "default": false
+                        },
+                        "additional_plugins": {
+                            "description": "A comma-separated list of additional plugins to activate in the environment. Accepts: WordPress.org plugin slugs, Woo.com Product Slugs or Woo.com Product IDs.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "minimum": 1
+                            }
+                        },
+                        "additional_woo_plugins": {
+                            "description": "[Deprecated] A comma-separated list of Additional WooCommerce Extension IDs.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "integer",
+                                "minimum": 1
+                            }
+                        },
+                        "additional_wordpress_plugins": {
+                            "description": "[Deprecated] A comma-separated list of Additional WordPress plugin slugs.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "minimum": 1
+                            }
+                        },
+                        "phpstan_level": {
+                            "description": "The PHPStan level to use for the test run.",
+                            "type": "integer",
+                            "required": true,
+                            "default": 2,
+                            "enum": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10
+                            ]
                         }
                     }
                 },
@@ -116,7 +162,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -129,7 +175,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -143,7 +189,7 @@
                             ]
                         },
                         "php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The PHP version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -215,7 +261,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -228,7 +274,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -400,7 +446,7 @@
                             "default": false
                         },
                         "min_php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The minimum PHP version to test an extension's compatibility against.",
                             "type": "string",
                             "enum": [
@@ -415,7 +461,7 @@
                             ]
                         },
                         "max_php_version": {
-                            "default": "8.4",
+                            "default": "X.X.X",
                             "description": "The maximum PHP version to test an extension's compatibility against.",
                             "type": "string",
                             "enum": [
@@ -494,7 +540,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -507,7 +553,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -628,7 +674,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -641,7 +687,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -761,7 +807,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -774,7 +820,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -788,7 +834,7 @@
                             ]
                         },
                         "php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The PHP version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -906,7 +952,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -919,7 +965,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -933,7 +979,7 @@
                             ]
                         },
                         "php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The PHP version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -1219,7 +1265,7 @@
                         "php_version": {
                             "description": "The PHP version to use in the test.",
                             "type": "string",
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "enum": [
                                 "7.4",
                                 "8.0",
@@ -1230,7 +1276,7 @@
                             ]
                         },
                         "min_php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The minimum PHP version to use in a PHPCompatibility.",
                             "type": "string",
                             "enum": [
@@ -1245,7 +1291,7 @@
                             ]
                         },
                         "max_php_version": {
-                            "default": "8.4",
+                            "default": "X.X.X",
                             "description": "The maximum PHP version to use in a PHPCompatibility.",
                             "type": "string",
                             "enum": [
@@ -1344,6 +1390,13 @@
                                 "plugin",
                                 "theme"
                             ]
+                        },
+                        "extension_set": {
+                            "description": "The predefined set of extensions to include in the mass test.",
+                            "type": "string",
+                            "enum": [
+                                "compatibility"
+                            ]
                         }
                     }
                 }
@@ -1383,17 +1436,35 @@
             },
             "versions": {
                 "woocommerce": {
-                    "stable": "9.6.0",
-                    "rc": "9.7.0-beta.1",
-                    "rc_unsynced": "9.7.0-beta.1"
+                    "stable": "X.X.X",
+                    "rc": "X.X.X",
+                    "rc_unsynced": "X.X.X"
                 },
                 "wordpress": {
-                    "stable": "6.7.1",
-                    "rc": "6.7.1"
+                    "stable": "X.X.X",
+                    "rc": "X.X.X"
                 }
             },
             "hide_e2e": false,
-            "playwright_version": "1.49.1"
+            "playwright_version": "X.X.X",
+            "extension_sets": {
+                "compatibility": [
+                    "gift-cards",
+                    "woocommerce-product-add-ons",
+                    "woocommerce-min-max-quantities",
+                    "woocommerce-product-bundles",
+                    "woocommerce-product-recommendations",
+                    "woocommerce-payments",
+                    "automatewoo",
+                    "woocommerce-shipping",
+                    "woocommerce-subscriptions",
+                    "woocommerce-composite-products",
+                    "woocommerce-services",
+                    "woocommerce-google-analytics-integration",
+                    "mailpoet",
+                    "jetpack"
+                ]
+            }
         }
     }
 }

--- a/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner__2.json
+++ b/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner__2.json
@@ -47,7 +47,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -60,7 +60,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -99,6 +99,52 @@
                             "description": "Whether this is a product update test run.",
                             "type": "boolean",
                             "default": false
+                        },
+                        "additional_plugins": {
+                            "description": "A comma-separated list of additional plugins to activate in the environment. Accepts: WordPress.org plugin slugs, Woo.com Product Slugs or Woo.com Product IDs.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "minimum": 1
+                            }
+                        },
+                        "additional_woo_plugins": {
+                            "description": "[Deprecated] A comma-separated list of Additional WooCommerce Extension IDs.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "integer",
+                                "minimum": 1
+                            }
+                        },
+                        "additional_wordpress_plugins": {
+                            "description": "[Deprecated] A comma-separated list of Additional WordPress plugin slugs.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "minimum": 1
+                            }
+                        },
+                        "phpstan_level": {
+                            "description": "The PHPStan level to use for the test run.",
+                            "type": "integer",
+                            "required": true,
+                            "default": 2,
+                            "enum": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10
+                            ]
                         }
                     }
                 },
@@ -116,7 +162,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -129,7 +175,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -143,7 +189,7 @@
                             ]
                         },
                         "php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The PHP version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -215,7 +261,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -228,7 +274,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -400,7 +446,7 @@
                             "default": false
                         },
                         "min_php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The minimum PHP version to test an extension's compatibility against.",
                             "type": "string",
                             "enum": [
@@ -415,7 +461,7 @@
                             ]
                         },
                         "max_php_version": {
-                            "default": "8.4",
+                            "default": "X.X.X",
                             "description": "The maximum PHP version to test an extension's compatibility against.",
                             "type": "string",
                             "enum": [
@@ -494,7 +540,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -507,7 +553,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -628,7 +674,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -641,7 +687,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -761,7 +807,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -774,7 +820,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -788,7 +834,7 @@
                             ]
                         },
                         "php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The PHP version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -906,7 +952,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -919,7 +965,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -933,7 +979,7 @@
                             ]
                         },
                         "php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The PHP version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -1219,7 +1265,7 @@
                         "php_version": {
                             "description": "The PHP version to use in the test.",
                             "type": "string",
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "enum": [
                                 "7.4",
                                 "8.0",
@@ -1230,7 +1276,7 @@
                             ]
                         },
                         "min_php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The minimum PHP version to use in a PHPCompatibility.",
                             "type": "string",
                             "enum": [
@@ -1245,7 +1291,7 @@
                             ]
                         },
                         "max_php_version": {
-                            "default": "8.4",
+                            "default": "X.X.X",
                             "description": "The maximum PHP version to use in a PHPCompatibility.",
                             "type": "string",
                             "enum": [
@@ -1344,6 +1390,13 @@
                                 "plugin",
                                 "theme"
                             ]
+                        },
+                        "extension_set": {
+                            "description": "The predefined set of extensions to include in the mass test.",
+                            "type": "string",
+                            "enum": [
+                                "compatibility"
+                            ]
                         }
                     }
                 }
@@ -1383,17 +1436,35 @@
             },
             "versions": {
                 "woocommerce": {
-                    "stable": "9.6.0",
-                    "rc": "9.7.0-beta.1",
-                    "rc_unsynced": "9.7.0-beta.1"
+                    "stable": "X.X.X",
+                    "rc": "X.X.X",
+                    "rc_unsynced": "X.X.X"
                 },
                 "wordpress": {
-                    "stable": "6.7.1",
-                    "rc": "6.7.1"
+                    "stable": "X.X.X",
+                    "rc": "X.X.X"
                 }
             },
             "hide_e2e": false,
-            "playwright_version": "1.49.1"
+            "playwright_version": "X.X.X",
+            "extension_sets": {
+                "compatibility": [
+                    "gift-cards",
+                    "woocommerce-product-add-ons",
+                    "woocommerce-min-max-quantities",
+                    "woocommerce-product-bundles",
+                    "woocommerce-product-recommendations",
+                    "woocommerce-payments",
+                    "automatewoo",
+                    "woocommerce-shipping",
+                    "woocommerce-subscriptions",
+                    "woocommerce-composite-products",
+                    "woocommerce-services",
+                    "woocommerce-google-analytics-integration",
+                    "mailpoet",
+                    "jetpack"
+                ]
+            }
         }
     }
 }

--- a/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner_on_different_environments__1.json
+++ b/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner_on_different_environments__1.json
@@ -47,7 +47,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -60,7 +60,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -99,6 +99,52 @@
                             "description": "Whether this is a product update test run.",
                             "type": "boolean",
                             "default": false
+                        },
+                        "additional_plugins": {
+                            "description": "A comma-separated list of additional plugins to activate in the environment. Accepts: WordPress.org plugin slugs, Woo.com Product Slugs or Woo.com Product IDs.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "minimum": 1
+                            }
+                        },
+                        "additional_woo_plugins": {
+                            "description": "[Deprecated] A comma-separated list of Additional WooCommerce Extension IDs.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "integer",
+                                "minimum": 1
+                            }
+                        },
+                        "additional_wordpress_plugins": {
+                            "description": "[Deprecated] A comma-separated list of Additional WordPress plugin slugs.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "minimum": 1
+                            }
+                        },
+                        "phpstan_level": {
+                            "description": "The PHPStan level to use for the test run.",
+                            "type": "integer",
+                            "required": true,
+                            "default": 2,
+                            "enum": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10
+                            ]
                         }
                     }
                 },
@@ -116,7 +162,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -129,7 +175,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -143,7 +189,7 @@
                             ]
                         },
                         "php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The PHP version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -215,7 +261,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -228,7 +274,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -400,7 +446,7 @@
                             "default": false
                         },
                         "min_php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The minimum PHP version to test an extension's compatibility against.",
                             "type": "string",
                             "enum": [
@@ -415,7 +461,7 @@
                             ]
                         },
                         "max_php_version": {
-                            "default": "8.4",
+                            "default": "X.X.X",
                             "description": "The maximum PHP version to test an extension's compatibility against.",
                             "type": "string",
                             "enum": [
@@ -494,7 +540,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -507,7 +553,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -628,7 +674,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -641,7 +687,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -761,7 +807,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -774,7 +820,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -788,7 +834,7 @@
                             ]
                         },
                         "php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The PHP version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -906,7 +952,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -919,7 +965,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -933,7 +979,7 @@
                             ]
                         },
                         "php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The PHP version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -1219,7 +1265,7 @@
                         "php_version": {
                             "description": "The PHP version to use in the test.",
                             "type": "string",
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "enum": [
                                 "7.4",
                                 "8.0",
@@ -1230,7 +1276,7 @@
                             ]
                         },
                         "min_php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The minimum PHP version to use in a PHPCompatibility.",
                             "type": "string",
                             "enum": [
@@ -1245,7 +1291,7 @@
                             ]
                         },
                         "max_php_version": {
-                            "default": "8.4",
+                            "default": "X.X.X",
                             "description": "The maximum PHP version to use in a PHPCompatibility.",
                             "type": "string",
                             "enum": [
@@ -1344,6 +1390,13 @@
                                 "plugin",
                                 "theme"
                             ]
+                        },
+                        "extension_set": {
+                            "description": "The predefined set of extensions to include in the mass test.",
+                            "type": "string",
+                            "enum": [
+                                "compatibility"
+                            ]
                         }
                     }
                 }
@@ -1383,17 +1436,35 @@
             },
             "versions": {
                 "woocommerce": {
-                    "stable": "9.6.0",
-                    "rc": "9.7.0-beta.1",
-                    "rc_unsynced": "9.7.0-beta.1"
+                    "stable": "X.X.X",
+                    "rc": "X.X.X",
+                    "rc_unsynced": "X.X.X"
                 },
                 "wordpress": {
-                    "stable": "6.7.1",
-                    "rc": "6.7.1"
+                    "stable": "X.X.X",
+                    "rc": "X.X.X"
                 }
             },
             "hide_e2e": false,
-            "playwright_version": "1.49.1"
+            "playwright_version": "X.X.X",
+            "extension_sets": {
+                "compatibility": [
+                    "gift-cards",
+                    "woocommerce-product-add-ons",
+                    "woocommerce-min-max-quantities",
+                    "woocommerce-product-bundles",
+                    "woocommerce-product-recommendations",
+                    "woocommerce-payments",
+                    "automatewoo",
+                    "woocommerce-shipping",
+                    "woocommerce-subscriptions",
+                    "woocommerce-composite-products",
+                    "woocommerce-services",
+                    "woocommerce-google-analytics-integration",
+                    "mailpoet",
+                    "jetpack"
+                ]
+            }
         }
     }
 }

--- a/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner_on_different_environments__2.json
+++ b/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner_on_different_environments__2.json
@@ -47,7 +47,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -60,7 +60,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -99,6 +99,52 @@
                             "description": "Whether this is a product update test run.",
                             "type": "boolean",
                             "default": false
+                        },
+                        "additional_plugins": {
+                            "description": "A comma-separated list of additional plugins to activate in the environment. Accepts: WordPress.org plugin slugs, Woo.com Product Slugs or Woo.com Product IDs.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "minimum": 1
+                            }
+                        },
+                        "additional_woo_plugins": {
+                            "description": "[Deprecated] A comma-separated list of Additional WooCommerce Extension IDs.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "integer",
+                                "minimum": 1
+                            }
+                        },
+                        "additional_wordpress_plugins": {
+                            "description": "[Deprecated] A comma-separated list of Additional WordPress plugin slugs.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "minimum": 1
+                            }
+                        },
+                        "phpstan_level": {
+                            "description": "The PHPStan level to use for the test run.",
+                            "type": "integer",
+                            "required": true,
+                            "default": 2,
+                            "enum": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10
+                            ]
                         }
                     }
                 },
@@ -116,7 +162,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -129,7 +175,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -143,7 +189,7 @@
                             ]
                         },
                         "php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The PHP version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -215,7 +261,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -228,7 +274,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -400,7 +446,7 @@
                             "default": false
                         },
                         "min_php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The minimum PHP version to test an extension's compatibility against.",
                             "type": "string",
                             "enum": [
@@ -415,7 +461,7 @@
                             ]
                         },
                         "max_php_version": {
-                            "default": "8.4",
+                            "default": "X.X.X",
                             "description": "The maximum PHP version to test an extension's compatibility against.",
                             "type": "string",
                             "enum": [
@@ -494,7 +540,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -507,7 +553,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -628,7 +674,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -641,7 +687,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -761,7 +807,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -774,7 +820,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -788,7 +834,7 @@
                             ]
                         },
                         "php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The PHP version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -906,7 +952,7 @@
                             "type": "integer"
                         },
                         "wordpress_version": {
-                            "default": "6.7.1",
+                            "default": "X.X.X",
                             "description": "The WordPress version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -919,7 +965,7 @@
                             ]
                         },
                         "woocommerce_version": {
-                            "default": "9.6.0",
+                            "default": "X.X.X",
                             "description": "The WooCommerce version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -933,7 +979,7 @@
                             ]
                         },
                         "php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The PHP version to use in the test.",
                             "type": "string",
                             "enum": [
@@ -1219,7 +1265,7 @@
                         "php_version": {
                             "description": "The PHP version to use in the test.",
                             "type": "string",
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "enum": [
                                 "7.4",
                                 "8.0",
@@ -1230,7 +1276,7 @@
                             ]
                         },
                         "min_php_version": {
-                            "default": "7.4",
+                            "default": "X.X.X",
                             "description": "The minimum PHP version to use in a PHPCompatibility.",
                             "type": "string",
                             "enum": [
@@ -1245,7 +1291,7 @@
                             ]
                         },
                         "max_php_version": {
-                            "default": "8.4",
+                            "default": "X.X.X",
                             "description": "The maximum PHP version to use in a PHPCompatibility.",
                             "type": "string",
                             "enum": [
@@ -1344,6 +1390,13 @@
                                 "plugin",
                                 "theme"
                             ]
+                        },
+                        "extension_set": {
+                            "description": "The predefined set of extensions to include in the mass test.",
+                            "type": "string",
+                            "enum": [
+                                "compatibility"
+                            ]
                         }
                     }
                 }
@@ -1383,17 +1436,35 @@
             },
             "versions": {
                 "woocommerce": {
-                    "stable": "9.6.0",
-                    "rc": "9.7.0-beta.1",
-                    "rc_unsynced": "9.7.0-beta.1"
+                    "stable": "X.X.X",
+                    "rc": "X.X.X",
+                    "rc_unsynced": "X.X.X"
                 },
                 "wordpress": {
-                    "stable": "6.7.1",
-                    "rc": "6.7.1"
+                    "stable": "X.X.X",
+                    "rc": "X.X.X"
                 }
             },
             "hide_e2e": false,
-            "playwright_version": "1.49.1"
+            "playwright_version": "X.X.X",
+            "extension_sets": {
+                "compatibility": [
+                    "gift-cards",
+                    "woocommerce-product-add-ons",
+                    "woocommerce-min-max-quantities",
+                    "woocommerce-product-bundles",
+                    "woocommerce-product-recommendations",
+                    "woocommerce-payments",
+                    "automatewoo",
+                    "woocommerce-shipping",
+                    "woocommerce-subscriptions",
+                    "woocommerce-composite-products",
+                    "woocommerce-services",
+                    "woocommerce-google-analytics-integration",
+                    "mailpoet",
+                    "jetpack"
+                ]
+            }
         }
     }
 }

--- a/src/tests/__snapshots__/RunTestsTest__test_run_with_additional_plugins__1.json
+++ b/src/tests/__snapshots__/RunTestsTest__test_run_with_additional_plugins__1.json
@@ -2,8 +2,8 @@
     "url": "https:\/\/qit.woo.com\/wp-json\/cd\/v1\/enqueue-woo-e2e",
     "method": "POST",
     "post_body": {
-        "wordpress_version": "6.7.1",
-        "woocommerce_version": "9.6.0",
+        "wordpress_version": "X.X.X",
+        "woocommerce_version": "X.X.X",
         "php_version": "",
         "optional_features": [],
         "additional_plugins": "456,789",

--- a/src/tests/__snapshots__/RunTestsTest__test_run_with_additional_plugins__2.json
+++ b/src/tests/__snapshots__/RunTestsTest__test_run_with_additional_plugins__2.json
@@ -2,8 +2,8 @@
     "url": "https:\/\/qit.woo.com\/wp-json\/cd\/v1\/enqueue-woo-e2e",
     "method": "POST",
     "post_body": {
-        "wordpress_version": "6.7.1",
-        "woocommerce_version": "9.6.0",
+        "wordpress_version": "X.X.X",
+        "woocommerce_version": "X.X.X",
         "php_version": "",
         "optional_features": [],
         "additional_plugins": "bar-extension,baz-extension",

--- a/src/tests/__snapshots__/RunTestsTest__test_run_with_additional_plugins__3.json
+++ b/src/tests/__snapshots__/RunTestsTest__test_run_with_additional_plugins__3.json
@@ -2,8 +2,8 @@
     "url": "https:\/\/qit.woo.com\/wp-json\/cd\/v1\/enqueue-woo-e2e",
     "method": "POST",
     "post_body": {
-        "wordpress_version": "6.7.1",
-        "woocommerce_version": "9.6.0",
+        "wordpress_version": "X.X.X",
+        "woocommerce_version": "X.X.X",
         "php_version": "",
         "optional_features": [],
         "additional_plugins": "456,baz-extension",


### PR DESCRIPTION
When testing the activation test with the `compatibility` extension set, I discovered some deprecation warnings that were coming from the set members, rather than the SUT:

```
Class Jetpack_Geo_Location is deprecated since version 14.3 with no alternative available.
&
Hook woocommerce_get_price is deprecated since version 3.0.0! Use woocommerce_product_get_price instead.
```

The first is coming from Jetpack itself, since it adds geo-location support to the 20xx themes, but has also deprecated its geo-location support. This is indeed a little silly, and Jetpack is updating that behavior. Supressing this in the meantime is good.

The second comes from some common code in Subscriptions and Payments. It'd be nice to address, but is also probably low priority. Also a reasonable candidate to ignore - as long as we're not testing one of those two, in which case we should surface it, since they could do something about it (vs some random SUT just using the extension set).

Testing: this one is tricky. The activation test actually uses the Query Monitor logs, and a separate change is coming to filter these messages there. However, the Woo API and Woo E2E test types can also use extension sets, and do use the debug log we're parsing here, so fixing it for them is reasonable. Those run in GH actions though, so I'm less sure how to get the new QIT binary in there to test it. I've tested it locally with the activation test and some logging, and confirmed that it does skip the desired lines, so maybe that's good enough?

This will need a new release once merged, I believe.