### PR TITLE
Normalize activation test self-test snapshots

### DIFF
--- a/_tests/managed_tests/tests/QITE2ETestCase.php
+++ b/_tests/managed_tests/tests/QITE2ETestCase.php
@@ -230,9 +230,6 @@ class QITE2ETestCase extends TestCase {
 					$value = str_replace( 'qit-runner-staging', 'qit-runner', $value );
 					$value = str_replace( 'compatibility-dashboard', 'qit-runner', $value );
 
-					// This removes *entire* lines that contain "Using cached file"
-					// $value = preg_replace('/^.*Using cached file.*\n?/m', '', $value);
-
 					// Replace qitenvnginx + random hex with a single placeholder
 					$value = preg_replace('/qitenvnginx[0-9a-f]+/i', 'qitenvnginxNORMALIZED', $value);
 

--- a/_tests/managed_tests/tests/QITE2ETestCase.php
+++ b/_tests/managed_tests/tests/QITE2ETestCase.php
@@ -230,6 +230,15 @@ class QITE2ETestCase extends TestCase {
 					$value = str_replace( 'qit-runner-staging', 'qit-runner', $value );
 					$value = str_replace( 'compatibility-dashboard', 'qit-runner', $value );
 
+					// This removes *entire* lines that contain "Using cached file"
+					// $value = preg_replace('/^.*Using cached file.*\n?/m', '', $value);
+
+					// Replace qitenvnginx + random hex with a single placeholder
+					$value = preg_replace('/qitenvnginx[0-9a-f]+/i', 'qitenvnginxNORMALIZED', $value);
+
+					// Pattern: dash, 10+ hex chars, then dot, then jpg/jpeg/png
+					$value = preg_replace('/-[0-9a-f]{10,}\.(jpe?g|png|webm)/i', '-HASHNORMALIZED.$1', $value);
+
 					// 3) Decode back to array so we can walk the structure
 					if ( $array_mode ) {
 						$value = json_decode( $value, true );

--- a/_tests/managed_tests/tests/QITE2ETestCase.php
+++ b/_tests/managed_tests/tests/QITE2ETestCase.php
@@ -249,6 +249,22 @@ class QITE2ETestCase extends TestCase {
 						return [];
 					}
 
+					// Remove lines containing "Using cached file" from all tests' stdout arrays
+					if ( isset( $value['results']['tests'] ) && is_array( $value['results']['tests'] ) ) {
+						foreach ( $value['results']['tests'] as &$test ) {
+							// Only proceed if stdout is an array of lines
+							if ( isset( $test['stdout'] ) && is_array( $test['stdout'] ) ) {
+								$test['stdout'] = array_values(
+									array_filter( $test['stdout'], static function ( $line ) {
+										return stripos( $line, 'Using cached file' ) === false;
+									}
+									)
+								);
+							}
+						}
+						unset( $test );
+					}
+
 					// 5) Now traverse the CTRF JSON to normalize ephemeral fields
 					if ( isset( $value['results'] ) && is_array( $value['results'] ) ) {
 						// 5a) Summary-level ephemeral data

--- a/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_childtheme_woostable_php82_wpstable_586f8c4da7220df02f5f27d4e54835e3__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_childtheme_woostable_php82_wpstable_586f8c4da7220df02f5f27d4e54835e3__1.php
@@ -212,6 +212,10 @@
                                 "Success: Updated \'woocommerce_coming_soon\' option.\\n",
                                 "Success: Updated \'woocommerce_store_pages_only\' option.\\n",
                                 "Coming soon mode disabled in beforeAll.\\n",
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
+                                "Console warning: `select` control in `@wordpress\\/data-controls` is deprecated since version 5.7. Please use built-in `resolveSelect` control in `@wordpress\\/data` instead.\\n",
+                                "Console warning: Bottom margin styles for wp.components.CheckboxControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n",
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
                                 "[INFO] Final sorted plugin list:\\n",
                                 " 1. \\"Query Monitor\\" (Dependencies: [])\\n",
                                 " 2. \\"WooCommerce\\" (Dependencies: [])\\n"
@@ -282,7 +286,14 @@
                             "steps": [],
                             "suite": "[test] Woocommerce (Run) > woocommerce\\/activation\\/activation.spec.js",
                             "attachments": [],
-                            "stdout": [],
+                            "stdout": [
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
+                                "Console warning: `select` control in `@wordpress\\/data-controls` is deprecated since version 5.7. Please use built-in `resolveSelect` control in `@wordpress\\/data` instead.\\n",
+                                "Console warning: Bottom margin styles for wp.components.CheckboxControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n",
+                                "Console warning: Bottom margin styles for wp.components.TextControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n",
+                                "Console warning: Bottom margin styles for wp.components.SelectControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n",
+                                "Console warning: Bottom margin styles for wp.components.ToggleControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": []
@@ -303,7 +314,17 @@
                             "steps": [],
                             "suite": "[test] Woocommerce (Run) > woocommerce\\/activation\\/activation.spec.js",
                             "attachments": [],
-                            "stdout": [],
+                            "stdout": [
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
+                                "Console warning: `select` control in `@wordpress\\/data-controls` is deprecated since version 5.7. Please use built-in `resolveSelect` control in `@wordpress\\/data` instead.\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 146a31f030838c11fb3922ac3c896bf5, type: notice, message: Notice on all requests - Child theme, file: wp-content\\/themes\\/bistro\\/functions.php, line: 17}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
+                                "Console warning: `select` control in `@wordpress\\/data-controls` is deprecated since version 5.7. Please use built-in `resolveSelect` control in `@wordpress\\/data` instead.\\n",
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
+                                "Console warning: `select` control in `@wordpress\\/data-controls` is deprecated since version 5.7. Please use built-in `resolveSelect` control in `@wordpress\\/data` instead.\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": []
@@ -324,7 +345,21 @@
                             "steps": [],
                             "suite": "[test] Woocommerce (Run) > woocommerce\\/activation\\/activation.spec.js",
                             "attachments": [],
-                            "stdout": [],
+                            "stdout": [
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
+                                "Console warning: `select` control in `@wordpress\\/data-controls` is deprecated since version 5.7. Please use built-in `resolveSelect` control in `@wordpress\\/data` instead.\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 146a31f030838c11fb3922ac3c896bf5, type: notice, message: Notice on all requests - Child theme, file: wp-content\\/themes\\/bistro\\/functions.php, line: 17}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 146a31f030838c11fb3922ac3c896bf5, type: notice, message: Notice on all requests - Child theme, file: wp-content\\/themes\\/bistro\\/functions.php, line: 17}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
+                                "Console warning: `select` control in `@wordpress\\/data-controls` is deprecated since version 5.7. Please use built-in `resolveSelect` control in `@wordpress\\/data` instead.\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 146a31f030838c11fb3922ac3c896bf5, type: notice, message: Notice on all requests - Child theme, file: wp-content\\/themes\\/bistro\\/functions.php, line: 17}\\n",
+                                "Console endGroup: console.groupEnd\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": []
@@ -345,7 +380,24 @@
                             "steps": [],
                             "suite": "[test] Woocommerce (Run) > woocommerce\\/activation\\/activation.spec.js",
                             "attachments": [],
-                            "stdout": [],
+                            "stdout": [
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
+                                "Console warning: `select` control in `@wordpress\\/data-controls` is deprecated since version 5.7. Please use built-in `resolveSelect` control in `@wordpress\\/data` instead.\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 146a31f030838c11fb3922ac3c896bf5, type: notice, message: Notice on all requests - Child theme, file: wp-content\\/themes\\/bistro\\/functions.php, line: 17}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 146a31f030838c11fb3922ac3c896bf5, type: notice, message: Notice on all requests - Child theme, file: wp-content\\/themes\\/bistro\\/functions.php, line: 17}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 146a31f030838c11fb3922ac3c896bf5, type: notice, message: Notice on all requests - Child theme, file: wp-content\\/themes\\/bistro\\/functions.php, line: 17}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
+                                "Console warning: `select` control in `@wordpress\\/data-controls` is deprecated since version 5.7. Please use built-in `resolveSelect` control in `@wordpress\\/data` instead.\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 146a31f030838c11fb3922ac3c896bf5, type: notice, message: Notice on all requests - Child theme, file: wp-content\\/themes\\/bistro\\/functions.php, line: 17}\\n",
+                                "Console endGroup: console.groupEnd\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": [
@@ -362,7 +414,7 @@
                             "start": 1111111111,
                             "stop": 2222222222,
                             "message": "Error: \\u001b[31mTimed out 20000ms waiting for \\u001b[39m\\u001b[2mexpect(\\u001b[22m\\u001b[31mlocator\\u001b[39m\\u001b[2m).\\u001b[22mtoContainText\\u001b[2m(\\u001b[22m\\u001b[32mexpected\\u001b[39m\\u001b[2m)\\u001b[22m\\n\\nLocator: locator(\'.wc-block-components-product-name\')\\nExpected string: \\u001b[32m\\"Test Product\\"\\u001b[39m\\nReceived: <element(s) not found>\\nCall log:\\n\\u001b[2m  - expect.toContainText with timeout 20000ms\\u001b[22m\\n\\u001b[2m  - waiting for locator(\'.wc-block-components-product-name\')\\u001b[22m\\n",
-                            "trace": "Error: \\u001b[31mTimed out 20000ms waiting for \\u001b[39m\\u001b[2mexpect(\\u001b[22m\\u001b[31mlocator\\u001b[39m\\u001b[2m).\\u001b[22mtoContainText\\u001b[2m(\\u001b[22m\\u001b[32mexpected\\u001b[39m\\u001b[2m)\\u001b[22m\\n\\nLocator: locator(\'.wc-block-components-product-name\')\\nExpected string: \\u001b[32m\\"Test Product\\"\\u001b[39m\\nReceived: <element(s) not found>\\nCall log:\\n\\u001b[2m  - expect.toContainText with timeout 20000ms\\u001b[22m\\n\\u001b[2m  - waiting for locator(\'.wc-block-components-product-name\')\\u001b[22m\\n\\n    at \\/qit\\/tests\\/e2e\\/woocommerce\\/activation\\/activation.spec.js:671:69",
+                            "trace": "Error: \\u001b[31mTimed out 20000ms waiting for \\u001b[39m\\u001b[2mexpect(\\u001b[22m\\u001b[31mlocator\\u001b[39m\\u001b[2m).\\u001b[22mtoContainText\\u001b[2m(\\u001b[22m\\u001b[32mexpected\\u001b[39m\\u001b[2m)\\u001b[22m\\n\\nLocator: locator(\'.wc-block-components-product-name\')\\nExpected string: \\u001b[32m\\"Test Product\\"\\u001b[39m\\nReceived: <element(s) not found>\\nCall log:\\n\\u001b[2m  - expect.toContainText with timeout 20000ms\\u001b[22m\\n\\u001b[2m  - waiting for locator(\'.wc-block-components-product-name\')\\u001b[22m\\n\\n    at \\/qit\\/tests\\/e2e\\/woocommerce\\/activation\\/activation.spec.js:672:69",
                             "rawStatus": "failed",
                             "tags": [],
                             "type": "e2e",
@@ -388,7 +440,9 @@
                                     "path": "\\/qit\\/results\\/playwright\\/activation-Add-Product-Cart--test-Woocommerce-Run-\\/trace.zip"
                                 }
                             ],
-                            "stdout": [],
+                            "stdout": [
+                                "Console error: Failed to load resource: the server responded with a status of 500 (Internal Server Error)\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": []

--- a/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_childtheme_woostable_php82_wpstable_586f8c4da7220df02f5f27d4e54835e3__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_childtheme_woostable_php82_wpstable_586f8c4da7220df02f5f27d4e54835e3__1.php
@@ -174,7 +174,6 @@
                                 "Success: Installed 1 of 1 plugins.\\n",
                                 "Installing Twenty Twenty-Four (1.3)\\n",
                                 "Downloading installation package from https:\\/\\/downloads.wordpress.org\\/theme\\/twentytwentyfour.1.3.zip...\\n",
-                                "Using cached file \'\\/qit\\/cache\\/wp-cli\\/theme\\/twentytwentyfour-1.3.zip\'...\\n",
                                 "Unpacking the package...\\n",
                                 "Installing the theme...\\n",
                                 "Theme installed successfully.\\n",

--- a/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_generic_woorc_php74_wprc_334048b547066d6408232a37d57ddff2__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_generic_woorc_php74_wprc_334048b547066d6408232a37d57ddff2__1.php
@@ -212,6 +212,7 @@
                                 "Success: Updated \'woocommerce_coming_soon\' option.\\n",
                                 "Success: Updated \'woocommerce_store_pages_only\' option.\\n",
                                 "Coming soon mode disabled in beforeAll.\\n",
+                                "Console warning: Bottom margin styles for wp.components.CheckboxControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n",
                                 "[INFO] Final sorted plugin list:\\n",
                                 " 1. \\"Query Monitor\\" (Dependencies: [])\\n",
                                 " 2. \\"WooCommerce\\" (Dependencies: [])\\n",
@@ -280,7 +281,12 @@
                             "steps": [],
                             "suite": "[test] Woocommerce (Run) > woocommerce\\/activation\\/activation.spec.js",
                             "attachments": [],
-                            "stdout": [],
+                            "stdout": [
+                                "Console warning: Bottom margin styles for wp.components.CheckboxControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n",
+                                "Console warning: Bottom margin styles for wp.components.TextControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n",
+                                "Console warning: Bottom margin styles for wp.components.SelectControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n",
+                                "Console warning: Bottom margin styles for wp.components.ToggleControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": []
@@ -301,7 +307,11 @@
                             "steps": [],
                             "suite": "[test] Woocommerce (Run) > woocommerce\\/activation\\/activation.spec.js",
                             "attachments": [],
-                            "stdout": [],
+                            "stdout": [
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: ce3dd029c6a0313fd73a3385a1e07698, type: notice, message: Notice on all requests, file: wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php, line: 16}\\n",
+                                "Console endGroup: console.groupEnd\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": []
@@ -322,7 +332,18 @@
                             "steps": [],
                             "suite": "[test] Woocommerce (Run) > woocommerce\\/activation\\/activation.spec.js",
                             "attachments": [],
-                            "stdout": [],
+                            "stdout": [
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: ce3dd029c6a0313fd73a3385a1e07698, type: notice, message: Notice on all requests, file: wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php, line: 16}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: ce3dd029c6a0313fd73a3385a1e07698, type: notice, message: Notice on all requests, file: wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php, line: 16}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console warning: Navigation store is deprecated.\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: ce3dd029c6a0313fd73a3385a1e07698, type: notice, message: Notice on all requests, file: wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php, line: 16}\\n",
+                                "Console endGroup: console.groupEnd\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": []
@@ -343,7 +364,20 @@
                             "steps": [],
                             "suite": "[test] Woocommerce (Run) > woocommerce\\/activation\\/activation.spec.js",
                             "attachments": [],
-                            "stdout": [],
+                            "stdout": [
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: ce3dd029c6a0313fd73a3385a1e07698, type: notice, message: Notice on all requests, file: wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php, line: 16}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: ce3dd029c6a0313fd73a3385a1e07698, type: notice, message: Notice on all requests, file: wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php, line: 16}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: ce3dd029c6a0313fd73a3385a1e07698, type: notice, message: Notice on all requests, file: wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php, line: 16}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: ce3dd029c6a0313fd73a3385a1e07698, type: notice, message: Notice on all requests, file: wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php, line: 16}\\n",
+                                "Console endGroup: console.groupEnd\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": [
@@ -360,7 +394,7 @@
                             "start": 1111111111,
                             "stop": 2222222222,
                             "message": "Error: \\u001b[31mTimed out 20000ms waiting for \\u001b[39m\\u001b[2mexpect(\\u001b[22m\\u001b[31mlocator\\u001b[39m\\u001b[2m).\\u001b[22mtoContainText\\u001b[2m(\\u001b[22m\\u001b[32mexpected\\u001b[39m\\u001b[2m)\\u001b[22m\\n\\nLocator: locator(\'.wc-block-components-product-name\')\\nExpected string: \\u001b[32m\\"Test Product\\"\\u001b[39m\\nReceived: <element(s) not found>\\nCall log:\\n\\u001b[2m  - expect.toContainText with timeout 20000ms\\u001b[22m\\n\\u001b[2m  - waiting for locator(\'.wc-block-components-product-name\')\\u001b[22m\\n",
-                            "trace": "Error: \\u001b[31mTimed out 20000ms waiting for \\u001b[39m\\u001b[2mexpect(\\u001b[22m\\u001b[31mlocator\\u001b[39m\\u001b[2m).\\u001b[22mtoContainText\\u001b[2m(\\u001b[22m\\u001b[32mexpected\\u001b[39m\\u001b[2m)\\u001b[22m\\n\\nLocator: locator(\'.wc-block-components-product-name\')\\nExpected string: \\u001b[32m\\"Test Product\\"\\u001b[39m\\nReceived: <element(s) not found>\\nCall log:\\n\\u001b[2m  - expect.toContainText with timeout 20000ms\\u001b[22m\\n\\u001b[2m  - waiting for locator(\'.wc-block-components-product-name\')\\u001b[22m\\n\\n    at \\/qit\\/tests\\/e2e\\/woocommerce\\/activation\\/activation.spec.js:671:69",
+                            "trace": "Error: \\u001b[31mTimed out 20000ms waiting for \\u001b[39m\\u001b[2mexpect(\\u001b[22m\\u001b[31mlocator\\u001b[39m\\u001b[2m).\\u001b[22mtoContainText\\u001b[2m(\\u001b[22m\\u001b[32mexpected\\u001b[39m\\u001b[2m)\\u001b[22m\\n\\nLocator: locator(\'.wc-block-components-product-name\')\\nExpected string: \\u001b[32m\\"Test Product\\"\\u001b[39m\\nReceived: <element(s) not found>\\nCall log:\\n\\u001b[2m  - expect.toContainText with timeout 20000ms\\u001b[22m\\n\\u001b[2m  - waiting for locator(\'.wc-block-components-product-name\')\\u001b[22m\\n\\n    at \\/qit\\/tests\\/e2e\\/woocommerce\\/activation\\/activation.spec.js:672:69",
                             "rawStatus": "failed",
                             "tags": [],
                             "type": "e2e",
@@ -386,7 +420,9 @@
                                     "path": "\\/qit\\/results\\/playwright\\/activation-Add-Product-Cart--test-Woocommerce-Run-\\/trace.zip"
                                 }
                             ],
-                            "stdout": [],
+                            "stdout": [
+                                "Console error: Failed to load resource: the server responded with a status of 500 (Internal Server Error)\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": []

--- a/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_generic_woorc_php74_wprc_334048b547066d6408232a37d57ddff2__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_generic_woorc_php74_wprc_334048b547066d6408232a37d57ddff2__1.php
@@ -174,7 +174,6 @@
                                 "Success: Installed 1 of 1 plugins.\\n",
                                 "Installing Twenty Twenty-Four (1.3)\\n",
                                 "Downloading installation package from https:\\/\\/downloads.wordpress.org\\/theme\\/twentytwentyfour.1.3.zip...\\n",
-                                "Using cached file \'\\/qit\\/cache\\/wp-cli\\/theme\\/twentytwentyfour-1.3.zip\'...\\n",
                                 "Unpacking the package...\\n",
                                 "Installing the theme...\\n",
                                 "Theme installed successfully.\\n",

--- a/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_parenttheme_woostable_php82_wpstable_4236e2db0915f662c3e5813c9b6224ab__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_parenttheme_woostable_php82_wpstable_4236e2db0915f662c3e5813c9b6224ab__1.php
@@ -174,7 +174,6 @@
                                 "Success: Installed 1 of 1 plugins.\\n",
                                 "Installing Twenty Twenty-Four (1.3)\\n",
                                 "Downloading installation package from https:\\/\\/downloads.wordpress.org\\/theme\\/twentytwentyfour.1.3.zip...\\n",
-                                "Using cached file \'\\/qit\\/cache\\/wp-cli\\/theme\\/twentytwentyfour-1.3.zip\'...\\n",
                                 "Unpacking the package...\\n",
                                 "Installing the theme...\\n",
                                 "Theme installed successfully.\\n",

--- a/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_parenttheme_woostable_php82_wpstable_4236e2db0915f662c3e5813c9b6224ab__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_parenttheme_woostable_php82_wpstable_4236e2db0915f662c3e5813c9b6224ab__1.php
@@ -212,6 +212,10 @@
                                 "Success: Updated \'woocommerce_coming_soon\' option.\\n",
                                 "Success: Updated \'woocommerce_store_pages_only\' option.\\n",
                                 "Coming soon mode disabled in beforeAll.\\n",
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
+                                "Console warning: `select` control in `@wordpress\\/data-controls` is deprecated since version 5.7. Please use built-in `resolveSelect` control in `@wordpress\\/data` instead.\\n",
+                                "Console warning: Bottom margin styles for wp.components.CheckboxControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n",
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
                                 "[INFO] Final sorted plugin list:\\n",
                                 " 1. \\"Query Monitor\\" (Dependencies: [])\\n",
                                 " 2. \\"WooCommerce\\" (Dependencies: [])\\n"
@@ -282,7 +286,14 @@
                             "steps": [],
                             "suite": "[test] Woocommerce (Run) > woocommerce\\/activation\\/activation.spec.js",
                             "attachments": [],
-                            "stdout": [],
+                            "stdout": [
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
+                                "Console warning: `select` control in `@wordpress\\/data-controls` is deprecated since version 5.7. Please use built-in `resolveSelect` control in `@wordpress\\/data` instead.\\n",
+                                "Console warning: Bottom margin styles for wp.components.CheckboxControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n",
+                                "Console warning: Bottom margin styles for wp.components.TextControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n",
+                                "Console warning: Bottom margin styles for wp.components.SelectControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n",
+                                "Console warning: Bottom margin styles for wp.components.ToggleControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": []
@@ -303,7 +314,17 @@
                             "steps": [],
                             "suite": "[test] Woocommerce (Run) > woocommerce\\/activation\\/activation.spec.js",
                             "attachments": [],
-                            "stdout": [],
+                            "stdout": [
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
+                                "Console warning: `select` control in `@wordpress\\/data-controls` is deprecated since version 5.7. Please use built-in `resolveSelect` control in `@wordpress\\/data` instead.\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 0dfadb931fb42d51a8c9a4494d5bbbdd, type: notice, message: Notice on all requests - Parent Theme, file: wp-content\\/themes\\/bistro\\/functions.php, line: 17}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
+                                "Console warning: `select` control in `@wordpress\\/data-controls` is deprecated since version 5.7. Please use built-in `resolveSelect` control in `@wordpress\\/data` instead.\\n",
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
+                                "Console warning: `select` control in `@wordpress\\/data-controls` is deprecated since version 5.7. Please use built-in `resolveSelect` control in `@wordpress\\/data` instead.\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": []
@@ -324,7 +345,21 @@
                             "steps": [],
                             "suite": "[test] Woocommerce (Run) > woocommerce\\/activation\\/activation.spec.js",
                             "attachments": [],
-                            "stdout": [],
+                            "stdout": [
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
+                                "Console warning: `select` control in `@wordpress\\/data-controls` is deprecated since version 5.7. Please use built-in `resolveSelect` control in `@wordpress\\/data` instead.\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 0dfadb931fb42d51a8c9a4494d5bbbdd, type: notice, message: Notice on all requests - Parent Theme, file: wp-content\\/themes\\/bistro\\/functions.php, line: 17}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 0dfadb931fb42d51a8c9a4494d5bbbdd, type: notice, message: Notice on all requests - Parent Theme, file: wp-content\\/themes\\/bistro\\/functions.php, line: 17}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
+                                "Console warning: `select` control in `@wordpress\\/data-controls` is deprecated since version 5.7. Please use built-in `resolveSelect` control in `@wordpress\\/data` instead.\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 0dfadb931fb42d51a8c9a4494d5bbbdd, type: notice, message: Notice on all requests - Parent Theme, file: wp-content\\/themes\\/bistro\\/functions.php, line: 17}\\n",
+                                "Console endGroup: console.groupEnd\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": []
@@ -345,7 +380,24 @@
                             "steps": [],
                             "suite": "[test] Woocommerce (Run) > woocommerce\\/activation\\/activation.spec.js",
                             "attachments": [],
-                            "stdout": [],
+                            "stdout": [
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
+                                "Console warning: `select` control in `@wordpress\\/data-controls` is deprecated since version 5.7. Please use built-in `resolveSelect` control in `@wordpress\\/data` instead.\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 0dfadb931fb42d51a8c9a4494d5bbbdd, type: notice, message: Notice on all requests - Parent Theme, file: wp-content\\/themes\\/bistro\\/functions.php, line: 17}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 0dfadb931fb42d51a8c9a4494d5bbbdd, type: notice, message: Notice on all requests - Parent Theme, file: wp-content\\/themes\\/bistro\\/functions.php, line: 17}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 0dfadb931fb42d51a8c9a4494d5bbbdd, type: notice, message: Notice on all requests - Parent Theme, file: wp-content\\/themes\\/bistro\\/functions.php, line: 17}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console error: Store \\"core\\/interface\\" is already registered.\\n",
+                                "Console warning: `select` control in `@wordpress\\/data-controls` is deprecated since version 5.7. Please use built-in `resolveSelect` control in `@wordpress\\/data` instead.\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 0dfadb931fb42d51a8c9a4494d5bbbdd, type: notice, message: Notice on all requests - Parent Theme, file: wp-content\\/themes\\/bistro\\/functions.php, line: 17}\\n",
+                                "Console endGroup: console.groupEnd\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": [
@@ -362,7 +414,7 @@
                             "start": 1111111111,
                             "stop": 2222222222,
                             "message": "Error: \\u001b[31mTimed out 20000ms waiting for \\u001b[39m\\u001b[2mexpect(\\u001b[22m\\u001b[31mlocator\\u001b[39m\\u001b[2m).\\u001b[22mtoContainText\\u001b[2m(\\u001b[22m\\u001b[32mexpected\\u001b[39m\\u001b[2m)\\u001b[22m\\n\\nLocator: locator(\'.wc-block-components-product-name\')\\nExpected string: \\u001b[32m\\"Test Product\\"\\u001b[39m\\nReceived: <element(s) not found>\\nCall log:\\n\\u001b[2m  - expect.toContainText with timeout 20000ms\\u001b[22m\\n\\u001b[2m  - waiting for locator(\'.wc-block-components-product-name\')\\u001b[22m\\n",
-                            "trace": "Error: \\u001b[31mTimed out 20000ms waiting for \\u001b[39m\\u001b[2mexpect(\\u001b[22m\\u001b[31mlocator\\u001b[39m\\u001b[2m).\\u001b[22mtoContainText\\u001b[2m(\\u001b[22m\\u001b[32mexpected\\u001b[39m\\u001b[2m)\\u001b[22m\\n\\nLocator: locator(\'.wc-block-components-product-name\')\\nExpected string: \\u001b[32m\\"Test Product\\"\\u001b[39m\\nReceived: <element(s) not found>\\nCall log:\\n\\u001b[2m  - expect.toContainText with timeout 20000ms\\u001b[22m\\n\\u001b[2m  - waiting for locator(\'.wc-block-components-product-name\')\\u001b[22m\\n\\n    at \\/qit\\/tests\\/e2e\\/woocommerce\\/activation\\/activation.spec.js:671:69",
+                            "trace": "Error: \\u001b[31mTimed out 20000ms waiting for \\u001b[39m\\u001b[2mexpect(\\u001b[22m\\u001b[31mlocator\\u001b[39m\\u001b[2m).\\u001b[22mtoContainText\\u001b[2m(\\u001b[22m\\u001b[32mexpected\\u001b[39m\\u001b[2m)\\u001b[22m\\n\\nLocator: locator(\'.wc-block-components-product-name\')\\nExpected string: \\u001b[32m\\"Test Product\\"\\u001b[39m\\nReceived: <element(s) not found>\\nCall log:\\n\\u001b[2m  - expect.toContainText with timeout 20000ms\\u001b[22m\\n\\u001b[2m  - waiting for locator(\'.wc-block-components-product-name\')\\u001b[22m\\n\\n    at \\/qit\\/tests\\/e2e\\/woocommerce\\/activation\\/activation.spec.js:672:69",
                             "rawStatus": "failed",
                             "tags": [],
                             "type": "e2e",
@@ -388,7 +440,9 @@
                                     "path": "\\/qit\\/results\\/playwright\\/activation-Add-Product-Cart--test-Woocommerce-Run-\\/trace.zip"
                                 }
                             ],
-                            "stdout": [],
+                            "stdout": [
+                                "Console error: Failed to load resource: the server responded with a status of 500 (Internal Server Error)\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": []

--- a/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_php82_woorc_php82_wprc_b401265b202fc3b86b98faf66ab1e3f7__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_php82_woorc_php82_wprc_b401265b202fc3b86b98faf66ab1e3f7__1.php
@@ -212,6 +212,7 @@
                                 "Success: Updated \'woocommerce_coming_soon\' option.\\n",
                                 "Success: Updated \'woocommerce_store_pages_only\' option.\\n",
                                 "Coming soon mode disabled in beforeAll.\\n",
+                                "Console warning: Bottom margin styles for wp.components.CheckboxControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n",
                                 "[INFO] Final sorted plugin list:\\n",
                                 " 1. \\"Query Monitor\\" (Dependencies: [])\\n",
                                 " 2. \\"WooCommerce\\" (Dependencies: [])\\n",
@@ -280,7 +281,12 @@
                             "steps": [],
                             "suite": "[test] Woocommerce (Run) > woocommerce\\/activation\\/activation.spec.js",
                             "attachments": [],
-                            "stdout": [],
+                            "stdout": [
+                                "Console warning: Bottom margin styles for wp.components.CheckboxControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n",
+                                "Console warning: Bottom margin styles for wp.components.TextControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n",
+                                "Console warning: Bottom margin styles for wp.components.SelectControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n",
+                                "Console warning: Bottom margin styles for wp.components.ToggleControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": []
@@ -301,7 +307,11 @@
                             "steps": [],
                             "suite": "[test] Woocommerce (Run) > woocommerce\\/activation\\/activation.spec.js",
                             "attachments": [],
-                            "stdout": [],
+                            "stdout": [
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 186e674c5a36642a5d0696dcd2ba795c, type: deprecated, message: Creation of dynamic property SUT\\\\BarUser::$bar is deprecated, file: wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php, line: 28}\\n",
+                                "Console endGroup: console.groupEnd\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": []
@@ -322,7 +332,18 @@
                             "steps": [],
                             "suite": "[test] Woocommerce (Run) > woocommerce\\/activation\\/activation.spec.js",
                             "attachments": [],
-                            "stdout": [],
+                            "stdout": [
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 186e674c5a36642a5d0696dcd2ba795c, type: deprecated, message: Creation of dynamic property SUT\\\\BarUser::$bar is deprecated, file: wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php, line: 28}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 186e674c5a36642a5d0696dcd2ba795c, type: deprecated, message: Creation of dynamic property SUT\\\\BarUser::$bar is deprecated, file: wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php, line: 28}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console warning: Navigation store is deprecated.\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 186e674c5a36642a5d0696dcd2ba795c, type: deprecated, message: Creation of dynamic property SUT\\\\BarUser::$bar is deprecated, file: wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php, line: 28}\\n",
+                                "Console endGroup: console.groupEnd\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": []
@@ -343,7 +364,20 @@
                             "steps": [],
                             "suite": "[test] Woocommerce (Run) > woocommerce\\/activation\\/activation.spec.js",
                             "attachments": [],
-                            "stdout": [],
+                            "stdout": [
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 186e674c5a36642a5d0696dcd2ba795c, type: deprecated, message: Creation of dynamic property SUT\\\\BarUser::$bar is deprecated, file: wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php, line: 28}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 186e674c5a36642a5d0696dcd2ba795c, type: deprecated, message: Creation of dynamic property SUT\\\\BarUser::$bar is deprecated, file: wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php, line: 28}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 186e674c5a36642a5d0696dcd2ba795c, type: deprecated, message: Creation of dynamic property SUT\\\\BarUser::$bar is deprecated, file: wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php, line: 28}\\n",
+                                "Console endGroup: console.groupEnd\\n",
+                                "Console startGroup: PHP Errors in Ajax Response\\n",
+                                "Console warning: {key: 186e674c5a36642a5d0696dcd2ba795c, type: deprecated, message: Creation of dynamic property SUT\\\\BarUser::$bar is deprecated, file: wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php, line: 28}\\n",
+                                "Console endGroup: console.groupEnd\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": [
@@ -368,7 +402,9 @@
                             "steps": [],
                             "suite": "[test] Woocommerce (Run) > woocommerce\\/activation\\/activation.spec.js",
                             "attachments": [],
-                            "stdout": [],
+                            "stdout": [
+                                "Console warning: showSpinner prop is deprecated and will be removed from WooCommerce in version 8.9.0. Please use Render a spinner in the button children instead. instead.\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": []
@@ -389,7 +425,10 @@
                             "steps": [],
                             "suite": "[test] Woocommerce (Run) > woocommerce\\/activation\\/activation.spec.js",
                             "attachments": [],
-                            "stdout": [],
+                            "stdout": [
+                                "Console warning: showSpinner prop is deprecated and will be removed from WooCommerce in version 8.9.0. Please use Render a spinner in the button children instead. instead.\\n",
+                                "Console warning: showSpinner prop is deprecated and will be removed from WooCommerce in version 8.9.0. Please use Render a spinner in the button children instead. instead.\\n"
+                            ],
                             "stderr": [],
                             "extra": {
                                 "annotations": []

--- a/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_php82_woorc_php82_wprc_b401265b202fc3b86b98faf66ab1e3f7__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_php82_woorc_php82_wprc_b401265b202fc3b86b98faf66ab1e3f7__1.php
@@ -174,7 +174,6 @@
                                 "Success: Installed 1 of 1 plugins.\\n",
                                 "Installing Twenty Twenty-Four (1.3)\\n",
                                 "Downloading installation package from https:\\/\\/downloads.wordpress.org\\/theme\\/twentytwentyfour.1.3.zip...\\n",
-                                "Using cached file \'\\/qit\\/cache\\/wp-cli\\/theme\\/twentytwentyfour-1.3.zip\'...\\n",
                                 "Unpacking the package...\\n",
                                 "Installing the theme...\\n",
                                 "Theme installed successfully.\\n",

--- a/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_with_custom_pages_woorc_php74_wprc_c88ead353ce4cbe8dc55a38d95020a2e__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_with_custom_pages_woorc_php74_wprc_c88ead353ce4cbe8dc55a38d95020a2e__1.php
@@ -310,12 +310,12 @@
                                 {
                                     "name": "00_Plugin_A",
                                     "contentType": "image\\/jpeg",
-                                    "path": "\\/qit\\/results\\/playwright\\/activation-Visit-wp-admin-pages-added-by-the-plugin--test-Woocommerce-Run-\\/attachments\\/00-Plugin-A-c32ffd34c2a7735d608bc38fc43d1766f1f634b0.jpg"
+                                    "path": "\\/qit\\/results\\/playwright\\/activation-Visit-wp-admin-pages-added-by-the-plugin--test-Woocommerce-Run-\\/attachments\\/00-Plugin-A-HASHNORMALIZED.jpg"
                                 },
                                 {
                                     "name": "01_Plugin_B",
                                     "contentType": "image\\/jpeg",
-                                    "path": "\\/qit\\/results\\/playwright\\/activation-Visit-wp-admin-pages-added-by-the-plugin--test-Woocommerce-Run-\\/attachments\\/01-Plugin-B-b832b7ace5937cb9a7bd9babad0abb367dcd0700.jpg"
+                                    "path": "\\/qit\\/results\\/playwright\\/activation-Visit-wp-admin-pages-added-by-the-plugin--test-Woocommerce-Run-\\/attachments\\/01-Plugin-B-HASHNORMALIZED.jpg"
                                 },
                                 {
                                     "name": "screenshot",
@@ -334,12 +334,12 @@
                                 }
                             ],
                             "stdout": [
-                                "Navigating to http:\\/\\/qitenvnginx67e68e2d4cece\\/wp-admin\\/admin.php?page=plugin-a\\n",
+                                "Navigating to http:\\/\\/qitenvnginxNORMALIZED\\/wp-admin\\/admin.php?page=plugin-a\\n",
                                 "Console log: Console Log in custom page.\\n",
                                 "Console warning: Console Warning in custom page.\\n",
                                 "Console error: Console Error in custom page.\\n",
-                                "Uncaught exception: \\"Error - Uncaught Error in custom page. - Error: Uncaught Error in custom page.\\n    at http:\\/\\/qitenvnginx67e68e2d4cece\\/wp-admin\\/admin.php?page=plugin-a:209:223\\"\\n",
-                                "Navigating to http:\\/\\/qitenvnginx67e68e2d4cece\\/wp-admin\\/admin.php?page=plugin-b\\n",
+                                "Uncaught exception: \\"Error - Uncaught Error in custom page. - Error: Uncaught Error in custom page.\\n    at http:\\/\\/qitenvnginxNORMALIZED\\/wp-admin\\/admin.php?page=plugin-a:209:223\\"\\n",
+                                "Navigating to http:\\/\\/qitenvnginxNORMALIZED\\/wp-admin\\/admin.php?page=plugin-b\\n",
                                 "Console error: Failed to load resource: the server responded with a status of 500 (Internal Server Error)\\n",
                                 "Console error: PHP Fatal Error: Uncaught Error: Call to undefined function call_to_an_undefined_function()\\n"
                             ],

--- a/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_with_custom_pages_woorc_php74_wprc_c88ead353ce4cbe8dc55a38d95020a2e__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_with_custom_pages_woorc_php74_wprc_c88ead353ce4cbe8dc55a38d95020a2e__1.php
@@ -269,6 +269,7 @@
                                 "Success: Updated \'woocommerce_coming_soon\' option.\\n",
                                 "Success: Updated \'woocommerce_store_pages_only\' option.\\n",
                                 "Coming soon mode disabled in beforeAll.\\n",
+                                "Console warning: Bottom margin styles for wp.components.CheckboxControl is deprecated since version 6.7 and will be removed in version 7.0. Note: Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version.\\n",
                                 "[INFO] Final sorted plugin list:\\n",
                                 " 1. \\"Query Monitor\\" (Dependencies: [])\\n",
                                 " 2. \\"WooCommerce\\" (Dependencies: [])\\n",
@@ -287,7 +288,7 @@
                             "start": 1111111111,
                             "stop": 2222222222,
                             "message": "Error: There was a fatal error in the debug log\\n\\n\\u001b[2mexpect(\\u001b[22m\\u001b[31mreceived\\u001b[39m\\u001b[2m).\\u001b[22mnot\\u001b[2m.\\u001b[22mtoContain\\u001b[2m(\\u001b[22m\\u001b[32mexpected\\u001b[39m\\u001b[2m) \\/\\/ indexOf\\u001b[22m\\n\\nExpected substring: not \\u001b[32m\\"Fatal error\\"\\u001b[39m\\nReceived string:        \\u001b[31m\\"[TIMESTAMP] PHP \\u001b[7mFatal error\\u001b[27m:  Uncaught Error: Call to undefined function call_to_an_undefined_function() in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php:29\\u001b[39m\\n\\u001b[31mStack trace:\\u001b[39m\\n\\u001b[31m#0 \\/var\\/www\\/html\\/wp-includes\\/class-wp-hook.php(324): {closure}(\'\')\\u001b[39m\\n\\u001b[31m#1 \\/var\\/www\\/html\\/wp-includes\\/class-wp-hook.php(348): WP_Hook->apply_filters(\'\', Array)\\u001b[39m\\n\\u001b[31m#2 \\/var\\/www\\/html\\/wp-includes\\/plugin.php(517): WP_Hook->do_action(Array)\\u001b[39m\\n\\u001b[31m#3 \\/var\\/www\\/html\\/wp-admin\\/admin.php(259): do_action(\'toplevel_page_p...\')\\u001b[39m\\n\\u001b[31m#4 {main}\\u001b[39m\\n\\u001b[31m  thrown in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 29\\"\\u001b[39m",
-                            "trace": "Error: There was a fatal error in the debug log\\n\\n\\u001b[2mexpect(\\u001b[22m\\u001b[31mreceived\\u001b[39m\\u001b[2m).\\u001b[22mnot\\u001b[2m.\\u001b[22mtoContain\\u001b[2m(\\u001b[22m\\u001b[32mexpected\\u001b[39m\\u001b[2m) \\/\\/ indexOf\\u001b[22m\\n\\nExpected substring: not \\u001b[32m\\"Fatal error\\"\\u001b[39m\\nReceived string:        \\u001b[31m\\"[TIMESTAMP] PHP \\u001b[7mFatal error\\u001b[27m:  Uncaught Error: Call to undefined function call_to_an_undefined_function() in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php:29\\u001b[39m\\n\\u001b[31mStack trace:\\u001b[39m\\n\\u001b[31m#0 \\/var\\/www\\/html\\/wp-includes\\/class-wp-hook.php(324): {closure}(\'\')\\u001b[39m\\n\\u001b[31m#1 \\/var\\/www\\/html\\/wp-includes\\/class-wp-hook.php(348): WP_Hook->apply_filters(\'\', Array)\\u001b[39m\\n\\u001b[31m#2 \\/var\\/www\\/html\\/wp-includes\\/plugin.php(517): WP_Hook->do_action(Array)\\u001b[39m\\n\\u001b[31m#3 \\/var\\/www\\/html\\/wp-admin\\/admin.php(259): do_action(\'toplevel_page_p...\')\\u001b[39m\\n\\u001b[31m#4 {main}\\u001b[39m\\n\\u001b[31m  thrown in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 29\\"\\u001b[39m\\n    at \\/qit\\/tests\\/e2e\\/woocommerce\\/activation\\/activation.spec.js:428:89\\n    at \\/qit\\/tests\\/e2e\\/woocommerce\\/activation\\/activation.spec.js:364:9",
+                            "trace": "Error: There was a fatal error in the debug log\\n\\n\\u001b[2mexpect(\\u001b[22m\\u001b[31mreceived\\u001b[39m\\u001b[2m).\\u001b[22mnot\\u001b[2m.\\u001b[22mtoContain\\u001b[2m(\\u001b[22m\\u001b[32mexpected\\u001b[39m\\u001b[2m) \\/\\/ indexOf\\u001b[22m\\n\\nExpected substring: not \\u001b[32m\\"Fatal error\\"\\u001b[39m\\nReceived string:        \\u001b[31m\\"[TIMESTAMP] PHP \\u001b[7mFatal error\\u001b[27m:  Uncaught Error: Call to undefined function call_to_an_undefined_function() in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php:29\\u001b[39m\\n\\u001b[31mStack trace:\\u001b[39m\\n\\u001b[31m#0 \\/var\\/www\\/html\\/wp-includes\\/class-wp-hook.php(324): {closure}(\'\')\\u001b[39m\\n\\u001b[31m#1 \\/var\\/www\\/html\\/wp-includes\\/class-wp-hook.php(348): WP_Hook->apply_filters(\'\', Array)\\u001b[39m\\n\\u001b[31m#2 \\/var\\/www\\/html\\/wp-includes\\/plugin.php(517): WP_Hook->do_action(Array)\\u001b[39m\\n\\u001b[31m#3 \\/var\\/www\\/html\\/wp-admin\\/admin.php(259): do_action(\'toplevel_page_p...\')\\u001b[39m\\n\\u001b[31m#4 {main}\\u001b[39m\\n\\u001b[31m  thrown in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 29\\"\\u001b[39m\\n    at \\/qit\\/tests\\/e2e\\/woocommerce\\/activation\\/activation.spec.js:429:89\\n    at \\/qit\\/tests\\/e2e\\/woocommerce\\/activation\\/activation.spec.js:365:9",
                             "rawStatus": "failed",
                             "tags": [],
                             "type": "e2e",
@@ -309,12 +310,12 @@
                                 {
                                     "name": "00_Plugin_A",
                                     "contentType": "image\\/jpeg",
-                                    "path": "\\/qit\\/results\\/playwright\\/activation-Visit-wp-admin-pages-added-by-the-plugin--test-Woocommerce-Run-\\/attachments\\/00-Plugin-A-81b6065ade9ef04d2c20d058d1b50ce06e6bcace.jpg"
+                                    "path": "\\/qit\\/results\\/playwright\\/activation-Visit-wp-admin-pages-added-by-the-plugin--test-Woocommerce-Run-\\/attachments\\/00-Plugin-A-f84bda60bb9659adea487e961571930c884dc70e.jpg"
                                 },
                                 {
                                     "name": "01_Plugin_B",
                                     "contentType": "image\\/jpeg",
-                                    "path": "\\/qit\\/results\\/playwright\\/activation-Visit-wp-admin-pages-added-by-the-plugin--test-Woocommerce-Run-\\/attachments\\/01-Plugin-B-15a35fc7d001164d9562509d213c6c1b3fe61135.jpg"
+                                    "path": "\\/qit\\/results\\/playwright\\/activation-Visit-wp-admin-pages-added-by-the-plugin--test-Woocommerce-Run-\\/attachments\\/01-Plugin-B-1929904332d7d2927a962ff537eb100fbf2961e5.jpg"
                                 },
                                 {
                                     "name": "screenshot",
@@ -333,9 +334,14 @@
                                 }
                             ],
                             "stdout": [
-                                "Navigating to http:\\/\\/qitenvnginx67e4930e6d77c\\/wp-admin\\/admin.php?page=plugin-a\\n",
-                                "Uncaught exception: \\"Error - Uncaught Error in custom page. - Error: Uncaught Error in custom page.\\n    at http:\\/\\/qitenvnginx67e4930e6d77c\\/wp-admin\\/admin.php?page=plugin-a:209:223\\"\\n",
-                                "Navigating to http:\\/\\/qitenvnginx67e4930e6d77c\\/wp-admin\\/admin.php?page=plugin-b\\n"
+                                "Navigating to http:\\/\\/qitenvnginx67e5853950adf\\/wp-admin\\/admin.php?page=plugin-a\\n",
+                                "Console log: Console Log in custom page.\\n",
+                                "Console warning: Console Warning in custom page.\\n",
+                                "Console error: Console Error in custom page.\\n",
+                                "Uncaught exception: \\"Error - Uncaught Error in custom page. - Error: Uncaught Error in custom page.\\n    at http:\\/\\/qitenvnginx67e5853950adf\\/wp-admin\\/admin.php?page=plugin-a:209:223\\"\\n",
+                                "Navigating to http:\\/\\/qitenvnginx67e5853950adf\\/wp-admin\\/admin.php?page=plugin-b\\n",
+                                "Console error: Failed to load resource: the server responded with a status of 500 (Internal Server Error)\\n",
+                                "Console error: PHP Fatal Error: Uncaught Error: Call to undefined function call_to_an_undefined_function()\\n"
                             ],
                             "stderr": [],
                             "extra": {

--- a/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_with_custom_pages_woorc_php74_wprc_c88ead353ce4cbe8dc55a38d95020a2e__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_with_custom_pages_woorc_php74_wprc_c88ead353ce4cbe8dc55a38d95020a2e__1.php
@@ -231,7 +231,6 @@
                                 "Success: Installed 1 of 1 plugins.\\n",
                                 "Installing Twenty Twenty-Four (1.3)\\n",
                                 "Downloading installation package from https:\\/\\/downloads.wordpress.org\\/theme\\/twentytwentyfour.1.3.zip...\\n",
-                                "Using cached file \'\\/qit\\/cache\\/wp-cli\\/theme\\/twentytwentyfour-1.3.zip\'...\\n",
                                 "Unpacking the package...\\n",
                                 "Installing the theme...\\n",
                                 "Theme installed successfully.\\n",

--- a/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_with_custom_pages_woorc_php74_wprc_c88ead353ce4cbe8dc55a38d95020a2e__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_with_custom_pages_woorc_php74_wprc_c88ead353ce4cbe8dc55a38d95020a2e__1.php
@@ -310,12 +310,12 @@
                                 {
                                     "name": "00_Plugin_A",
                                     "contentType": "image\\/jpeg",
-                                    "path": "\\/qit\\/results\\/playwright\\/activation-Visit-wp-admin-pages-added-by-the-plugin--test-Woocommerce-Run-\\/attachments\\/00-Plugin-A-f84bda60bb9659adea487e961571930c884dc70e.jpg"
+                                    "path": "\\/qit\\/results\\/playwright\\/activation-Visit-wp-admin-pages-added-by-the-plugin--test-Woocommerce-Run-\\/attachments\\/00-Plugin-A-c32ffd34c2a7735d608bc38fc43d1766f1f634b0.jpg"
                                 },
                                 {
                                     "name": "01_Plugin_B",
                                     "contentType": "image\\/jpeg",
-                                    "path": "\\/qit\\/results\\/playwright\\/activation-Visit-wp-admin-pages-added-by-the-plugin--test-Woocommerce-Run-\\/attachments\\/01-Plugin-B-1929904332d7d2927a962ff537eb100fbf2961e5.jpg"
+                                    "path": "\\/qit\\/results\\/playwright\\/activation-Visit-wp-admin-pages-added-by-the-plugin--test-Woocommerce-Run-\\/attachments\\/01-Plugin-B-b832b7ace5937cb9a7bd9babad0abb367dcd0700.jpg"
                                 },
                                 {
                                     "name": "screenshot",
@@ -334,12 +334,12 @@
                                 }
                             ],
                             "stdout": [
-                                "Navigating to http:\\/\\/qitenvnginx67e5853950adf\\/wp-admin\\/admin.php?page=plugin-a\\n",
+                                "Navigating to http:\\/\\/qitenvnginx67e68e2d4cece\\/wp-admin\\/admin.php?page=plugin-a\\n",
                                 "Console log: Console Log in custom page.\\n",
                                 "Console warning: Console Warning in custom page.\\n",
                                 "Console error: Console Error in custom page.\\n",
-                                "Uncaught exception: \\"Error - Uncaught Error in custom page. - Error: Uncaught Error in custom page.\\n    at http:\\/\\/qitenvnginx67e5853950adf\\/wp-admin\\/admin.php?page=plugin-a:209:223\\"\\n",
-                                "Navigating to http:\\/\\/qitenvnginx67e5853950adf\\/wp-admin\\/admin.php?page=plugin-b\\n",
+                                "Uncaught exception: \\"Error - Uncaught Error in custom page. - Error: Uncaught Error in custom page.\\n    at http:\\/\\/qitenvnginx67e68e2d4cece\\/wp-admin\\/admin.php?page=plugin-a:209:223\\"\\n",
+                                "Navigating to http:\\/\\/qitenvnginx67e68e2d4cece\\/wp-admin\\/admin.php?page=plugin-b\\n",
                                 "Console error: Failed to load resource: the server responded with a status of 500 (Internal Server Error)\\n",
                                 "Console error: PHP Fatal Error: Uncaught Error: Call to undefined function call_to_an_undefined_function()\\n"
                             ],

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_delete_products_woorc_php74_wprc_b153920e11128a2003ccfabb5a1c2b66__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_delete_products_woorc_php74_wprc_b153920e11128a2003ccfabb5a1c2b66__1.php
@@ -33,12 +33,6 @@
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
             "test_summary": "Delete_Products Normalized Summary",
-            "debug_log": [
-                {
-                    "count": "0",
-                    "message": "Debug log is ignored for woo-e2e\\/delete_products tests."
-                }
-            ],
             "version": "Undefined",
             "update_complete": true,
             "ai_suggestion_status": "none",
@@ -50,13 +44,22 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_result_json_extracted": "{EXTRACTED}",
-            "ctrf_json_extracted": "{EXTRACTED}"
+            "ctrf_json_extracted": "{EXTRACTED}",
+            "debug_log_extracted": "{EXTRACTED}"
         },
         {
             "test_result_json": []
         },
         {
             "ctrf_json": []
+        },
+        {
+            "debug_log": [
+                {
+                    "count": "0",
+                    "message": "Debug log is ignored for woo-e2e\\/delete_products tests."
+                }
+            ]
         }
     ]
 ]';


### PR DESCRIPTION
Adds bits and pieces of the activation test output for snapshot testing used on our self-tests.

Some of these changes came in after we updated Playwright to 1.51.1