### PR TITLE
Fix PHP version display

### DIFF
--- a/src/src/Commands/CreateRunCommands.php
+++ b/src/src/Commands/CreateRunCommands.php
@@ -503,7 +503,9 @@ class CreateRunCommands extends DynamicCommandCreator {
 						if ( isset( $last_result['woocommerce_version'] ) ) {
 							$table_data[] = [ 'WooCommerce Version', $last_result['woocommerce_version'] ];
 						}
-						if ( isset( $last_result['php_version'] ) ) {
+						if ( isset( $last_result['min_php_version'] ) && isset( $last_result['max_php_version'] ) ) {
+							$table_data[] = [ 'PHP Version Range', $last_result['min_php_version'] . ' - ' . $last_result['max_php_version'] ];
+						} elseif ( isset( $last_result['php_version'] ) ) {
 							$table_data[] = [ 'PHP Version', $last_result['php_version'] ];
 						}
 


### PR DESCRIPTION
This PR fixes the way we display PHP versions for PHP Compatibility tests--previously we didn't show the range and only the "base" version (which doesn't make much sense for this test). The new version is below:

<img width="1168" height="189" alt="Screenshot 2025-10-24 at 4 56 46 PM" src="https://github.com/user-attachments/assets/7848b9e0-58b3-483e-b07d-aec7e32ec74e" />
<img width="1174" height="192" alt="Screenshot 2025-10-24 at 4 57 22 PM" src="https://github.com/user-attachments/assets/09b73ee5-b95b-490b-bb91-1e493bfa9fa7" />

---

FWIW I also played with a split out version, but I like the single line a bit better, though happy to switch it back depending on what folks think!

<img width="1175" height="211" alt="Screenshot 2025-10-24 at 4 52 20 PM" src="https://github.com/user-attachments/assets/392aad61-8f9a-48b6-b5f8-107fd9e278c4" />
<img width="1171" height="213" alt="Screenshot 2025-10-24 at 4 53 12 PM" src="https://github.com/user-attachments/assets/b0302845-48d2-4aa7-919e-fbd3a7c895f9" />

(note that this was before I removed the PHP version line, I would keep it out also for this version!)