### PR TITLE
[dev] Pin Github actions to full-commit SHA

### DIFF
--- a/.github/workflows/qit-environment-test-mac.yml
+++ b/.github/workflows/qit-environment-test-mac.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Setup Docker on macOS
         if: matrix.os == 'macos-13'
-        uses: douglascamata/setup-docker-macos-action@v1-alpha
+        uses: douglascamata/setup-docker-macos-action@f2b307ddc57e8b9d3f9761f3cafa8883b2cdffd4 # v1-alpha
 
       - name: Check Colima Status (Mac)
         if: matrix.os == 'macos-13'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           else
             echo "Valid build version. Proceeding."
           fi
-      - uses: ncipollo/release-action@v1
+      - uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
         with:
           artifacts: "qit"
           bodyFile: ./docs/changelogs/${{github.ref_name}}.md


### PR DESCRIPTION
Closes [QAO-47](https://linear.app/a8c/issue/QAO-47/woocommerceqit-cli-pin-github-actions-to-full-commit-sha)

Pins Github actions to full commit SHAs as immutable references.
Skipped official GitHub actions.
No version updates - used the latest commit in the tag that was already used.