### PR TITLE
Cache undefined versions for 1h instead of 1m

### DIFF
--- a/src/src/Environment/ExtensionDownload/Handlers/Handler.php
+++ b/src/src/Environment/ExtensionDownload/Handlers/Handler.php
@@ -60,11 +60,11 @@ abstract class Handler {
 				$cache_burst = gmdate( 'z' );
 			} else {
 				/*
-				 * Otherwise, cache it for 1 minute.
+				 * Otherwise, cache it for 1 hour.
 				 * This is because we don't know what version we should be fetching, so we can't cache burst it with confidence.
-				 * We cache it for 1 minute which is just enough to throttle requests.
+				 * We cache it for 1 hour.
 				 */
-				$cache_burst = gmdate( 'YmdHi' );
+				$cache_burst = gmdate( 'YmdH' );
 			}
 		}
 


### PR DESCRIPTION
WPORG is getting sensitive when running multiple tests in sequence. This PR increases how long we cache undefined versions from 1 minute to 1h.

The 1 minute cache was meant to just avoid being throttled, because we essentially didn't have a reliable way to cache burst since we didn't have a version.

This PR increases how long we cache in this scenario to 1h, which is the intended behavior on 99.9% of the cases.