### PR TITLE
Using ubuntu-latest for workflow

### DIFF
--- a/.github/workflows/qit-self-group-test.yml
+++ b/.github/workflows/qit-self-group-test.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   self_test_custom_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       NO_COLOR: 1
       QIT_DISABLE_ONBOARDING: yes

--- a/.github/workflows/qit-self-group-test.yml
+++ b/.github/workflows/qit-self-group-test.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   self_test_custom_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       NO_COLOR: 1
       QIT_DISABLE_ONBOARDING: yes


### PR DESCRIPTION
Ubuntu 20.04 Actions runner image is deprecated, this will prevent running [QIT Self-Tests - Group Tests](https://github.com/woocommerce/qit-cli/actions/runs/14870632280) workflow
