### PR TITLE
Update managed tests snapshots

### DIFF
--- a/_tests/managed_tests/tests/__snapshots__/MalwareTest__test_malware_jetpack_scan_woo_php_wp_6721f9775c2073c083e409914f62ed75__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/MalwareTest__test_malware_jetpack_scan_woo_php_wp_6721f9775c2073c083e409914f62ed75__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/MalwareTest__test_malware_no_op_woo_php_wp_0dd309d969e4d46682be10c3bd717eb0__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/MalwareTest__test_malware_no_op_woo_php_wp_0dd309d969e4d46682be10c3bd717eb0__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_childtheme_woo_php_wp_857a3bbe5fef96a3b158c7389549fa57__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_childtheme_woo_php_wp_857a3bbe5fef96a3b158c7389549fa57__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_main_woo_php_wp_28e03c1a3073469aae3b28c10dfeac1d__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_main_woo_php_wp_28e03c1a3073469aae3b28c10dfeac1d__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_parenttheme_woo_php_wp_6851f6654a4c24423121aa31423c2753__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_parenttheme_woo_php_wp_6851f6654a4c24423121aa31423c2753__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_72_to_74_woo_php_wp_b1c588503637a98590143b312a69beba__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_72_to_74_woo_php_wp_b1c588503637a98590143b312a69beba__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_81_to_82_woo_php_wp_6ee042538e1935736a9856e687d0c150__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_81_to_82_woo_php_wp_6ee042538e1935736a9856e687d0c150__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_default_php_version_woo_php_wp_aab4e9b0325ab0d8921f5fb94ffecdac__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpcompatibilityTest__test_phpcompatibility_sut_default_php_version_woo_php_wp_aab4e9b0325ab0d8921f5fb94ffecdac__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_additional_plugins_woo_php_wp_efa95b897ff4a83698ed4371166ccba5__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_additional_plugins_woo_php_wp_efa95b897ff4a83698ed4371166ccba5__1.php
@@ -48,7 +48,6 @@
             "phpstan_level": 2,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_childtheme_woo_php_wp_acd1df3b6787d2c2218b6be0b465f886__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_childtheme_woo_php_wp_acd1df3b6787d2c2218b6be0b465f886__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": 2,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_main_woo_php_wp_f80e75e0a6ea5d06dd6dc94dc9336592__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_main_woo_php_wp_f80e75e0a6ea5d06dd6dc94dc9336592__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": 2,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_parenttheme_woo_php_wp_995dee7cfdc6a851703a72185472abe7__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_parenttheme_woo_php_wp_995dee7cfdc6a851703a72185472abe7__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": 2,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_phpstan_neon_file_woo_php_wp_2bcbd964dd4ad8a665344d590acf7557__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_phpstan_neon_file_woo_php_wp_2bcbd964dd4ad8a665344d590acf7557__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": 2,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_with_vendor_woo_php_wp_b50d713e3b9c085feafab3638144cb8a__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/PhpstanTest__test_phpstan_with_vendor_woo_php_wp_b50d713e3b9c085feafab3638144cb8a__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": 2,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_childtheme_woo_php_wp_b075c74b6040c155dee4bf80601d8593__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_childtheme_woo_php_wp_b075c74b6040c155dee4bf80601d8593__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_db_woo_php_wp_49db8a4a428f094d772dd537f86cafc1__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_db_woo_php_wp_49db8a4a428f094d772dd537f86cafc1__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_exclusions_woo_php_wp_781a480f91705a029738d07d57a3454d__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_exclusions_woo_php_wp_781a480f91705a029738d07d57a3454d__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_main_woo_php_wp_58e73693928f158eed05cb07b0787674__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_main_woo_php_wp_58e73693928f158eed05cb07b0787674__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_nonce_woo_php_wp_675f895c6a36c524d03d9e313702ec6b__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_nonce_woo_php_wp_675f895c6a36c524d03d9e313702ec6b__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_parenttheme_woo_php_wp_cc908a9e48789589e553f91761083f53__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/SecurityTest__test_security_parenttheme_woo_php_wp_cc908a9e48789589e553f91761083f53__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_main_plugin_woo_php_wp_08cb3463942aa74df688a3f4a807718e__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_main_plugin_woo_php_wp_08cb3463942aa74df688a3f4a807718e__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_main_theme_woo_php_wp_3976d011ae5709242b883dfb4863e252__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_main_theme_woo_php_wp_3976d011ae5709242b883dfb4863e252__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_missing_plugin_woo_php_wp_b2f118a836d0b8cf4a8f3ca7c3af96c6__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_missing_plugin_woo_php_wp_b2f118a836d0b8cf4a8f3ca7c3af96c6__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_missing_theme_woo_php_wp_0f4ea06ab85fe945af93b8dc42336c32__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_missing_theme_woo_php_wp_0f4ea06ab85fe945af93b8dc42336c32__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_plugin_readme_woo_php_wp_e77ebed808cac5ec958e0ed7397b9ef4__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_plugin_readme_woo_php_wp_e77ebed808cac5ec958e0ed7397b9ef4__1.php
@@ -46,7 +46,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}"

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_childtheme_woostable_php82_wpstable_440db7a70e471458f49b3c2aca2ba623__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_childtheme_woostable_php82_wpstable_440db7a70e471458f49b3c2aca2ba623__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_delete_products_woorc_php74_wprc_ca644c3f45a3d92971d7c34b17b9bf40__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_delete_products_woorc_php74_wprc_ca644c3f45a3d92971d7c34b17b9bf40__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_delete_products_woorc_php82_wprc_8ddcb1dd26e5c14fcd0a28ef812daa5c__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_delete_products_woorc_php82_wprc_8ddcb1dd26e5c14fcd0a28ef812daa5c__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_delete_products_woostable_php74_wprc_c35449740535ad91e8942f8f0ed05b72__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_delete_products_woostable_php74_wprc_c35449740535ad91e8942f8f0ed05b72__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_delete_products_woostable_php82_wprc_f53670e03588ff82e9c536ab4127fb87__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_delete_products_woostable_php82_wprc_f53670e03588ff82e9c536ab4127fb87__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woorc_php74_wprc_346c5f1d46bbec1721f5bbf11816a5c0__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woorc_php74_wprc_346c5f1d46bbec1721f5bbf11816a5c0__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woorc_php82_wprc_2b7d6254596db2c73939e0d764cc4ba3__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woorc_php82_wprc_2b7d6254596db2c73939e0d764cc4ba3__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woostable_php74_wprc_7362ffe83e2b60ebc0cf5c63b3856976__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woostable_php74_wprc_7362ffe83e2b60ebc0cf5c63b3856976__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woostable_php82_wprc_5e58227b55849b8c7239a9971ae5d264__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_no_op_woostable_php82_wprc_5e58227b55849b8c7239a9971ae5d264__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woorc_php74_wprc_ffc30a443f4fcc32b0abe133375adbd8__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woorc_php74_wprc_ffc30a443f4fcc32b0abe133375adbd8__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woorc_php82_wprc_eb7749dc7ada621516b289b420c7aa83__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woorc_php82_wprc_eb7749dc7ada621516b289b420c7aa83__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woostable_php74_wprc_ca36e1e383c91cc1e399f1bab52b350b__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woostable_php74_wprc_ca36e1e383c91cc1e399f1bab52b350b__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woostable_php82_wprc_30c8c208075c921416b6f88c67b78c16__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_order_cache_bug_woostable_php82_wprc_30c8c208075c921416b6f88c67b78c16__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_parenttheme_woostable_php82_wpstable_4fea9b07dff27b783d26f0b4b90cc6e4__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_parenttheme_woostable_php82_wpstable_4fea9b07dff27b783d26f0b4b90cc6e4__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woorc_php74_wprc_fdd35606f836d278e28ee1655d190df0__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woorc_php74_wprc_fdd35606f836d278e28ee1655d190df0__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woorc_php82_wprc_f4cd9965b5cceb8e299a36acf245b6f0__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woorc_php82_wprc_f4cd9965b5cceb8e299a36acf245b6f0__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woostable_php74_wprc_c5e572f0e7a39cd8994d515514e0be3a__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woostable_php74_wprc_c5e572f0e7a39cd8994d515514e0be3a__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woostable_php82_wprc_18f274ce2084619bd42b38449a1c9321__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/WooapiTest__test_woo_api_valid_features_woostable_php82_wprc_18f274ce2084619bd42b38449a1c9321__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_delete_products_woorc_php74_wprc_b153920e11128a2003ccfabb5a1c2b66__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_delete_products_woorc_php74_wprc_b153920e11128a2003ccfabb5a1c2b66__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_delete_products_woostable_php74_wprc_2a952a960085a76868033dc54aa96159__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_delete_products_woostable_php74_wprc_2a952a960085a76868033dc54aa96159__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woorc_php82_wprc_4ee1157429027befae37425348f5bd84__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woorc_php82_wprc_4ee1157429027befae37425348f5bd84__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woorc_php82_wpstable_b23dfeb910e3a66fc64cf81023cfeaea__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woorc_php82_wpstable_b23dfeb910e3a66fc64cf81023cfeaea__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woostable_php82_wprc_960168535790f3a7eff463fb11517d63__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woostable_php82_wprc_960168535790f3a7eff463fb11517d63__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woostable_php82_wpstable_ed7d3932b380dcf5673cf151dde0eb37__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_php82_woostable_php82_wpstable_ed7d3932b380dcf5673cf151dde0eb37__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woorc_php74_wprc_818ebdd6b04d0991fd37d3414ff14307__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woorc_php74_wprc_818ebdd6b04d0991fd37d3414ff14307__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woorc_php74_wpstable_8ea880f7c0e5f4aeb8851ca23268fcd8__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woorc_php74_wpstable_8ea880f7c0e5f4aeb8851ca23268fcd8__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woostable_php74_wprc_865de3b217a16a96d42609a9ca8ebcf0__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woostable_php74_wprc_865de3b217a16a96d42609a9ca8ebcf0__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",

--- a/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woostable_php74_wpstable_4d0acdce8f051e58d6c20e496553c9b6__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/Wooe2eTest__test_woo_e2e_no_op_woostable_php74_wpstable_4d0acdce8f051e58d6c20e496553c9b6__1.php
@@ -44,7 +44,6 @@
             "phpstan_level": null,
             "test_variation": "",
             "test_packages": [],
-            "iterations": 7,
             "test_group_id": "",
             "created_at": "2025-01-01 00:00:00",
             "test_result_json_extracted": "{EXTRACTED}",


### PR DESCRIPTION
[This PR](https://github.com/woocommerce/qit-cli/pull/387) didn't update the self-tests snapshots, so we've prepared this one to address it and fix those tests.