### PR TITLE
Add key to snapshots

### DIFF
--- a/_tests/managed_tests/add_keys_to_snapshots.php
+++ b/_tests/managed_tests/add_keys_to_snapshots.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Script: add_keys_to_snapshots.php
+ * 
+ * This script modifies PHPUnit snapshot files by inserting specific JSON keys
+ * in a structured "add this key after this key with this value" format.
+ * 
+ * ✅ **Preserves PHPUnit snapshot formatting**
+ * ✅ **Explicitly defines key order and values**
+ * ✅ **Works recursively for nested structures**
+ * ✅ **Only modifies files that need changes, making Git commits clean**
+ *
+ * Usage:
+ * ```
+ * php add_keys_to_snapshots.php
+ * ```
+ *
+ * Example:
+ * - Before:
+ * ```json
+ * {
+ *   "phpstan_level": null,
+ *   "test_result_json_extracted": "{EXTRACTED}"
+ * }
+ * ```
+ * - After:
+ * ```json
+ * {
+ *   "phpstan_level": null,
+ *   "test_variation": "example_value",
+ *   "test_result_json_extracted": "{EXTRACTED}"
+ * }
+ * ```
+ */
+
+$snapshotsDir = 'tests/__snapshots__';
+
+if (!is_dir($snapshotsDir)) {
+    die("Snapshots directory not found: $snapshotsDir\n");
+}
+
+$snapshotFiles = glob("$snapshotsDir/*.php");
+
+/**
+ * Recursively inserts specified keys into the JSON structure.
+ * 
+ * @param array &$array The snapshot data array.
+ * @param array $keysToAdd An array defining which key to add, after which key, and with what value.
+ */
+function insertKeys(&$array, $keysToAdd) {
+    foreach ($array as &$entry) {
+        if (is_array($entry)) {
+            foreach ($keysToAdd as $newKey => $details) {
+                $afterKey = $details['after']; // The key after which to insert
+                $value = $details['value'];    // The value to assign
+
+                if (array_key_exists($afterKey, $entry) && !array_key_exists($newKey, $entry)) {
+                    echo "   ➡ Adding '$newKey' after '$afterKey' with value: " . json_encode($value) . "\n";
+
+                    // Preserve order by inserting after the specified key
+                    $orderedEntry = [];
+                    foreach ($entry as $key => $val) {
+                        $orderedEntry[$key] = $val;
+                        if ($key === $afterKey) {
+                            $orderedEntry[$newKey] = $value;
+                        }
+                    }
+                    $entry = $orderedEntry;
+                }
+            }
+            // Recurse into nested structures
+            insertKeys($entry, $keysToAdd);
+        }
+    }
+}
+
+// Define the keys to add and their values
+$keysToAdd = [
+    "test_variation" => [
+        "after" => "phpstan_level",
+        "value" => ""
+    ]
+];
+
+foreach ($snapshotFiles as $file) {
+    echo "Processing: $file\n";
+
+    $jsonString = require $file;
+
+    if (!is_string($jsonString)) {
+        echo "❌ Error: Expected a JSON string in $file, but got something else.\n";
+        continue;
+    }
+
+    $data = json_decode($jsonString, true);
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        echo "❌ Error decoding JSON in file: $file\n";
+        echo "   ➡ " . json_last_error_msg() . "\n";
+        continue;
+    }
+
+    // Insert keys recursively
+    $before = json_encode($data, JSON_UNESCAPED_SLASHES);
+    insertKeys($data, $keysToAdd);
+    $after = json_encode($data, JSON_UNESCAPED_SLASHES);
+
+    if ($before !== $after) {
+        $newJsonString = json_encode($data, JSON_PRETTY_PRINT); // Keeps `\/` escaped
+        $newPhpContent = "<?php return " . var_export($newJsonString, true) . ";\n";
+        file_put_contents($file, $newPhpContent);
+        echo "✅ Updated: $file\n";
+    } else {
+        echo "✔ No changes needed: $file\n";
+    }
+}
+
+echo "🎉 Done.\n";
+

--- a/_tests/managed_tests/add_keys_to_snapshots.php
+++ b/_tests/managed_tests/add_keys_to_snapshots.php
@@ -1,38 +1,16 @@
 <?php
 
 /**
- * Script: add_keys_to_snapshots.php
- * 
- * This script modifies PHPUnit snapshot files by inserting specific JSON keys
- * in a structured "add this key after this key with this value" format.
- * 
- * ✅ **Preserves PHPUnit snapshot formatting**
- * ✅ **Explicitly defines key order and values**
- * ✅ **Works recursively for nested structures**
- * ✅ **Only modifies files that need changes, making Git commits clean**
- *
- * Usage:
- * ```
- * php add_keys_to_snapshots.php
- * ```
- *
- * Example:
- * - Before:
- * ```json
- * {
- *   "phpstan_level": null,
- *   "test_result_json_extracted": "{EXTRACTED}"
- * }
- * ```
- * - After:
- * ```json
- * {
- *   "phpstan_level": null,
- *   "test_variation": "example_value",
- *   "test_result_json_extracted": "{EXTRACTED}"
- * }
- * ```
+ * Add keys to snapshots without having to re-run all tests.
  */
+
+// Define the keys to add and their values
+$keysToAdd = [
+	"test_variation" => [
+		"after" => "phpstan_level",
+		"value" => ""
+	]
+];
 
 $snapshotsDir = 'tests/__snapshots__';
 
@@ -74,14 +52,6 @@ function insertKeys(&$array, $keysToAdd) {
         }
     }
 }
-
-// Define the keys to add and their values
-$keysToAdd = [
-    "test_variation" => [
-        "after" => "phpstan_level",
-        "value" => ""
-    ]
-];
 
 foreach ($snapshotFiles as $file) {
     echo "Processing: $file\n";

--- a/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_childtheme_woostable_php82_wpstable_586f8c4da7220df02f5f27d4e54835e3__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_childtheme_woostable_php82_wpstable_586f8c4da7220df02f5f27d4e54835e3__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_generic_woorc_php74_wprc_334048b547066d6408232a37d57ddff2__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_generic_woorc_php74_wprc_334048b547066d6408232a37d57ddff2__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_parenttheme_woostable_php82_wpstable_4236e2db0915f662c3e5813c9b6224ab__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_parenttheme_woostable_php82_wpstable_4236e2db0915f662c3e5813c9b6224ab__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_php82_woorc_php82_wprc_b401265b202fc3b86b98faf66ab1e3f7__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_php82_woorc_php82_wprc_b401265b202fc3b86b98faf66ab1e3f7__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_with_custom_pages_woorc_php74_wprc_c88ead353ce4cbe8dc55a38d95020a2e__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_with_custom_pages_woorc_php74_wprc_c88ead353ce4cbe8dc55a38d95020a2e__1.php
@@ -101,6 +101,7 @@
             ],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/MalwareTest__test_malware_jetpack_scan_woo_php_wp_6721f9775c2073c083e409914f62ed75__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/MalwareTest__test_malware_jetpack_scan_woo_php_wp_6721f9775c2073c083e409914f62ed75__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/MalwareTest__test_malware_no_op_woo_php_wp_0dd309d969e4d46682be10c3bd717eb0__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/MalwareTest__test_malware_no_op_woo_php_wp_0dd309d969e4d46682be10c3bd717eb0__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_childtheme_woo_php_wp_857a3bbe5fef96a3b158c7389549fa57__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_childtheme_woo_php_wp_857a3bbe5fef96a3b158c7389549fa57__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_main_woo_php_wp_28e03c1a3073469aae3b28c10dfeac1d__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_main_woo_php_wp_28e03c1a3073469aae3b28c10dfeac1d__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_parenttheme_woo_php_wp_6851f6654a4c24423121aa31423c2753__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_parenttheme_woo_php_wp_6851f6654a4c24423121aa31423c2753__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_72_to_74_woo_php_wp_b1c588503637a98590143b312a69beba__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_72_to_74_woo_php_wp_b1c588503637a98590143b312a69beba__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_81_to_82_woo_php_wp_6ee042538e1935736a9856e687d0c150__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_81_to_82_woo_php_wp_6ee042538e1935736a9856e687d0c150__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_default_php_version_woo_php_wp_aab4e9b0325ab0d8921f5fb94ffecdac__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_default_php_version_woo_php_wp_aab4e9b0325ab0d8921f5fb94ffecdac__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_additional_plugins_woo_php_wp_efa95b897ff4a83698ed4371166ccba5__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_additional_plugins_woo_php_wp_efa95b897ff4a83698ed4371166ccba5__1.php
@@ -50,6 +50,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": 2,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_childtheme_woo_php_wp_acd1df3b6787d2c2218b6be0b465f886__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_childtheme_woo_php_wp_acd1df3b6787d2c2218b6be0b465f886__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": 2,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_main_woo_php_wp_f80e75e0a6ea5d06dd6dc94dc9336592__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_main_woo_php_wp_f80e75e0a6ea5d06dd6dc94dc9336592__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": 2,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_parenttheme_woo_php_wp_995dee7cfdc6a851703a72185472abe7__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_parenttheme_woo_php_wp_995dee7cfdc6a851703a72185472abe7__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": 2,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_with_vendor_woo_php_wp_b50d713e3b9c085feafab3638144cb8a__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_with_vendor_woo_php_wp_b50d713e3b9c085feafab3638144cb8a__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": 2,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_childtheme_woo_php_wp_b075c74b6040c155dee4bf80601d8593__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_childtheme_woo_php_wp_b075c74b6040c155dee4bf80601d8593__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_db_woo_php_wp_49db8a4a428f094d772dd537f86cafc1__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_db_woo_php_wp_49db8a4a428f094d772dd537f86cafc1__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_exclusions_woo_php_wp_781a480f91705a029738d07d57a3454d__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_exclusions_woo_php_wp_781a480f91705a029738d07d57a3454d__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_main_woo_php_wp_58e73693928f158eed05cb07b0787674__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_main_woo_php_wp_58e73693928f158eed05cb07b0787674__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_nonce_woo_php_wp_675f895c6a36c524d03d9e313702ec6b__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_nonce_woo_php_wp_675f895c6a36c524d03d9e313702ec6b__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_parenttheme_woo_php_wp_cc908a9e48789589e553f91761083f53__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_parenttheme_woo_php_wp_cc908a9e48789589e553f91761083f53__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_main_plugin_woo_php_wp_08cb3463942aa74df688a3f4a807718e__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_main_plugin_woo_php_wp_08cb3463942aa74df688a3f4a807718e__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_main_theme_woo_php_wp_3976d011ae5709242b883dfb4863e252__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_main_theme_woo_php_wp_3976d011ae5709242b883dfb4863e252__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_missing_plugin_woo_php_wp_b2f118a836d0b8cf4a8f3ca7c3af96c6__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_missing_plugin_woo_php_wp_b2f118a836d0b8cf4a8f3ca7c3af96c6__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_missing_theme_woo_php_wp_0f4ea06ab85fe945af93b8dc42336c32__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_missing_theme_woo_php_wp_0f4ea06ab85fe945af93b8dc42336c32__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_plugin_readme_woo_php_wp_e77ebed808cac5ec958e0ed7397b9ef4__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_plugin_readme_woo_php_wp_e77ebed808cac5ec958e0ed7397b9ef4__1.php
@@ -44,6 +44,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}"
         },
         {

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_childtheme_woostable_php82_wpstable_440db7a70e471458f49b3c2aca2ba623__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_childtheme_woostable_php82_wpstable_440db7a70e471458f49b3c2aca2ba623__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_delete_products_woorc_php74_wprc_ca644c3f45a3d92971d7c34b17b9bf40__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_delete_products_woorc_php74_wprc_ca644c3f45a3d92971d7c34b17b9bf40__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_delete_products_woorc_php82_wprc_8ddcb1dd26e5c14fcd0a28ef812daa5c__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_delete_products_woorc_php82_wprc_8ddcb1dd26e5c14fcd0a28ef812daa5c__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_delete_products_woostable_php74_wprc_c35449740535ad91e8942f8f0ed05b72__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_delete_products_woostable_php74_wprc_c35449740535ad91e8942f8f0ed05b72__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_delete_products_woostable_php82_wprc_f53670e03588ff82e9c536ab4127fb87__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_delete_products_woostable_php82_wprc_f53670e03588ff82e9c536ab4127fb87__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woorc_php74_wprc_346c5f1d46bbec1721f5bbf11816a5c0__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woorc_php74_wprc_346c5f1d46bbec1721f5bbf11816a5c0__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woorc_php82_wprc_2b7d6254596db2c73939e0d764cc4ba3__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woorc_php82_wprc_2b7d6254596db2c73939e0d764cc4ba3__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woostable_php74_wprc_7362ffe83e2b60ebc0cf5c63b3856976__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woostable_php74_wprc_7362ffe83e2b60ebc0cf5c63b3856976__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woostable_php82_wprc_5e58227b55849b8c7239a9971ae5d264__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woostable_php82_wprc_5e58227b55849b8c7239a9971ae5d264__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woorc_php74_wprc_ffc30a443f4fcc32b0abe133375adbd8__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woorc_php74_wprc_ffc30a443f4fcc32b0abe133375adbd8__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woorc_php82_wprc_eb7749dc7ada621516b289b420c7aa83__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woorc_php82_wprc_eb7749dc7ada621516b289b420c7aa83__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woostable_php74_wprc_ca36e1e383c91cc1e399f1bab52b350b__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woostable_php74_wprc_ca36e1e383c91cc1e399f1bab52b350b__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woostable_php82_wprc_30c8c208075c921416b6f88c67b78c16__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woostable_php82_wprc_30c8c208075c921416b6f88c67b78c16__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_parenttheme_woostable_php82_wpstable_4fea9b07dff27b783d26f0b4b90cc6e4__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_parenttheme_woostable_php82_wpstable_4fea9b07dff27b783d26f0b4b90cc6e4__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woorc_php74_wprc_fdd35606f836d278e28ee1655d190df0__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woorc_php74_wprc_fdd35606f836d278e28ee1655d190df0__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woorc_php82_wprc_f4cd9965b5cceb8e299a36acf245b6f0__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woorc_php82_wprc_f4cd9965b5cceb8e299a36acf245b6f0__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woostable_php74_wprc_c5e572f0e7a39cd8994d515514e0be3a__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woostable_php74_wprc_c5e572f0e7a39cd8994d515514e0be3a__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woostable_php82_wprc_18f274ce2084619bd42b38449a1c9321__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woostable_php82_wprc_18f274ce2084619bd42b38449a1c9321__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_delete_products_woorc_php74_wprc_b153920e11128a2003ccfabb5a1c2b66__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_delete_products_woorc_php74_wprc_b153920e11128a2003ccfabb5a1c2b66__1.php
@@ -48,6 +48,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}"
         },

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_delete_products_woostable_php74_wprc_2a952a960085a76868033dc54aa96159__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_delete_products_woostable_php74_wprc_2a952a960085a76868033dc54aa96159__1.php
@@ -48,6 +48,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}"
         },

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woorc_php82_wprc_4ee1157429027befae37425348f5bd84__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woorc_php82_wprc_4ee1157429027befae37425348f5bd84__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woorc_php82_wpstable_b23dfeb910e3a66fc64cf81023cfeaea__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woorc_php82_wpstable_b23dfeb910e3a66fc64cf81023cfeaea__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woostable_php82_wprc_960168535790f3a7eff463fb11517d63__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woostable_php82_wprc_960168535790f3a7eff463fb11517d63__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woostable_php82_wpstable_ed7d3932b380dcf5673cf151dde0eb37__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woostable_php82_wpstable_ed7d3932b380dcf5673cf151dde0eb37__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woorc_php74_wprc_818ebdd6b04d0991fd37d3414ff14307__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woorc_php74_wprc_818ebdd6b04d0991fd37d3414ff14307__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woorc_php74_wpstable_8ea880f7c0e5f4aeb8851ca23268fcd8__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woorc_php74_wpstable_8ea880f7c0e5f4aeb8851ca23268fcd8__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woostable_php74_wprc_865de3b217a16a96d42609a9ca8ebcf0__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woostable_php74_wprc_865de3b217a16a96d42609a9ca8ebcf0__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woostable_php74_wpstable_4d0acdce8f051e58d6c20e496553c9b6__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woostable_php74_wpstable_4d0acdce8f051e58d6c20e496553c9b6__1.php
@@ -42,6 +42,7 @@
             "test_media": [],
             "extension_set": "",
             "phpstan_level": null,
+            "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
             "ctrf_json_extracted": "{EXTRACTED}",
             "debug_log_extracted": "{EXTRACTED}"


### PR DESCRIPTION
Add a script to add a key to the snapshots without having to re-run all the tests. Uses it to add `test_variation` after `phpstan_level` as expected.