### PR TITLE
Add InfraProvider interface for infrastructure abstraction

### DIFF
--- a/src/src/Environment/Infra/InfraProvider.php
+++ b/src/src/Environment/Infra/InfraProvider.php
@@ -7,11 +7,11 @@ use QIT_CLI\Environment\Environments\QITEnvInfo;
 
 /**
  * Infrastructure provider interface for environment provisioning.
- * Implementations handle Docker (local) or WP Cloud (remote) infrastructure.
+ * Implementations handle local (Docker) or cloud (remote) infrastructure.
  */
 interface InfraProvider {
 	/**
-	 * Provision infrastructure (Docker containers or WP Cloud instance).
+	 * Provision infrastructure (Docker containers or cloud instance).
 	 * After this call, the environment should be ready for WordPress setup.
 	 *
 	 * @param QITEnvInfo $env Environment configuration.
@@ -39,7 +39,7 @@ interface InfraProvider {
 	 *
 	 * @param QITEnvInfo $env Environment configuration.
 	 *
-	 * @return string Site URL (e.g., https://abc123.wpcloud.example.com).
+	 * @return string Site URL (e.g., https://abc123.example.com).
 	 */
 	public function get_site_url( QITEnvInfo $env ): string;
 
@@ -51,7 +51,7 @@ interface InfraProvider {
 	public function reset( QITEnvInfo $env ): void;
 
 	/**
-	 * Destroy the infrastructure (Docker down or release WP Cloud instance).
+	 * Destroy the infrastructure (Docker down or release cloud instance).
 	 *
 	 * @param QITEnvInfo $env Environment configuration.
 	 */

--- a/src/src/Environment/Infra/InfraProvider.php
+++ b/src/src/Environment/Infra/InfraProvider.php
@@ -1,0 +1,93 @@
+<?php
+declare( strict_types=1 );
+
+namespace QIT_CLI\Environment\Infra;
+
+use QIT_CLI\Environment\Environments\QITEnvInfo;
+
+/**
+ * Infrastructure provider interface for environment provisioning.
+ * Implementations handle Docker (local) or WP Cloud (remote) infrastructure.
+ */
+interface InfraProvider {
+	/**
+	 * Provision infrastructure (Docker containers or WP Cloud instance).
+	 * After this call, the environment should be ready for WordPress setup.
+	 *
+	 * @param QITEnvInfo $env Environment configuration.
+	 *
+	 * @throws \RuntimeException If provisioning fails.
+	 */
+	public function provision( QITEnvInfo $env ): void;
+
+	/**
+	 * Execute command inside the environment.
+	 *
+	 * @param QITEnvInfo           $env      Environment configuration.
+	 * @param array<string>        $command  Command to execute (e.g., ['wp', 'plugin', 'list']).
+	 * @param array<string,string> $env_vars Environment variables.
+	 * @param int                  $timeout  Timeout in seconds (0 = no timeout).
+	 *
+	 * @return string Command stdout.
+	 *
+	 * @throws \RuntimeException If command fails.
+	 */
+	public function exec( QITEnvInfo $env, array $command, array $env_vars = [], int $timeout = 300 ): string;
+
+	/**
+	 * Get the site URL for the environment.
+	 *
+	 * @param QITEnvInfo $env Environment configuration.
+	 *
+	 * @return string Site URL (e.g., https://abc123.wpcloud.example.com).
+	 */
+	public function get_site_url( QITEnvInfo $env ): string;
+
+	/**
+	 * Reset environment to post-setup state (restore DB snapshot).
+	 *
+	 * @param QITEnvInfo $env Environment configuration.
+	 */
+	public function reset( QITEnvInfo $env ): void;
+
+	/**
+	 * Destroy the infrastructure (Docker down or release WP Cloud instance).
+	 *
+	 * @param QITEnvInfo $env Environment configuration.
+	 */
+	public function destroy( QITEnvInfo $env ): void;
+
+	/**
+	 * Upload a file to the environment.
+	 *
+	 * @param QITEnvInfo $env         Environment configuration.
+	 * @param string     $local_path  Local file path.
+	 * @param string     $remote_path Remote destination path.
+	 */
+	public function upload( QITEnvInfo $env, string $local_path, string $remote_path ): void;
+
+	/**
+	 * Download a file from the environment.
+	 *
+	 * @param QITEnvInfo $env         Environment configuration.
+	 * @param string     $remote_path Remote file path.
+	 * @param string     $local_path  Local destination path.
+	 */
+	public function download( QITEnvInfo $env, string $remote_path, string $local_path ): void;
+
+	/**
+	 * Check if the infrastructure is healthy and responsive.
+	 *
+	 * @param QITEnvInfo $env Environment configuration.
+	 *
+	 * @return bool True if healthy.
+	 */
+	public function is_healthy( QITEnvInfo $env ): bool;
+
+	/**
+	 * Get the provider type identifier.
+	 *
+	 * @return string Provider type ('local' or 'cloud').
+	 */
+	public function get_type(): string;
+}


### PR DESCRIPTION
## Summary

- Adds `InfraProvider` interface at `src/src/Environment/Infra/InfraProvider.php`
- Defines contract for infrastructure providers (local Docker, cloud remote)
- Foundation for cloud infrastructure integration

## Interface Methods

| Method | Purpose |
|--------|---------|
| `provision()` | Create Docker containers or claim cloud instance |
| `exec()` | Execute command inside the environment |
| `get_site_url()` | Get the site URL |
| `reset()` | Reset to post-setup state (restore DB snapshot) |
| `destroy()` | Tear down infrastructure |
| `upload()` / `download()` | Transfer files to/from environment |
| `is_healthy()` | Check if infrastructure is responsive |
| `get_type()` | Return provider type identifier ('local' or 'cloud') |

## Test plan

- [x] PHP syntax check passes (`php -l`)
- [x] PHPCS passes (code style)
- [ ] Verify autoloading works when implementing `LocalProvider` (QIT-868)

## Related

- Linear: [QIT-867](https://linear.app/a8c/issue/QIT-867/create-infraprovider-interface)
- Next: QIT-868 (LocalProvider), QIT-869 (InfraProviderFactory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)