### PR TITLE
Profile Inherit SUT

### DIFF
--- a/src/src/Commands/QITCommand.php
+++ b/src/src/Commands/QITCommand.php
@@ -168,7 +168,14 @@ abstract class QITCommand extends Command {
 			return [];
 		}
 
-		return $config['test_types'][ $test_type ][ $profile ] ?? [];
+		$profile_config = $config['test_types'][ $test_type ][ $profile ] ?? [];
+
+		// Inherit top-level SUT if profile doesn't define its own
+		if ( ! isset( $profile_config['sut'] ) && isset( $config['sut'] ) ) {
+			$profile_config['sut'] = $config['sut'];
+		}
+
+		return $profile_config;
 	}
 
 	/**

--- a/src/tests/integration/tests/TestPackages/Commands/RunE2E/Configuration/ConfigurationTest.php
+++ b/src/tests/integration/tests/TestPackages/Commands/RunE2E/Configuration/ConfigurationTest.php
@@ -309,11 +309,11 @@ class ConfigurationTest extends TestCase {
 
 	/**
 	 * Test #8: Verbose output
-	 * 
+	 *
 	 * Coverage aim: Validates verbose output functionality.
 	 * Tests that the --verbose flag properly increases output detail,
 	 * helping users debug issues with more information.
-	 * 
+	 *
 	 * Key aspects tested:
 	 * - Verbose flag functionality
 	 * - Enhanced output with -v flag
@@ -333,8 +333,65 @@ class ConfigurationTest extends TestCase {
 		$output = $proc->getOutput();
 
 		$this->assertEquals( 0, $proc->getExitCode() );
-		
+
 		// Should complete successfully
+		$this->assertStringContainsString( 'Status:        ✓ PASSED', $output );
+	}
+
+	/**
+	 * Test #9: SUT inheritance from top-level config
+	 *
+	 * Coverage aim: Validates that profiles automatically inherit the top-level SUT
+	 * configuration when they don't define their own SUT. This is a common workflow
+	 * where users define the plugin/theme being tested once at the top level and
+	 * create multiple test profiles without repeating the SUT definition.
+	 *
+	 * Key aspects tested:
+	 * - Top-level SUT configuration is inherited by profiles
+	 * - Profiles without SUT can run without requiring CLI SUT argument
+	 * - Configuration inheritance works correctly
+	 */
+	public function test_sut_inheritance_from_top_level(): void {
+		$testPackage = $this->fixturesDir . '/regular-test-package-one';
+
+		// Create config with top-level SUT but profile doesn't define SUT
+		$config = [
+			'sut' => [
+				'type' => 'plugin',
+				'slug' => 'woocommerce',
+				'source' => [
+					'type' => 'wporg',
+					'version' => 'stable'
+				]
+			],
+			'test_types' => [
+				'e2e' => [
+					'default' => [
+						'test_packages' => [ $testPackage ]
+						// Note: No 'sut' key here - should inherit from top level
+					]
+				]
+			]
+		];
+
+		$tempDir = sys_get_temp_dir() . '/qit-fixture-test-' . uniqid();
+		mkdir( $tempDir, 0755, true );
+		$this->tempDirs[] = $tempDir;
+
+		$configPath = $tempDir . '/qit.json';
+		file_put_contents( $configPath, json_encode( $config, JSON_PRETTY_PRINT ) );
+
+		// Run WITHOUT specifying SUT as CLI argument - should inherit from config
+		$proc = qit( [
+			'run:e2e',
+			'--config=' . $configPath,
+			'--profile=default',
+		], return_process: true );
+
+		$output = $proc->getOutput();
+
+		// Should succeed - SUT was inherited from top-level config
+		$this->assertEquals( 0, $proc->getExitCode(), 'Should inherit SUT from top-level config' );
 		$this->assertStringContainsString( 'Status:        ✓ PASSED', $output );
 	}
 


### PR DESCRIPTION
### Description

Profiles in the `qit.json` where not inheriting the SUT at the top level. This PR fixes that.

### Changes in this PR
- Inherit SUT from `qit.json` if none is explicitly passed.

### Testing Instructions 
1. Deploy https://github.com/Automattic/compatibility-dashboard/pull/1286 to staging 
2. Create a `qit.json` in the root of this project(I've attached one on this PR)
3. Checkout https://github.com/woocommerce/qit-cli/pull/309 and connect it to staging
4. Run a profile with no sut defined and confirm it fails(e.g. `./qit run:phpstan --profile=default ` )
5. Checkout this branch and rerun the test above and confirm it passes.
6. Run a profile with SUT provided and confirm it works as expected(e.g. `./qit run:phpstan woocommerce-bookings --profile=default` )
7. Test around this issue.


[qit.json](https://github.com/user-attachments/files/22886319/qit.json)
