### PR TITLE
Add --url_only option to e2e-report for automated, non-interactive flows

### DIFF
--- a/src/src/Commands/CustomTests/ShowReportCommand.php
+++ b/src/src/Commands/CustomTests/ShowReportCommand.php
@@ -28,13 +28,15 @@ class ShowReportCommand extends Command {
 			->addArgument( 'report_dir', InputArgument::OPTIONAL, '(Optional) The report directory. If not set, will show the last report.' )
 			->addOption( 'local', null, null, 'Force showing the local report instead of the remote one.' )
 			->addOption( 'dir_only', null, null, 'Only output the local report directory path.' )
+			->addOption( 'url_only', null, null, 'Only output the remote report URL.' )
 			->setDescription( 'Shows a test report.' );
 	}
 
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
 		// Determine the report directories.
-		if ( ! is_null( $input->getArgument( 'report_dir' ) ) ) {
-			$local_report  = $input->getArgument( 'report_dir' );
+		$supplied_report_dir = $input->getArgument( 'report_dir' );
+		if ( ! is_null( $supplied_report_dir ) ) {
+			$local_report  = $supplied_report_dir;
 			$remote_report = null; // Assuming no remote report when report_dir is specified.
 		} else {
 			$report_dir = json_decode( $this->cache->get( 'last_e2e_report' ) ?: '', true );
@@ -63,6 +65,21 @@ class ShowReportCommand extends Command {
 			}
 
 			$output->writeln( $directory );
+
+			return Command::SUCCESS;
+		}
+
+		// Also handle --url_only option early.
+		if ( $input->getOption( 'url_only' ) ) {
+			if ( ! is_null( $supplied_report_dir ) ) {
+				throw new \RuntimeException( 'The --url_only option cannot be used with the --report_dir option.' );
+			}
+
+			if ( empty( $remote_report ) ) {
+				throw new \RuntimeException( 'No remote report was found.' );
+			}
+
+			$output->writeln( $remote_report );
 
 			return Command::SUCCESS;
 		}

--- a/src/src/Commands/CustomTests/ShowReportCommand.php
+++ b/src/src/Commands/CustomTests/ShowReportCommand.php
@@ -72,7 +72,7 @@ class ShowReportCommand extends Command {
 		// Also handle --url_only option early.
 		if ( $input->getOption( 'url_only' ) ) {
 			if ( ! is_null( $supplied_report_dir ) ) {
-				throw new \RuntimeException( 'The --url_only option cannot be used with the --report_dir option.' );
+				throw new \RuntimeException( 'The --url_only option cannot be used when the report directory is provided.' );
 			}
 
 			if ( empty( $remote_report ) ) {


### PR DESCRIPTION
As part of working on a GitHub workflow to run custom e2e tests via `qit run:e2e`, I noticed that there is no direct/easy way to determine the URL for the tests when you're in a non-interactive situation. This PR adds a `--url_only` option to `qit e2e-report` so there is a way to output only the URL of the relevant e2e test report.

I considered adding this to the output logging for the upload, but that is less automation-friendly.

For illustration, this means that running `qit e2e-report --url_only` would result in just writing out the remote report URL, and nothing else.