### PR TITLE
Include Basic Auth plugin in the performance environment setup

### DIFF
--- a/src/src/LocalTests/Performance/Environment/PerformanceEnvironment.php
+++ b/src/src/LocalTests/Performance/Environment/PerformanceEnvironment.php
@@ -151,6 +151,7 @@ class PerformanceEnvironment extends Environment {
 
 		$this->install_php_extensions();
 		$this->setup_wordpress();
+		$this->activate_required_plugins();
 		$this->activate_plugins_and_themes();
 	}
 
@@ -183,6 +184,15 @@ class PerformanceEnvironment extends Environment {
 			'SITE_URL'          => $this->env_info->site_url,
 			'QIT_DOCKER_REDIS'  => $this->env_info->object_cache ? 'yes' : 'no',
 		] );
+	}
+
+	/**
+	 * Activate required plugins.
+	 * This method installs and activates plugins that are required for the performance environment.
+	 */
+	private function activate_required_plugins(): void {
+		$this->output->writeln( '<info>Activating required plugins...</info>' );
+		$this->docker->run_inside_docker( $this->env_info, [ 'bash', '-c', 'wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --force --activate' ] );
 	}
 
 	/**

--- a/src/src/LocalTests/Performance/Runner/K6DockerConfig.php
+++ b/src/src/LocalTests/Performance/Runner/K6DockerConfig.php
@@ -107,7 +107,7 @@ class K6DockerConfig {
 	 */
 	private function get_k6_command(): array {
 		return [
-			'grafana/k6:latest-with-browser',
+			'grafana/k6:master-with-browser',
 			'run',
 			'--out',
 			'json=/results/k6-results.json',

--- a/src/tests/__snapshots__/PartnerManagementTest__test_add_partner__1.json
+++ b/src/tests/__snapshots__/PartnerManagementTest__test_add_partner__1.json
@@ -1609,9 +1609,9 @@
             ],
             "environments": {
                 "performance": {
-                    "url": "https:\/\/qit.woo.com\/wp-content\/uploads\/environments\/0f5f7f5ee97306ef96f388399a4ce32f.zip",
-                    "checksum": "0f5f7f5ee97306ef96f388399a4ce32f",
-                    "zip_checksum": 15493
+                    "url": "https:\/\/qit.woo.com\/wp-content\/uploads\/environments\/af7f947f97a78ede4c17bbd22bbe61cd.zip",
+                    "checksum": "af7f947f97a78ede4c17bbd22bbe61cd",
+                    "zip_checksum": 15490
                 },
                 "e2e": {
                     "url": "https:\/\/qit.woo.com\/wp-content\/uploads\/environments\/c1a78950ca0eb8a23f8706955681bf02.zip",

--- a/src/tests/__snapshots__/PartnerManagementTest__test_add_partner_email__1.json
+++ b/src/tests/__snapshots__/PartnerManagementTest__test_add_partner_email__1.json
@@ -1609,9 +1609,9 @@
             ],
             "environments": {
                 "performance": {
-                    "url": "https:\/\/qit.woo.com\/wp-content\/uploads\/environments\/0f5f7f5ee97306ef96f388399a4ce32f.zip",
-                    "checksum": "0f5f7f5ee97306ef96f388399a4ce32f",
-                    "zip_checksum": 15493
+                    "url": "https:\/\/qit.woo.com\/wp-content\/uploads\/environments\/af7f947f97a78ede4c17bbd22bbe61cd.zip",
+                    "checksum": "af7f947f97a78ede4c17bbd22bbe61cd",
+                    "zip_checksum": 15490
                 },
                 "e2e": {
                     "url": "https:\/\/qit.woo.com\/wp-content\/uploads\/environments\/c1a78950ca0eb8a23f8706955681bf02.zip",

--- a/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner__1.json
+++ b/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner__1.json
@@ -1609,9 +1609,9 @@
             ],
             "environments": {
                 "performance": {
-                    "url": "https:\/\/qit.woo.com\/wp-content\/uploads\/environments\/0f5f7f5ee97306ef96f388399a4ce32f.zip",
-                    "checksum": "0f5f7f5ee97306ef96f388399a4ce32f",
-                    "zip_checksum": 15493
+                    "url": "https:\/\/qit.woo.com\/wp-content\/uploads\/environments\/af7f947f97a78ede4c17bbd22bbe61cd.zip",
+                    "checksum": "af7f947f97a78ede4c17bbd22bbe61cd",
+                    "zip_checksum": 15490
                 },
                 "e2e": {
                     "url": "https:\/\/qit.woo.com\/wp-content\/uploads\/environments\/c1a78950ca0eb8a23f8706955681bf02.zip",

--- a/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner__2.json
+++ b/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner__2.json
@@ -1609,9 +1609,9 @@
             ],
             "environments": {
                 "performance": {
-                    "url": "https:\/\/qit.woo.com\/wp-content\/uploads\/environments\/0f5f7f5ee97306ef96f388399a4ce32f.zip",
-                    "checksum": "0f5f7f5ee97306ef96f388399a4ce32f",
-                    "zip_checksum": 15493
+                    "url": "https:\/\/qit.woo.com\/wp-content\/uploads\/environments\/af7f947f97a78ede4c17bbd22bbe61cd.zip",
+                    "checksum": "af7f947f97a78ede4c17bbd22bbe61cd",
+                    "zip_checksum": 15490
                 },
                 "e2e": {
                     "url": "https:\/\/qit.woo.com\/wp-content\/uploads\/environments\/c1a78950ca0eb8a23f8706955681bf02.zip",

--- a/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner_on_different_environments__1.json
+++ b/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner_on_different_environments__1.json
@@ -1609,9 +1609,9 @@
             ],
             "environments": {
                 "performance": {
-                    "url": "https:\/\/qit.woo.com\/wp-content\/uploads\/environments\/0f5f7f5ee97306ef96f388399a4ce32f.zip",
-                    "checksum": "0f5f7f5ee97306ef96f388399a4ce32f",
-                    "zip_checksum": 15493
+                    "url": "https:\/\/qit.woo.com\/wp-content\/uploads\/environments\/af7f947f97a78ede4c17bbd22bbe61cd.zip",
+                    "checksum": "af7f947f97a78ede4c17bbd22bbe61cd",
+                    "zip_checksum": 15490
                 },
                 "e2e": {
                     "url": "https:\/\/qit.woo.com\/wp-content\/uploads\/environments\/c1a78950ca0eb8a23f8706955681bf02.zip",

--- a/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner_on_different_environments__2.json
+++ b/src/tests/__snapshots__/PartnerManagementTest__test_switch_partner_on_different_environments__2.json
@@ -1609,9 +1609,9 @@
             ],
             "environments": {
                 "performance": {
-                    "url": "https:\/\/qit.woo.com\/wp-content\/uploads\/environments\/0f5f7f5ee97306ef96f388399a4ce32f.zip",
-                    "checksum": "0f5f7f5ee97306ef96f388399a4ce32f",
-                    "zip_checksum": 15493
+                    "url": "https:\/\/qit.woo.com\/wp-content\/uploads\/environments\/af7f947f97a78ede4c17bbd22bbe61cd.zip",
+                    "checksum": "af7f947f97a78ede4c17bbd22bbe61cd",
+                    "zip_checksum": 15490
                 },
                 "e2e": {
                     "url": "https:\/\/qit.woo.com\/wp-content\/uploads\/environments\/c1a78950ca0eb8a23f8706955681bf02.zip",


### PR DESCRIPTION
As part of performance tests, we need to send requests to the SUT's REST API. In order to make it simple, the performance environment setup logic has been updated to include the install and activation of the Basic Auth plugin, which streamlines the REST API setup of a WordPress site.

Additionally, the k6 image used in our setup has been switched from `latest` to `master`, which is the stable version.

### Testing instructions
- Checkout to this branch.
- Set up a performance environment with `php src/qit-cli.php env:up --environment_type=performance`.
- Go to the plugins page (`/wp-admin/plugins.php`) and verify that the **JSON Basic Authentication** plugin is installed and activated.