### PR TITLE
Update self-test snapshots

### DIFF
--- a/_tests/managed_tests/tests/__snapshots__/MalwareTest__test_malware_jetpack_scan_woo_php_wp_6721f9775c2073c083e409914f62ed75__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/MalwareTest__test_malware_jetpack_scan_woo_php_wp_6721f9775c2073c083e409914f62ed75__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/MalwareTest__test_malware_no_op_woo_php_wp_0dd309d969e4d46682be10c3bd717eb0__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/MalwareTest__test_malware_no_op_woo_php_wp_0dd309d969e4d46682be10c3bd717eb0__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_childtheme_woo_php_wp_857a3bbe5fef96a3b158c7389549fa57__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_childtheme_woo_php_wp_857a3bbe5fef96a3b158c7389549fa57__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_main_woo_php_wp_28e03c1a3073469aae3b28c10dfeac1d__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_main_woo_php_wp_28e03c1a3073469aae3b28c10dfeac1d__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_parenttheme_woo_php_wp_6851f6654a4c24423121aa31423c2753__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_parenttheme_woo_php_wp_6851f6654a4c24423121aa31423c2753__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_72_to_74_woo_php_wp_b1c588503637a98590143b312a69beba__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_72_to_74_woo_php_wp_b1c588503637a98590143b312a69beba__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_81_to_82_woo_php_wp_6ee042538e1935736a9856e687d0c150__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_81_to_82_woo_php_wp_6ee042538e1935736a9856e687d0c150__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_default_php_version_woo_php_wp_aab4e9b0325ab0d8921f5fb94ffecdac__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_default_php_version_woo_php_wp_aab4e9b0325ab0d8921f5fb94ffecdac__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_additional_plugins_woo_php_wp_efa95b897ff4a83698ed4371166ccba5__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_additional_plugins_woo_php_wp_efa95b897ff4a83698ed4371166ccba5__1.php
@@ -48,7 +48,7 @@
             "phpstan_level": 2,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_childtheme_woo_php_wp_acd1df3b6787d2c2218b6be0b465f886__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_childtheme_woo_php_wp_acd1df3b6787d2c2218b6be0b465f886__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": 2,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_main_woo_php_wp_f80e75e0a6ea5d06dd6dc94dc9336592__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_main_woo_php_wp_f80e75e0a6ea5d06dd6dc94dc9336592__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": 2,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_parenttheme_woo_php_wp_995dee7cfdc6a851703a72185472abe7__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_parenttheme_woo_php_wp_995dee7cfdc6a851703a72185472abe7__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": 2,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_phpstan_neon_file_woo_php_wp_2bcbd964dd4ad8a665344d590acf7557__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_phpstan_neon_file_woo_php_wp_2bcbd964dd4ad8a665344d590acf7557__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": 2,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_with_vendor_woo_php_wp_b50d713e3b9c085feafab3638144cb8a__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_with_vendor_woo_php_wp_b50d713e3b9c085feafab3638144cb8a__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": 2,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_childtheme_woo_php_wp_b075c74b6040c155dee4bf80601d8593__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_childtheme_woo_php_wp_b075c74b6040c155dee4bf80601d8593__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_db_woo_php_wp_49db8a4a428f094d772dd537f86cafc1__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_db_woo_php_wp_49db8a4a428f094d772dd537f86cafc1__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_exclusions_woo_php_wp_781a480f91705a029738d07d57a3454d__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_exclusions_woo_php_wp_781a480f91705a029738d07d57a3454d__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_main_woo_php_wp_58e73693928f158eed05cb07b0787674__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_main_woo_php_wp_58e73693928f158eed05cb07b0787674__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_nonce_woo_php_wp_675f895c6a36c524d03d9e313702ec6b__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_nonce_woo_php_wp_675f895c6a36c524d03d9e313702ec6b__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_parenttheme_woo_php_wp_cc908a9e48789589e553f91761083f53__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_parenttheme_woo_php_wp_cc908a9e48789589e553f91761083f53__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_main_plugin_woo_php_wp_08cb3463942aa74df688a3f4a807718e__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_main_plugin_woo_php_wp_08cb3463942aa74df688a3f4a807718e__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_main_theme_woo_php_wp_3976d011ae5709242b883dfb4863e252__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_main_theme_woo_php_wp_3976d011ae5709242b883dfb4863e252__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_missing_plugin_woo_php_wp_b2f118a836d0b8cf4a8f3ca7c3af96c6__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_missing_plugin_woo_php_wp_b2f118a836d0b8cf4a8f3ca7c3af96c6__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_missing_theme_woo_php_wp_0f4ea06ab85fe945af93b8dc42336c32__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_missing_theme_woo_php_wp_0f4ea06ab85fe945af93b8dc42336c32__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_plugin_readme_woo_php_wp_e77ebed808cac5ec958e0ed7397b9ef4__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_plugin_readme_woo_php_wp_e77ebed808cac5ec958e0ed7397b9ef4__1.php
@@ -46,7 +46,7 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 3,
+            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"


### PR DESCRIPTION
We've been having self tests failing for a while, likely due to out of date snapshots. This PR updates them.