### PR TITLE
Self-test enh: allow to use --one-of-each to test that all test types are working

### DIFF
--- a/_tests/managed_tests/QITSelfTests.php
+++ b/_tests/managed_tests/QITSelfTests.php
@@ -32,7 +32,7 @@ $validator->validate();
 $liveOutput                  = new QITLiveOutput();
 $tests_based_on_custom_tests = [ 'activation' ];
 
-$testManager  = new TestManager( $logger, $tests_based_on_custom_tests );
+$testManager  = new TestManager( $logger, $tests_based_on_custom_tests, $config->is_one_of_each() );
 $test_types   = $testManager->get_test_types();
 $test_types   = $testManager->filter_test_types( $test_types );
 $tests_to_run = $testManager->generate_test_runs( $test_types );

--- a/_tests/managed_tests/QITSelfTests.php
+++ b/_tests/managed_tests/QITSelfTests.php
@@ -32,7 +32,7 @@ $validator->validate();
 $liveOutput                  = new QITLiveOutput();
 $tests_based_on_custom_tests = [ 'activation' ];
 
-$testManager  = new TestManager( $logger, $tests_based_on_custom_tests, $config->is_one_of_each() );
+$testManager  = new TestManager( $logger, $tests_based_on_custom_tests, $config->one_of_each );
 $test_types   = $testManager->get_test_types();
 $test_types   = $testManager->filter_test_types( $test_types );
 $tests_to_run = $testManager->generate_test_runs( $test_types );

--- a/_tests/managed_tests/src/Config.php
+++ b/_tests/managed_tests/src/Config.php
@@ -4,7 +4,7 @@ class Config {
 	private $params;
 	private $logger;
 	private $tests_based_on_custom_tests = [ 'activation' ];
-	private $one_of_each = false;
+	public $one_of_each = false;
 
 	public function __construct( $argv, Logger $logger ) {
 		$this->params = $argv;
@@ -14,20 +14,77 @@ class Config {
 	public function parse() {
 		$this->logger->log( "Script started with params: " . implode( ' ', $this->params ) );
 
-		// Handle debug mode
-		if ( ( $debugKey = array_search( '--debug', $this->params, true ) ) !== false ) {
+		/**
+		 * We’ll separate flags (anything starting with "--")
+		 * from positional arguments (action, test types, scenarios).
+		 *
+		 * By convention, $argv[0] is the script name. We skip that and
+		 * parse everything else from $argv[1], $argv[2], etc.
+		 */
+		$flags      = [];
+		$positional = [];
+		$allButZero = array_slice( $this->params, 1 ); // skip $argv[0] (the script name)
+
+		foreach ( $allButZero as $arg ) {
+			// If argument starts with "--", treat it as an option/flag
+			if ( strpos( $arg, '--' ) === 0 ) {
+				$flags[] = $arg;
+			} else {
+				$positional[] = $arg;
+			}
+		}
+
+		// ----------------------------------------------------
+		// 1) Parse flags (e.g. --debug, --one-of-each, --env_filter, etc.)
+		// ----------------------------------------------------
+
+		// --debug => enable debug mode
+		if ( in_array( '--debug', $flags, true ) ) {
 			Context::$debug_mode = true;
-			unset( $this->params[ $debugKey ] );
 			$this->logger->log( "Debug mode enabled" );
 		}
 
-		Context::$action = $this->params[1] ?? 'run';
+		// --one-of-each => run only one scenario per test type (prefer no_op)
+		if ( in_array( '--one-of-each', $flags, true ) ) {
+			$this->one_of_each = true;
+			$this->logger->log( "one-of-each mode enabled" );
+		}
+
+		/**
+		 * --env_filter=key=value => Example: --env_filter=wp=6.1
+		 * We might have multiple of these. We'll parse them all.
+		 */
+		Context::$env_filters = [];
+		foreach ( $flags as $flag ) {
+			if ( strpos( $flag, '--env_filter=' ) === 0 ) {
+				// e.g. "--env_filter=wp=6.0" => want to parse "wp=6.0"
+				$raw = substr( $flag, strlen( '--env_filter=' ) );
+				[ $key, $value ] = explode( '=', $raw, 2 );
+
+				if ( array_key_exists( $key, Context::$env_filters ) ) {
+					$this->logger->log( "Duplicate env filter key '{$key}' found." );
+					maybe_echo( "Duplicate env filter key '{$key}' found.\n" );
+					die( 1 );
+				}
+				Context::$env_filters[ $key ] = $value;
+				$this->logger->log( "Env filter: $key = $value" );
+			}
+		}
+
+		// ----------------------------------------------------
+		// 2) Parse positional args: [0] => action, [1] => test types, [2] => scenarios
+		// ----------------------------------------------------
+
+		// Action (e.g. "run", "update")
+		Context::$action = $positional[0] ?? 'run';
 		$this->logger->log( "Action: " . Context::$action );
 
-		// Test types
-		if ( isset( $this->params[2] ) ) {
-			Context::$test_types = array_map( 'trim', explode( ',', $this->params[2] ) );
+		// Test types (comma-separated)
+		if ( isset( $positional[1] ) && $positional[1] !== '' ) {
+			Context::$test_types = array_map( 'trim', explode( ',', $positional[1] ) );
 			$this->logger->log( "Requested test types: " . implode( ',', Context::$test_types ) );
+
+			// If multiple test types, ensure none is a "custom-test" type
 			if ( count( Context::$test_types ) > 1 ) {
 				foreach ( $this->tests_based_on_custom_tests as $custom_test ) {
 					if ( in_array( $custom_test, Context::$test_types, true ) ) {
@@ -38,49 +95,31 @@ class Config {
 				}
 			}
 		} else {
+			// If not specified, treat as "run all test types"
 			Context::$test_types = null;
 			$this->logger->log( "No specific test types requested" );
 		}
 
+		// Mark whether we are running a custom test
 		Context::$running_test_based_on_custom_test = ! is_null( Context::$test_types )
 		                                              && count( array_intersect( Context::$test_types, $this->tests_based_on_custom_tests ) ) > 0;
 
-		// Scenarios
-		if ( isset( $this->params[3] ) ) {
-			$scenarios          = array_map( 'trim', explode( ',', $this->params[3] ) );
-			$scenarios          = array_filter( $scenarios, static function ( $v ) {
+		// Scenarios (comma-separated)
+		if ( isset( $positional[2] ) && $positional[2] !== '' ) {
+			$scenarios = array_map( 'trim', explode( ',', $positional[2] ) );
+			/**
+			 * If you want to strip out anything that starts with "--",
+			 * just in case, but realistically we've already separated them.
+			 */
+			$scenarios = array_filter( $scenarios, static function ( $v ) {
 				return strpos( $v, "--" ) !== 0;
 			} );
+
 			Context::$scenarios = empty( $scenarios ) ? null : $scenarios;
 			$this->logger->log( "Scenarios requested: " . implode( ',', Context::$scenarios ?? [] ) );
 		} else {
 			Context::$scenarios = null;
 			$this->logger->log( "No specific scenarios requested" );
-		}
-
-		// Env filters
-		Context::$env_filters = [];
-		foreach (
-			array_filter( $this->params, static function ( $param ) {
-				return strpos( $param, '--env_filter=' ) === 0;
-			} ) as $env_filter
-		) {
-			[ $key, $value ] = explode( '=', substr( $env_filter, 13 ), 2 );
-
-			if ( array_key_exists( $key, Context::$env_filters ) ) {
-				$this->logger->log( "Duplicate key '{$key}' found in env filters." );
-				maybe_echo( "Duplicate key '{$key}' found in env filters." );
-				die( 1 );
-			}
-
-			Context::$env_filters[ $key ] = $value;
-			$this->logger->log( "Env filter: $key = $value" );
-		}
-
-		// One of each will run only one test of each test type.
-		if ( in_array( '--one-of-each', $this->params, true ) ) {
-			$this->one_of_each = true;
-			$this->logger->log( "one-of-each mode enabled" );
 		}
 	}
 }

--- a/_tests/managed_tests/src/Config.php
+++ b/_tests/managed_tests/src/Config.php
@@ -4,6 +4,7 @@ class Config {
 	private $params;
 	private $logger;
 	private $tests_based_on_custom_tests = [ 'activation' ];
+	private $one_of_each = false;
 
 	public function __construct( $argv, Logger $logger ) {
 		$this->params = $argv;
@@ -74,6 +75,12 @@ class Config {
 
 			Context::$env_filters[ $key ] = $value;
 			$this->logger->log( "Env filter: $key = $value" );
+		}
+
+		// One of each will run only one test of each test type.
+		if ( in_array( '--one-of-each', $this->params, true ) ) {
+			$this->one_of_each = true;
+			$this->logger->log( "one-of-each mode enabled" );
 		}
 	}
 }

--- a/_tests/managed_tests/src/TestManager.php
+++ b/_tests/managed_tests/src/TestManager.php
@@ -3,10 +3,12 @@
 class TestManager {
 	private $logger;
 	private $tests_based_on_custom_tests;
+	private $one_of_each;
 
-	public function __construct( Logger $logger, array $tests_based_on_custom_tests ) {
+	public function __construct( Logger $logger, array $tests_based_on_custom_tests, bool $one_of_each ) {
 		$this->logger                      = $logger;
 		$this->tests_based_on_custom_tests = $tests_based_on_custom_tests;
+		$this->one_of_each                 = $one_of_each;
 	}
 
 	public function get_test_types(): array {
@@ -88,7 +90,27 @@ class TestManager {
 
 		foreach ( $test_types as $test_type ) {
 			$tests_to_run[ basename( $test_type ) ] = [];
-			foreach ( $this->get_tests_in_test_type( $test_type ) as $test ) {
+
+			$scenarios = $this->get_tests_in_test_type( $test_type );
+
+			// If --one-of-each is set, pick exactly one scenario (prefer no_op)
+			if ( $this->one_of_each && ! empty( $scenarios ) ) {
+				$no_op_path = null;
+				foreach ( $scenarios as $scenario_path ) {
+					if ( basename( $scenario_path ) === 'no_op' ) {
+						$no_op_path = $scenario_path;
+						break;
+					}
+				}
+				if ( $no_op_path ) {
+					$scenarios = [ $no_op_path ];
+				} else {
+					// pick the first scenario if no_op doesn’t exist
+					$scenarios = [ reset( $scenarios ) ];
+				}
+			}
+			
+			foreach ( $scenarios as $test ) {
 				// Scenario filtering
 				if ( ! is_null( Context::$scenarios ) ) {
 					if ( ! in_array( basename( $test ), Context::$scenarios ) ) {


### PR DESCRIPTION
I've added this as a convenience to test the removal of Setup PHP, it just runs one test of each type for the self-test, which is just a convenience to run one scenario instead of multiple scenarios per test type.