### PR TITLE
Fix Allure-related CLI logs shown at the end of the activation tests run flow

### DIFF
--- a/src/src/Commands/RunE2ECommand.php
+++ b/src/src/Commands/RunE2ECommand.php
@@ -501,7 +501,7 @@ class RunE2ECommand extends QITCommand {
 					$orchestrator->post_processing_message( '  Add "allure-dir" to qit-test.json for failure debugging', false );
 				} elseif ( $packages_with_allure === $total_packages && $total_packages > 0 ) {
 					// All packages have Allure configured - perfect!
-					$orchestrator->post_processing_message( '✓ Allure configured (uploads on test failure)', false );
+					$orchestrator->post_processing_message( 'Allure configured (uploads on test failure)' );
 				}
 			}
 

--- a/src/src/Utils/LocalTestRunNotifier.php
+++ b/src/src/Utils/LocalTestRunNotifier.php
@@ -250,7 +250,7 @@ class LocalTestRunNotifier {
 			if ( ! $tests_failed ) {
 				// Tests passed - don't upload Allure to save bandwidth
 				if ( $orchestrator ) {
-					$orchestrator->post_processing_message( 'Allure report available locally (not uploaded - tests passed)', false );
+					$orchestrator->post_processing_message( 'Allure report available locally (not uploaded - tests passed)' );
 				}
 			} else {
 				// Tests failed - upload Allure for debugging


### PR DESCRIPTION
While testing activation tests running with the test packages implementation, I discovered there was an inconsistency in the summary logs shown in the terminal at the end of the execution flow:

```
┌─ POST-PROCESSING ────────────────────────────────────────────────────────
│ ✓ Merging CTRF reports...
│ ✓ CTRF reports merged
│ ✓ Merging blob reports into HTML...
│ ✓ HTML report generated
│ ✓ Saving Allure reports...
│ ✓ Allure reports saved
│ ✗ ✓ Allure configured (uploads on test failure)
│ ✗ Allure report available locally (not uploaded - tests passed)
└───────────────────────────────────────────────────────────────────────────
```

In particular, these:

```
✗ ✓ Allure configured (uploads on test failure)
✗ Allure report available locally (not uploaded - tests passed)
```

The first one was logged as failed and passed at the same time, and the second one was logged as failed, so I decided to investigate the code behind both steps to find out that the code was correct and the issue was in the logging.

Both steps should be logged as `success`, as all reports were in place, so code was hitting positive scenarios.

### Testing instructions
- Ensure you're using the QIT-CLI version from this branch pointing locally to [this CD version](https://github.com/Automattic/compatibility-dashboard/pull/1286).
- Ensure the default activation test package is published so you can run it.
- Run activation tests with `php src/qit-cli.php run:activation automatewoo`.
- Check that tests pass.
- Check that the CLI logs include a section titled as `POST-PROCESSING` that looks like this:
```
┌─ POST-PROCESSING ────────────────────────────────────────────────────────
│ ✓ Merging CTRF reports...
│ ✓ CTRF reports merged
│ ✓ Merging blob reports into HTML...
│ ✓ HTML report generated
│ ✓ Saving Allure reports...
│ ✓ Allure reports saved
│ ✓ Allure configured (uploads on test failure)
Wrote debug contents to: /var/folders/j8/1djrt0mj0p56ph_dlrxghbz00000gn/T/qit-results-qitenvbdd4ff4c581c9398/debug-prepared.log
│ ✓ Allure report available locally (not uploaded - tests passed)
└───────────────────────────────────────────────────────
```

In particular, verify that the following steps are marked as `passed`:
```
Allure configured (uploads on test failure)
Allure report available locally (not uploaded - tests passed)
```