### PR TITLE
Update snapshots for PHPStan level

### DIFF
--- a/src/tests/__snapshots__/PartnerManagementTest__test_add_partner__1.json
+++ b/src/tests/__snapshots__/PartnerManagementTest__test_add_partner__1.json
@@ -1397,6 +1397,24 @@
                             "enum": [
                                 "compatibility"
                             ]
+                        },
+                        "phpstan_level": {
+                            "default": null,
+                            "description": "The level of PHPStan analysis to perform during the test.",
+                            "type": "integer",
+                            "enum": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10
+                            ]
                         }
                     }
                 }

--- a/src/tests/__snapshots__/PartnerManagementTest__test_add_partner_email__1.json
+++ b/src/tests/__snapshots__/PartnerManagementTest__test_add_partner_email__1.json
@@ -1397,6 +1397,24 @@
                             "enum": [
                                 "compatibility"
                             ]
+                        },
+                        "phpstan_level": {
+                            "default": null,
+                            "description": "The level of PHPStan analysis to perform during the test.",
+                            "type": "integer",
+                            "enum": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10
+                            ]
                         }
                     }
                 }

--- a/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner__1.json
+++ b/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner__1.json
@@ -1397,6 +1397,24 @@
                             "enum": [
                                 "compatibility"
                             ]
+                        },
+                        "phpstan_level": {
+                            "default": null,
+                            "description": "The level of PHPStan analysis to perform during the test.",
+                            "type": "integer",
+                            "enum": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10
+                            ]
                         }
                     }
                 }

--- a/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner__2.json
+++ b/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner__2.json
@@ -1397,6 +1397,24 @@
                             "enum": [
                                 "compatibility"
                             ]
+                        },
+                        "phpstan_level": {
+                            "default": null,
+                            "description": "The level of PHPStan analysis to perform during the test.",
+                            "type": "integer",
+                            "enum": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10
+                            ]
                         }
                     }
                 }

--- a/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner_on_different_environments__1.json
+++ b/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner_on_different_environments__1.json
@@ -1397,6 +1397,24 @@
                             "enum": [
                                 "compatibility"
                             ]
+                        },
+                        "phpstan_level": {
+                            "default": null,
+                            "description": "The level of PHPStan analysis to perform during the test.",
+                            "type": "integer",
+                            "enum": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10
+                            ]
                         }
                     }
                 }

--- a/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner_on_different_environments__2.json
+++ b/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner_on_different_environments__2.json
@@ -1397,6 +1397,24 @@
                             "enum": [
                                 "compatibility"
                             ]
+                        },
+                        "phpstan_level": {
+                            "default": null,
+                            "description": "The level of PHPStan analysis to perform during the test.",
+                            "type": "integer",
+                            "enum": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10
+                            ]
                         }
                     }
                 }


### PR DESCRIPTION
Unit tests are currently failing on trunk since these snapshots were missing the phpstan level parameter.