### PR TITLE
Update self-tests snapshots.

### DIFF
--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_childtheme_woostable_php82_wpstable_440db7a70e471458f49b3c2aca2ba623__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_childtheme_woostable_php82_wpstable_440db7a70e471458f49b3c2aca2ba623__1.php
@@ -1435,8 +1435,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "de61d442-301a-4b8c-bcf4-8ec52f4ccbce",
-                "timestamp": "2025-09-03T03:20:23.897Z",
+                "reportId": "ff2a782a-35bb-4585-b0e1-5e023392fc99",
+                "timestamp": "2025-09-05T11:41:14.208Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woorc_php74_wprc_346c5f1d46bbec1721f5bbf11816a5c0__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woorc_php74_wprc_346c5f1d46bbec1721f5bbf11816a5c0__1.php
@@ -1435,8 +1435,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "096f31e5-aef3-4dc3-b20d-fee2dcf37ee6",
-                "timestamp": "2025-09-03T03:19:36.152Z",
+                "reportId": "b27a9292-f419-4d08-9165-e98cb286c44e",
+                "timestamp": "2025-09-05T11:41:10.432Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woorc_php82_wprc_2b7d6254596db2c73939e0d764cc4ba3__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woorc_php82_wprc_2b7d6254596db2c73939e0d764cc4ba3__1.php
@@ -1435,8 +1435,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "51e5bb1e-0a2d-4d1f-b2ba-b2d027076435",
-                "timestamp": "2025-09-03T03:19:50.530Z",
+                "reportId": "d1992a92-5a89-4751-86a9-65a1ffbfc995",
+                "timestamp": "2025-09-05T11:41:00.387Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woostable_php74_wprc_7362ffe83e2b60ebc0cf5c63b3856976__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woostable_php74_wprc_7362ffe83e2b60ebc0cf5c63b3856976__1.php
@@ -1435,8 +1435,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "13c3ec5f-fca6-422a-8e59-ecd091f376fd",
-                "timestamp": "2025-09-03T03:20:16.083Z",
+                "reportId": "88b43b7d-63ec-4d3a-bb2b-8e06e4e7f342",
+                "timestamp": "2025-09-05T11:41:04.448Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woostable_php82_wprc_5e58227b55849b8c7239a9971ae5d264__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woostable_php82_wprc_5e58227b55849b8c7239a9971ae5d264__1.php
@@ -1435,8 +1435,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "d9f1b059-13b4-4df2-b4f6-df777add67d2",
-                "timestamp": "2025-09-03T03:20:15.463Z",
+                "reportId": "55efc692-2441-4c33-8531-2e1a7c304fcf",
+                "timestamp": "2025-09-05T11:41:15.960Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woorc_php74_wprc_ffc30a443f4fcc32b0abe133375adbd8__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woorc_php74_wprc_ffc30a443f4fcc32b0abe133375adbd8__1.php
@@ -1435,8 +1435,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "93c288b4-b105-4245-b1cd-74519bb048d6",
-                "timestamp": "2025-09-03T03:20:25.379Z",
+                "reportId": "47e24441-e050-4921-838b-60daef5f8e1d",
+                "timestamp": "2025-09-05T11:41:26.376Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woorc_php82_wprc_eb7749dc7ada621516b289b420c7aa83__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woorc_php82_wprc_eb7749dc7ada621516b289b420c7aa83__1.php
@@ -1435,8 +1435,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "3505ad8b-2746-4101-88f7-a12cf5d6bcd0",
-                "timestamp": "2025-09-03T03:20:44.277Z",
+                "reportId": "1114083b-05e6-49f5-a22b-c3e4363dc570",
+                "timestamp": "2025-09-05T11:41:40.211Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woostable_php74_wprc_ca36e1e383c91cc1e399f1bab52b350b__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woostable_php74_wprc_ca36e1e383c91cc1e399f1bab52b350b__1.php
@@ -1435,8 +1435,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "1a32640a-63ff-4c59-8b53-9666c13f4ea3",
-                "timestamp": "2025-09-03T03:20:43.826Z",
+                "reportId": "4fc85538-3d6c-4e94-b68b-edaff6ccb827",
+                "timestamp": "2025-09-05T11:41:33.031Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woostable_php82_wprc_30c8c208075c921416b6f88c67b78c16__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woostable_php82_wprc_30c8c208075c921416b6f88c67b78c16__1.php
@@ -1435,8 +1435,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "1f66455f-73d5-4da1-bf30-6b983f989152",
-                "timestamp": "2025-09-03T03:20:51.374Z",
+                "reportId": "e45f23c3-55de-43a5-90ea-6ea02bceac27",
+                "timestamp": "2025-09-05T11:41:36.589Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_parenttheme_woostable_php82_wpstable_4fea9b07dff27b783d26f0b4b90cc6e4__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_parenttheme_woostable_php82_wpstable_4fea9b07dff27b783d26f0b4b90cc6e4__1.php
@@ -1435,8 +1435,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "810392a6-7928-4040-974f-0886ac678e74",
-                "timestamp": "2025-09-03T03:18:58.161Z",
+                "reportId": "0e525579-f72c-41cf-951e-b7a154843e18",
+                "timestamp": "2025-09-05T11:40:57.094Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woorc_php74_wprc_fdd35606f836d278e28ee1655d190df0__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woorc_php74_wprc_fdd35606f836d278e28ee1655d190df0__1.php
@@ -1435,8 +1435,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "8e33d677-b17d-480e-bbe4-c47812f6f3e6",
-                "timestamp": "2025-09-03T03:18:20.952Z",
+                "reportId": "92efc2aa-8f01-48a2-91df-0b60a3a1020e",
+                "timestamp": "2025-09-05T11:40:44.211Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woorc_php82_wprc_f4cd9965b5cceb8e299a36acf245b6f0__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woorc_php82_wprc_f4cd9965b5cceb8e299a36acf245b6f0__1.php
@@ -1435,8 +1435,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "6d8323b3-9628-4a52-b38a-ce5817eb33f5",
-                "timestamp": "2025-09-03T03:18:30.625Z",
+                "reportId": "28c98970-9123-425a-9847-0e9021b2fb73",
+                "timestamp": "2025-09-05T11:40:44.995Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woostable_php74_wprc_c5e572f0e7a39cd8994d515514e0be3a__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woostable_php74_wprc_c5e572f0e7a39cd8994d515514e0be3a__1.php
@@ -1435,8 +1435,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "48a2c9bf-99d7-4f96-9704-23e8a1def9dd",
-                "timestamp": "2025-09-03T03:19:00.240Z",
+                "reportId": "e1935a49-6782-4f40-a7d4-3d0c434301a5",
+                "timestamp": "2025-09-05T11:40:52.349Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woostable_php82_wprc_18f274ce2084619bd42b38449a1c9321__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woostable_php82_wprc_18f274ce2084619bd42b38449a1c9321__1.php
@@ -1435,8 +1435,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "4f5800f3-4287-4923-aa16-74996cd2d269",
-                "timestamp": "2025-09-03T03:18:54.424Z",
+                "reportId": "2ef0bd67-b7a3-4a7e-98a0-9a384b3948e4",
+                "timestamp": "2025-09-05T11:40:48.764Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woorc_php82_wprc_4ee1157429027befae37425348f5bd84__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woorc_php82_wprc_4ee1157429027befae37425348f5bd84__1.php
@@ -2691,8 +2691,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "c2b1daf5-b48e-4bb0-8d08-33f440523627",
-                "timestamp": "2025-09-02T14:49:22.923Z",
+                "reportId": "ea617d97-682d-4620-8c67-56af04261a1b",
+                "timestamp": "2025-09-05T11:41:48.005Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woorc_php82_wpstable_b23dfeb910e3a66fc64cf81023cfeaea__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woorc_php82_wpstable_b23dfeb910e3a66fc64cf81023cfeaea__1.php
@@ -2691,8 +2691,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "5b872402-f457-47fa-95f3-626e498497fc",
-                "timestamp": "2025-09-02T14:49:38.187Z",
+                "reportId": "88a2e79b-b474-4d4c-9e2f-19e71f24107b",
+                "timestamp": "2025-09-05T11:44:14.965Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woostable_php82_wprc_960168535790f3a7eff463fb11517d63__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woostable_php82_wprc_960168535790f3a7eff463fb11517d63__1.php
@@ -2695,8 +2695,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "d5e7aede-0627-4698-a495-2e8a6b3fe28c",
-                "timestamp": "2025-09-02T14:49:19.921Z",
+                "reportId": "4de35283-fb83-4c14-938c-73ffeca094a6",
+                "timestamp": "2025-09-05T11:41:53.945Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woostable_php82_wpstable_ed7d3932b380dcf5673cf151dde0eb37__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woostable_php82_wpstable_ed7d3932b380dcf5673cf151dde0eb37__1.php
@@ -2695,8 +2695,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "86410801-a120-4b5f-9db9-30447c48ceed",
-                "timestamp": "2025-09-02T14:49:25.264Z",
+                "reportId": "dc1ec064-b4f6-4b19-9c47-2304515bff9f",
+                "timestamp": "2025-09-05T11:44:24.776Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woorc_php74_wprc_818ebdd6b04d0991fd37d3414ff14307__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woorc_php74_wprc_818ebdd6b04d0991fd37d3414ff14307__1.php
@@ -2691,8 +2691,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "3f1a5162-74e8-4661-bfd6-11c87144718f",
-                "timestamp": "2025-09-02T14:50:10.655Z",
+                "reportId": "f29c421f-e27c-4bd1-802f-f3b2cf1aee19",
+                "timestamp": "2025-09-05T11:44:23.161Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woorc_php74_wpstable_8ea880f7c0e5f4aeb8851ca23268fcd8__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woorc_php74_wpstable_8ea880f7c0e5f4aeb8851ca23268fcd8__1.php
@@ -2691,8 +2691,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "1a48dbba-39f1-4f31-a096-10601d700af0",
-                "timestamp": "2025-09-02T14:50:05.646Z",
+                "reportId": "f6f7f75f-773e-4934-ab49-e16eb77d1c22",
+                "timestamp": "2025-09-05T11:44:19.509Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woostable_php74_wprc_865de3b217a16a96d42609a9ca8ebcf0__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woostable_php74_wprc_865de3b217a16a96d42609a9ca8ebcf0__1.php
@@ -2695,8 +2695,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "4dbb5caa-0bd5-40b3-90c3-d33eab64f09a",
-                "timestamp": "2025-09-02T14:50:25.365Z",
+                "reportId": "ce267a02-0e32-49f1-8a6c-758766650805",
+                "timestamp": "2025-09-05T11:44:34.757Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woostable_php74_wpstable_4d0acdce8f051e58d6c20e496553c9b6__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woostable_php74_wpstable_4d0acdce8f051e58d6c20e496553c9b6__1.php
@@ -2695,8 +2695,8 @@
             "ctrf_json": {
                 "reportFormat": "CTRF",
                 "specVersion": "0.0.0",
-                "reportId": "91e2705d-3de4-4117-8eac-9a28e3f5402c",
-                "timestamp": "2025-09-02T14:50:25.343Z",
+                "reportId": "731169ec-a270-422d-916d-96ec4ce7cad0",
+                "timestamp": "2025-09-05T11:44:19.683Z",
                 "generatedBy": "playwright-ctrf-json-reporter",
                 "results": {
                     "tool": {


### PR DESCRIPTION
After the recent changes, self-tests started failing due to outdated snapshots.

This PR aims to update them to fix the these tests.