### PR TITLE
PoC: Setup ZAP in the test environment to run passive checks through the activation tests

### DIFF
--- a/src/src/Environment/Environments/E2E/E2EEnvInfo.php
+++ b/src/src/Environment/Environments/E2E/E2EEnvInfo.php
@@ -57,4 +57,10 @@ class E2EEnvInfo extends EnvInfo {
 
 	/** @var string The playwright test tag to be executed*/
 	public $pw_test_tag = '';
+
+	/** @var string The ZAP container name. */
+	public $zap_container;
+
+	/** @var string The ZAP proxy URL. */
+	public $zap_proxy;
 }

--- a/src/src/Environment/Environments/E2E/E2EEnvironment.php
+++ b/src/src/Environment/Environments/E2E/E2EEnvironment.php
@@ -124,6 +124,46 @@ class E2EEnvironment extends Environment {
 			);
 			$theme_activation->auto_activate_themes();
 		}
+
+		// Install Zaproxy for E2E security checks.
+		if ( getenv( 'QIT_SECURITY_CHECKS_PROXY' ) ) {
+			$this->output->writeln( '<info>Setting up Zaproxy for E2E security checks...</info>' );
+			$zap_image = 'zaproxy/zap-stable';
+			$zap_container_name = "qit_env_zap_{$this->env_info->env_id}";
+			$zap_port = 8079;
+
+			// Pull the ZAP image if needed
+			App::make( Docker::class )->maybe_pull_image( $zap_image );
+
+			// Run the ZAP container.
+			// Start ZAP container
+			$process = new Process([
+				App::make(Docker::class)->find_docker(),
+				'run',
+				'-d',
+				'-p', "{$zap_port}:{$zap_port}",
+				"--name=$zap_container_name",
+				"--network={$this->env_info->docker_network}",
+				$zap_image,
+				'zap.sh',
+				'-daemon',
+				'-host', '0.0.0.0',
+				'-port', $zap_port,
+				'-config', 'api.addrs.addr.name=.*',
+				'-config', 'api.addrs.addr.regex=true',
+				'-config', 'api.disablekey=true'
+			]);
+
+			$process->setTimeout(300);
+      $process->run();
+
+			// Store ZAP info in environment
+			$this->env_info->zap_container = $zap_container_name;
+			$this->env_info->zap_proxy = "http://host.docker.internal:$zap_port";
+
+			// Wait for ZAP to be ready
+			$this->wait_for_zap_ready($zap_container_name);
+		}
 	}
 
 	protected function additional_output(): void {
@@ -253,5 +293,39 @@ class E2EEnvironment extends Environment {
 		$default_volumes['/var/www/html'] = $named_volume;
 
 		return $default_volumes;
+	}
+
+	protected function wait_for_zap_ready( string $zap_container_name, int $timeout = 120 ): void {
+		$this->output->writeln( '<info>Waiting for Zaproxy to be ready...</info>' );
+		
+		$start = time();
+		while ( ( time() - $start ) < $timeout ) {
+			// Simple check: try to get ZAP version
+			$check_process = new Process( [
+				App::make( Docker::class )->find_docker(),
+				'exec',
+				$zap_container_name,
+				'curl',
+				'-s',
+				'-L',
+				'--fail',
+				"{$this->env_info->zap_proxy}/JSON/core/view/version/"
+			] );
+			
+			$check_process->run();
+			
+			if ( $check_process->isSuccessful() ) {
+				$this->output->writeln( '<info>Zaproxy is ready!</info>' );
+				return;
+			}
+			
+			sleep( 2 );
+		}
+		
+		throw new \RuntimeException( sprintf(
+			'Zaproxy container (%s) failed to start within %d seconds',
+			$zap_container_name,
+			$timeout
+	) );
 	}
 }

--- a/src/src/Environment/Environments/E2E/E2EEnvironment.php
+++ b/src/src/Environment/Environments/E2E/E2EEnvironment.php
@@ -127,16 +127,20 @@ class E2EEnvironment extends Environment {
 
 		// Install Zaproxy for E2E security checks.
 		if ( getenv( 'QIT_SECURITY_CHECKS_PROXY' ) ) {
-			$this->output->writeln( '<info>Setting up Zaproxy for E2E security checks...</info>' );
 			$zap_image = 'zaproxy/zap-stable';
 			$zap_container_name = "qit_env_zap_{$this->env_info->env_id}";
 			$zap_port = 8079;
+			$rule_ids_to_disable = [
+				'10011', '10035', '10040', '10041', '10042', '10020', '10038',
+				'10055', '10021', '10037', '10036', '10033', '10034', '2', '3',
+				'90001', '10032', '10061', '10039', '10052', '10056', '90030',
+				'10015', '10050', '10096', '10105', '10098',
+			];
 
-			// Pull the ZAP image if needed
+			$this->output->writeln( '<info>Setting up Zaproxy for E2E security checks...</info>' );
 			App::make( Docker::class )->maybe_pull_image( $zap_image );
 
-			// Run the ZAP container.
-			// Start ZAP container
+			// Start ZAP container.
 			$process = new Process([
 				App::make(Docker::class)->find_docker(),
 				'run',
@@ -161,8 +165,8 @@ class E2EEnvironment extends Environment {
 			$this->env_info->zap_container = $zap_container_name;
 			$this->env_info->zap_proxy = "http://host.docker.internal:$zap_port";
 
-			// Wait for ZAP to be ready
-			$this->wait_for_zap_ready($zap_container_name);
+			$this->wait_for_zap_ready();
+			$this->disable_zap_rules( $rule_ids_to_disable );
 		}
 	}
 
@@ -295,7 +299,7 @@ class E2EEnvironment extends Environment {
 		return $default_volumes;
 	}
 
-	protected function wait_for_zap_ready( string $zap_container_name, int $timeout = 120 ): void {
+	protected function wait_for_zap_ready( int $timeout = 120 ): void {
 		$this->output->writeln( '<info>Waiting for Zaproxy to be ready...</info>' );
 		
 		$start = time();
@@ -304,7 +308,7 @@ class E2EEnvironment extends Environment {
 			$check_process = new Process( [
 				App::make( Docker::class )->find_docker(),
 				'exec',
-				$zap_container_name,
+				$this->env_info->zap_container,
 				'curl',
 				'-s',
 				'-L',
@@ -324,8 +328,39 @@ class E2EEnvironment extends Environment {
 		
 		throw new \RuntimeException( sprintf(
 			'Zaproxy container (%s) failed to start within %d seconds',
-			$zap_container_name,
+			$this->env_info->zap_container,
 			$timeout
 	) );
+	}
+
+	protected function disable_zap_rules( array $rule_ids ): void {
+		$this->output->writeln( "Disabling specified passive scan rules via API..." );
+
+		$process = new Process( [
+			App::make( Docker::class )->find_docker(),
+			'exec',
+			$this->env_info->zap_container,
+			'curl',
+			'-s',
+			'-L',
+			'--fail',
+			"{$this->env_info->zap_proxy}/JSON/pscan/action/disableScanners/?ids=" . urlencode( implode( ',', $rule_ids ) )
+		] );
+
+		$process->run();
+
+		// Check if the process was successful
+		if ( $process->isSuccessful() ) {
+			$output = $process->getOutput();
+			$result = json_decode( $output, true );
+			
+			if ( isset( $result['Result'] ) && $result['Result'] === 'OK' ) {
+					echo "Successfully disabled all passive scan rules in ZAP\n";
+			} else {
+					echo "Request succeeded but returned unexpected response: " . $output . "\n";
+			}
+		} else {
+			echo "Failed to disable passive scan rules: " . $process->getErrorOutput() . "\n";
+		}
 	}
 }

--- a/src/src/Environment/Environments/Environment.php
+++ b/src/src/Environment/Environments/Environment.php
@@ -326,6 +326,28 @@ abstract class Environment {
 		$output              = $output ?? App::make( OutputInterface::class );
 		$environment_monitor = App::make( EnvironmentMonitor::class );
 
+		if ( getenv( 'QIT_SECURITY_CHECKS_PROXY' ) ) {
+			$zap_container_name = "qit_env_zap_{$env_info->env_id}";
+			try {
+				$down_zap_process = new Process( [
+					App::make( Docker::class )->find_docker(),
+					'rm',
+					'-f',
+					$zap_container_name,
+				] );
+
+				$down_zap_process->run();
+
+				if ( $output->isVerbose() ) {
+					$output->writeln( "Removed Zaproxy container: $zap_container_name" );
+				}
+			} catch ( \Exception $e ) {
+				if ( $output->isVerbose() ) {
+					$output->writeln( "<comment>Failed to remove Zaproxy container: {$e->getMessage()}</comment>" );
+				}
+			}
+		}
+
 		if ( ! file_exists( $env_info->temporary_env ) ) {
 			if ( $output->isVerbose() ) {
 				$output->writeln( sprintf( 'Tried to stop environment %s, but it does not exist.', $env_info->temporary_env ) );

--- a/src/src/LocalTests/E2E/Runner/PlaywrightRunner.php
+++ b/src/src/LocalTests/E2E/Runner/PlaywrightRunner.php
@@ -73,6 +73,12 @@ class PlaywrightRunner extends E2ERunner {
 			}
 		}
 
+		// Special setting for running security checks on Playwright tests through Zaproxy.
+		if ( getenv( 'QIT_SECURITY_CHECKS_PROXY' ) ) {
+			$env_info->playwright_config['use']['ignoreHTTPSErrors'] = true;
+			$env_info->playwright_config['use']['proxy']['server'] = $env_info->zap_proxy;
+		}
+
 		// Generate playwright-config.
 		$process = new Process( [ PHP_BINARY, $env_info->temporary_env . '/playwright/playwright-config-generator.php' ] );
 		$process->setEnv( [
@@ -449,6 +455,74 @@ class PlaywrightRunner extends E2ERunner {
 		}
 
 		$exit_status_code = $playwright_process->getExitCode();
+
+		/*
+		 * Download ZAP report if security checks were enabled.
+		 */
+		if ( getenv( 'QIT_SECURITY_CHECKS_PROXY' ) && $exit_status_code !== 143 ) {
+			$this->output->writeln( '<info>Downloading ZAP reports...</info>' );
+			
+			// Generate the report in JSON format
+			$generate_report_process = new Process( [
+				App::make( Docker::class )->find_docker(),
+				'exec',
+				$env_info->zap_container,
+				'curl',
+				'-s',
+				'-X',
+				'GET',
+				"{$env_info->zap_proxy}/JSON/reports/action/generate/?title=Zap+Report&template=traditional-json&theme=&description=&contexts=&sites=&sections=&includedConfidences=&includedRisks=&reportFileName=zap-report&reportFileNamePattern=&reportDir=&display="
+			] );
+
+			$generate_report_process->run();
+
+			if ( $generate_report_process->isSuccessful() && isset( json_decode( $generate_report_process->getOutput(), true )['generate'] ) ) {
+				$report_types = [
+					'html' => '/OTHER/core/other/htmlreport/',
+					'json' => '/OTHER/core/other/jsonreport/'
+				];
+
+				$success = true;
+				foreach ( $report_types as $type => $endpoint ) {
+					// Download report
+					$download_process = new Process( [
+						App::make( Docker::class )->find_docker(),
+						'exec',
+						$env_info->zap_container,
+						'curl',
+						'-s',
+						'-o',
+						"/tmp/zap-report.{$type}",
+						"{$env_info->zap_proxy}{$endpoint}",
+					] );
+
+					$download_process->run();
+
+					if ( $download_process->isSuccessful() ) {
+						// Copy report to host
+						$copy_process = new Process( [
+							App::make( Docker::class )->find_docker(),
+							'cp',
+							"{$env_info->zap_container}:/tmp/zap-report.{$type}",
+							$results_dir . "/zap-report.{$type}",
+						] );
+
+						$copy_process->run();
+						$success = $success && $copy_process->isSuccessful();
+					} else {
+						$success = false;
+					}
+				}
+
+				if ( $success ) {
+					$this->output->writeln( '<info>ZAP reports downloaded successfully.</info>' );
+				} else {
+					$this->output->writeln( '<error>Failed to download or copy ZAP reports.</error>' );
+				}
+			} else {
+				$this->output->writeln( '<error>Failed to generate ZAP report.</error>' );
+			}
+		}
 
 		/*
 		 * Upload test media if test not aborted.


### PR DESCRIPTION
This PR aims to introduce [OWASP ZAP](https://www.zaproxy.org/) as a pentesting tool to perform security checks passively on the Playwright tests by using it as a proxy.

In concrete, this PoC covers checking the feasibility of adding such feature, analyzing the behaviour of the QIT in that condition and overcome the main challenges we might find when setting up ZAP together with Playwright.

Below you can find the flows performed by the QIT when running Playwright tests both without the changes from this PR and with it.

#### Without the changes from this PR:

```mermaid
flowchart LR
    QIT --> PlaywrightTests
    PlaywrightTests -->|E2E tests<br/>API tests| SUT

    QIT[QIT]
    PlaywrightTests[Playwright Tests]
    SUT[SUT]
```

#### With the changes from this PR:

```mermaid
flowchart LR
    QIT --> PlaywrightTests
    PlaywrightTests -->|Proxy| ZAP
    ZAP -->|E2E tests<br/>API tests<br/>Security checks| SUT

    QIT[QIT]
    PlaywrightTests[Playwright Tests]
    ZAP[ZAP]
    SUT[SUT]
```

By setting ZAP as a proxy in Playwright, we will be able to run Playwright tests as usual, but now ZAP will perform security checks on all pages captured during the Playwright tests (no matter if they are E2E or API), generating a report at the end of the execution.

This new feature is controlled by a new environment variable `QIT_SECURITY_CHECKS_PROXY` in a way that - when enabled - it will start a container with ZAP running in daemon mode, configure Playwright to use it as a proxy, generate the security reports and turn down the new ZAP container together with the rest of the environment at the end of the flow.

### Changes introduced in this PR
* The [E2EEnvironment](https://github.com/woocommerce/qit-cli/pull/287/files#diff-23ba4b6b4986f6b92dd16e84b38e596ec74f799c52034880c1dd6a39cf64f217) class was updated to start a container with ZAP running in daemon mode when setting up the environment if `QIT_SECURITY_CHECKS_PROXY` is enabled.
* The [E2EEnvInfo](https://github.com/woocommerce/qit-cli/pull/287/files#diff-95e2dfe0992fdd4a6220210bc472e8f1a63110a2915792c698693b9796de764a) class was updated with 2 new attributes * zap_container and zap_proxy, some values that we need in other parts of our code.
* The [Environment](https://github.com/woocommerce/qit-cli/pull/287/files#diff-885aa6c6bc0ffb1f725afc8602067c3fede8d4ca6cf5915ec42cb5f8c2361f6b) class was updated to teardown the ZAP container (if `QIT_SECURITY_CHECKS_PROXY` is enabled) together with the rest of the environment.
* The [PlaywrightRunner](https://github.com/woocommerce/qit-cli/pull/287/files#diff-88948c4bd60aae5dc5e9c78fafe8e6357cc46f7ec036694b141a9dd3111a0431) class was updated to set the ZAP proxy in the Playwright config and include the reports as part of the test artifacts if `QIT_SECURITY_CHECKS_PROXY` is enabled.

### Testing instructions
* Checkout to this branch.
* Start the [Compatibility Dashboard](https://github.com/Automattic/compatibility-dashboard) local environment.
* Configure QIT-CLI to use the local backend - `php src/qit-cli.php backend:add`, then choose `Local`.
* Run the activation tests with the security checks flag enabled - `QIT_SECURITY_CHECKS_PROXY=1 php src/qit-cli.php run:activation automatewoo`.
* Check in the terminal logs that Zaproxy was installed successfully - you should see something like:
```
Setting up Zaproxy for E2E security checks...
Waiting for Zaproxy to be ready...
Zaproxy is ready!
```
* Once the tests have finished running, make sure they passed and 2 new items are included with the test artifacts folder: `zap-report.html` and `zap-report.json`.
* Open these reports and verify that requests were indeed captured by ZAP and security rules were applied to it (attaching a JSON report for reference - [zap-report.json](https://github.com/user-attachments/files/19871906/zap-report.json))
