### PR TITLE
Enable cash-on-delivery payment method by default in performance environment

### DIFF
--- a/src/src/LocalTests/Performance/Environment/PerformanceEnvironment.php
+++ b/src/src/LocalTests/Performance/Environment/PerformanceEnvironment.php
@@ -153,6 +153,7 @@ class PerformanceEnvironment extends Environment {
 		$this->setup_wordpress();
 		$this->activate_required_plugins();
 		$this->activate_plugins_and_themes();
+		$this->enable_payment_method();
 	}
 
 	/**
@@ -215,6 +216,15 @@ class PerformanceEnvironment extends Environment {
 
 		$theme_activation->maybe_activate_theme_that_is_dependency_of_sut();
 	}
+
+	/**
+	 * Enable payment methods.
+	 */
+	private function enable_payment_method(): void {
+		$this->output->writeln( '<info>Enabling Cash-on-delivery payment method...</info>' );
+		$this->docker->run_inside_docker( $this->env_info, [ 'bash', '-c', 'wp wc payment_gateway update cod --enabled=true --user=admin' ] );
+	}
+
 
 	protected function get_generate_docker_compose_envs(): array {
 		return [


### PR DESCRIPTION
In order to run the [performance tests for the checkout flow](https://github.com/Automattic/compatibility-dashboard/pull/1438), we need to ensure at least one payment method is enabled.

This PR enables the `cash-on-delivery` payment method during the performance environment setup through WP-CLI.

### Testing instructions
- Checkout to this branch.
- Set up a performance environment with `php src/qit-cli.php env:up --environment_type=performance`.
- Go to the offline payment methods page (`/wp-admin/admin.php?page=wc-settings&tab=checkout&section=offline`) and verify that `cash-on-delivery` is enabled.