### PR TITLE
Bidirectional Version Aliases

### DIFF
--- a/src/src/Commands/CreateRunCommands.php
+++ b/src/src/Commands/CreateRunCommands.php
@@ -133,7 +133,17 @@ class CreateRunCommands extends DynamicCommandCreator {
 				/****************************************************************
 				 * 2.  Apply CLI overrides (only what user provided)
 				 */
-				foreach ( $this->options_to_send as $opt_name ) {
+
+				// Map user-friendly aliases to API parameter names
+				// These aliases are available for any test type that supports them
+				$option_aliases = [
+					'wp'  => 'wordpress_version',
+					'woo' => 'woocommerce_version',
+					'php' => 'php_version',
+				];
+
+				// Fix: Iterate over array keys, not values (values are empty strings)
+				foreach ( array_keys( $this->options_to_send ) as $opt_name ) {
 
 					if ( ! $input->hasOption( $opt_name ) ) {
 						continue;                               // not typed – keep profile value
@@ -149,6 +159,16 @@ class CreateRunCommands extends DynamicCommandCreator {
 						) ) );
 					} else {
 						$options[ $opt_name ] = $cli_value;
+					}
+				}
+
+				// Apply aliased options to their real API parameter names
+				foreach ( $option_aliases as $alias => $real_name ) {
+					if ( $input->hasOption( $alias ) ) {
+						$alias_value = $input->getOption( $alias );
+						if ( $alias_value !== null && $alias_value !== '' ) {
+							$options[ $real_name ] = $alias_value;
+						}
 					}
 				}
 
@@ -650,6 +670,7 @@ class CreateRunCommands extends DynamicCommandCreator {
 
 		/**
 		 * CLI definition helpers (schema‑driven)
+		 * Note: add_schema_to_command also adds user-friendly aliases (--wp, --woo, --php)
 		 */
 		self::add_schema_to_command( $command, $schema );
 

--- a/src/src/Commands/DynamicCommandCreator.php
+++ b/src/src/Commands/DynamicCommandCreator.php
@@ -124,5 +124,22 @@ abstract class DynamicCommandCreator {
 				);
 			}
 		}
+
+		/* Add user-friendly aliases (only if schema supports the underlying parameter) */
+		$has_wordpress_version   = isset( $schema['properties']['wordpress_version'] );
+		$has_woocommerce_version = isset( $schema['properties']['woocommerce_version'] );
+		$has_php_version         = isset( $schema['properties']['php_version'] );
+
+		if ( $has_wordpress_version || $has_woocommerce_version || $has_php_version ) {
+			if ( $has_wordpress_version ) {
+				$command->addOption( 'wp', null, InputOption::VALUE_OPTIONAL, '(Optional) WordPress version (alias for --wordpress_version)' );
+			}
+			if ( $has_woocommerce_version ) {
+				$command->addOption( 'woo', null, InputOption::VALUE_OPTIONAL, '(Optional) WooCommerce version (alias for --woocommerce_version)' );
+			}
+			if ( $has_php_version ) {
+				$command->addOption( 'php', null, InputOption::VALUE_OPTIONAL, '(Optional) PHP version (alias for --php_version)' );
+			}
+		}
 	}
 }

--- a/src/src/Commands/RunE2ECommand.php
+++ b/src/src/Commands/RunE2ECommand.php
@@ -150,6 +150,10 @@ class RunE2ECommand extends QITCommand {
 			->reuseOption( 'env:up', 'env' )
 			->reuseOption( 'env:up', 'env_file' )
 			->reuseOption( 'env:up', 'json' )
+			// Add long-form aliases for consistency with remote test commands
+			->addOption( 'wordpress_version', null, InputOption::VALUE_OPTIONAL, 'WordPress version (alias for --wp)' )
+			->addOption( 'woocommerce_version', null, InputOption::VALUE_OPTIONAL, 'WooCommerce version (alias for --woo)' )
+			->addOption( 'php_version', null, InputOption::VALUE_OPTIONAL, 'PHP version (alias for --php)' )
 			->addOption( 'skip_activating_plugins', 's', InputOption::VALUE_NONE, 'Skip activating plugins' )
 			->addOption( 'skip_activating_themes', 'st', InputOption::VALUE_NONE, 'Skip activating themes' )
 
@@ -180,6 +184,22 @@ class RunE2ECommand extends QITCommand {
 		 * 1. Get environment options for delegation to env:up
 		 */
 		$env_up_options = $input->getEnvironmentOptions();
+
+		// Map long-form aliases to short-form options that env:up expects
+		$option_aliases = [
+			'wordpress_version'   => '--wp',
+			'woocommerce_version' => '--woo',
+			'php_version'         => '--php',
+		];
+
+		foreach ( $option_aliases as $long_form => $short_form ) {
+			if ( $input->hasOption( $long_form ) ) {
+				$value = $input->getOption( $long_form );
+				if ( $value !== null && $value !== '' ) {
+					$env_up_options[ $short_form ] = $value;
+				}
+			}
+		}
 
 		// Handle activation test scenario
 		$test_packages = $input->getTestPackages();

--- a/src/src/Commands/RunPerformanceTestCommand.php
+++ b/src/src/Commands/RunPerformanceTestCommand.php
@@ -682,6 +682,22 @@ class RunPerformanceTestCommand extends DynamicCommand {
 		// Parse options that should be sent to the API.
 		$parsed_options = parent::parse_options( $input, true );
 
+		// Map user-friendly aliases to API parameter names
+		$option_aliases = [
+			'wp'  => 'wordpress_version',
+			'woo' => 'woocommerce_version',
+			'php' => 'php_version',
+		];
+
+		foreach ( $option_aliases as $alias => $real_name ) {
+			if ( $input->hasOption( $alias ) ) {
+				$alias_value = $input->getOption( $alias );
+				if ( $alias_value !== null && $alias_value !== '' ) {
+					$parsed_options[ $real_name ] = $alias_value;
+				}
+			}
+		}
+
 		// Build options for remote API request.
 		$options = array_merge( $parsed_options, [
 			'woo_id' => $context['woo_id'],

--- a/src/tests/unit/__snapshots__/RunTestsTest__test_run_with_additional_plugins__1.json
+++ b/src/tests/unit/__snapshots__/RunTestsTest__test_run_with_additional_plugins__1.json
@@ -2,6 +2,7 @@
     "url": "https:\/\/qit.woo.com\/wp-json\/cd\/v1\/enqueue-woo-e2e",
     "method": "POST",
     "post_body": {
+        "additional_plugins": "10002,1000245",
         "woo_id": 10001,
         "event": "cli_published_extension_test",
         "client": "qit_cli"

--- a/src/tests/unit/__snapshots__/RunTestsTest__test_run_with_additional_plugins__2.json
+++ b/src/tests/unit/__snapshots__/RunTestsTest__test_run_with_additional_plugins__2.json
@@ -2,6 +2,7 @@
     "url": "https:\/\/qit.woo.com\/wp-json\/cd\/v1\/enqueue-woo-e2e",
     "method": "POST",
     "post_body": {
+        "additional_plugins": "wccom-plugin-2,wccom-plugin-4",
         "woo_id": 10001,
         "event": "cli_published_extension_test",
         "client": "qit_cli"

--- a/src/tests/unit/__snapshots__/RunTestsTest__test_run_with_additional_plugins__3.json
+++ b/src/tests/unit/__snapshots__/RunTestsTest__test_run_with_additional_plugins__3.json
@@ -2,6 +2,7 @@
     "url": "https:\/\/qit.woo.com\/wp-json\/cd\/v1\/enqueue-woo-e2e",
     "method": "POST",
     "post_body": {
+        "additional_plugins": "10002,wccom-plugin-5",
         "woo_id": 10001,
         "event": "cli_published_extension_test",
         "client": "qit_cli"


### PR DESCRIPTION
# Add Bidirectional Version Aliases for All Test Commands

## Summary

Adds user-friendly option aliases across all QIT test commands, allowing users to use either short forms (`--wp`, `--woo`, `--php`) or long forms (`--wordpress_version`, `--woocommerce_version`, `--php_version`) interchangeably.


## Changes

- Added Automatic Alias Generation
- Added Alias Mapping for Remote Tests
- Added Alias Mapping for Performance Tests
- Added Bidirectional Support for Local Tests

## Testing Instructions

### Remote Test Commands
```bash
# Test short-form aliases (NEW)
qit run:woo-e2e automatewoo --wp=6.7.4 --woo=10.3.2 --php=8.1

# Test long-form (FIXED - was broken before)
qit run:woo-e2e automatewoo --wordpress_version=6.7.4 --woocommerce_version=10.3.2 --php_version=8.1

# Test other remote commands
qit run:phpstan automatewoo --wp=6.8.3 --woo=stable
qit run:compatibility automatewoo --wordpress_version=stable --woocommerce_version=rc --php_version=8.3
qit run:performance automatewoo --wp=6.7.4 --woo=10.3.2
```

### Local Test Commands
```bash
# Test short-form (already worked)
qit run:e2e automatewoo --wp=6.8.3 --woo=stable --php=8.2 --test-package=automatewoo/e2e:1.0.0

# Test long-form (NEW)
qit run:e2e automatewoo --wordpress_version=6.8.3 --woocommerce_version=stable --php_version=8.2 
qit run:e2e automatewoo --wp=6.8.3 --woo=stable --php=8.2 --test-package=automatewoo/e2e:1.0.0

# Test activation
qit run:activation automatewoo --wordpress_version=stable --woocommerce_version=rc --php_version=8.1
```

### Verify Help Text
```bash
# All should show both forms
qit run:woo-e2e --help | grep -E "wp|woo|php"
qit run:e2e --help | grep -E "wordpress_version|woocommerce_version|php_version"
```
