### PR TITLE
Allow to use integer zero as value for required option built from schema

### DIFF
--- a/src/src/Commands/DynamicCommand.php
+++ b/src/src/Commands/DynamicCommand.php
@@ -27,7 +27,7 @@ abstract class DynamicCommand extends Command {
 		foreach ( $options as $option ) {
 			$name  = $option->getName();
 			$value = $input->getOption( $name );
-			if ( $option->isValueRequired() && empty( $value ) ) {
+			if ( $option->isValueRequired() && ( is_null( $value ) || $value === '' ) ) {
 				throw new \InvalidArgumentException( sprintf( 'The required option "%s" is not set. Run the command with --help for more information.', $name ) );
 			}
 		}


### PR DESCRIPTION
Fixes `qit run:phpstan foo --phpstan_level 0`, which previously complained that `--phpstan_level` was required.