### PR TITLE
Add LocalProvider (Docker Wrapper)

### DIFF
--- a/src/src/Environment/Infra/LocalProvider.php
+++ b/src/src/Environment/Infra/LocalProvider.php
@@ -1,0 +1,106 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace QIT_CLI\Environment\Infra;
+
+use QIT_CLI\App;
+use QIT_CLI\Environment\Docker;
+use QIT_CLI\Environment\Environments\QITEnvInfo;
+
+/**
+ * Local infrastructure provider using Docker.
+ * Wraps the existing Docker class to implement InfraProvider interface.
+ */
+class LocalProvider implements InfraProvider {
+	protected Docker $docker;
+
+	public function __construct( ?Docker $docker = null ) {
+		$this->docker = $docker ?? App::make( Docker::class );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function provision( QITEnvInfo $env ): void {
+		// Docker provisioning is handled by Environment classes.
+		// This is called after docker-compose.yml is generated.
+		// The actual 'docker compose up' happens in Environment::up().
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function exec( QITEnvInfo $env, array $command, array $env_vars = [], int $timeout = 300 ): string {
+		return $this->docker->run_inside_docker(
+			$env,
+			$command,
+			$env_vars,
+			null,
+			$timeout
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_site_url( QITEnvInfo $env ): string {
+		if ( ! empty( $env->site_url ) ) {
+			return $env->site_url;
+		}
+
+		return "http://localhost:{$env->nginx_port}";
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function reset( QITEnvInfo $env ): void {
+		$snapshot_path = $env->temporary_env . '/db-snapshot.sql';
+
+		if ( file_exists( $snapshot_path ) ) {
+			$this->exec( $env, [ 'wp', 'db', 'import', '/qit/db-snapshot.sql' ] );
+		}
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function destroy( QITEnvInfo $env ): void {
+		// Docker cleanup is handled by Environment::down().
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function upload( QITEnvInfo $env, string $local_path, string $remote_path ): void {
+		$this->docker->copy_into_docker( $env, $local_path, $remote_path );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function download( QITEnvInfo $env, string $remote_path, string $local_path ): void {
+		$this->docker->copy_from_docker( $env, $remote_path, $local_path );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function is_healthy( QITEnvInfo $env ): bool {
+		try {
+			$result = $this->exec( $env, [ 'wp', 'eval', 'echo "ok";' ], [], 10 );
+
+			return trim( $result ) === 'ok';
+		} catch ( \Exception $e ) {
+			return false;
+		}
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function get_type(): string {
+		return 'local';
+	}
+}

--- a/src/tests/unit/Environment/Infra/LocalProviderTest.php
+++ b/src/tests/unit/Environment/Infra/LocalProviderTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace QIT_CLI_Tests\Environment\Infra;
+
+use PHPUnit\Framework\TestCase;
+use QIT_CLI\Environment\Docker;
+use QIT_CLI\Environment\Environments\E2E\E2EEnvInfo;
+use QIT_CLI\Environment\Infra\InfraProvider;
+use QIT_CLI\Environment\Infra\LocalProvider;
+
+class LocalProviderTest extends TestCase {
+	public function test_implements_infra_provider(): void {
+		$docker_mock = $this->createMock( Docker::class );
+		$provider    = new LocalProvider( $docker_mock );
+
+		$this->assertInstanceOf( InfraProvider::class, $provider );
+	}
+
+	public function test_get_type_returns_local(): void {
+		$docker_mock = $this->createMock( Docker::class );
+		$provider    = new LocalProvider( $docker_mock );
+
+		$this->assertEquals( 'local', $provider->get_type() );
+	}
+
+	public function test_get_site_url_returns_url_from_env_info(): void {
+		$docker_mock = $this->createMock( Docker::class );
+		$provider    = new LocalProvider( $docker_mock );
+
+		$env_info           = $this->createMock( E2EEnvInfo::class );
+		$env_info->site_url = 'http://example.local';
+
+		$this->assertEquals( 'http://example.local', $provider->get_site_url( $env_info ) );
+	}
+
+	public function test_get_site_url_returns_localhost_with_port_when_site_url_empty(): void {
+		$docker_mock = $this->createMock( Docker::class );
+		$provider    = new LocalProvider( $docker_mock );
+
+		$env_info             = $this->createMock( E2EEnvInfo::class );
+		$env_info->site_url   = '';
+		$env_info->nginx_port = '8080';
+
+		$this->assertEquals( 'http://localhost:8080', $provider->get_site_url( $env_info ) );
+	}
+
+	public function test_exec_delegates_to_docker_run_inside_docker(): void {
+		$docker_mock = $this->createMock( Docker::class );
+
+		$env_info = $this->createMock( E2EEnvInfo::class );
+		$command  = [ 'wp', 'plugin', 'list' ];
+		$env_vars = [ 'FOO' => 'bar' ];
+		$timeout  = 120;
+
+		$docker_mock->expects( $this->once() )
+			->method( 'run_inside_docker' )
+			->with( $env_info, $command, $env_vars, null, $timeout )
+			->willReturn( 'plugin output' );
+
+		$provider = new LocalProvider( $docker_mock );
+		$result   = $provider->exec( $env_info, $command, $env_vars, $timeout );
+
+		$this->assertEquals( 'plugin output', $result );
+	}
+
+	public function test_upload_delegates_to_docker_copy_into_docker(): void {
+		$docker_mock = $this->createMock( Docker::class );
+
+		$env_info     = $this->createMock( E2EEnvInfo::class );
+		$local_path   = '/local/file.txt';
+		$remote_path  = '/var/www/html/file.txt';
+
+		$docker_mock->expects( $this->once() )
+			->method( 'copy_into_docker' )
+			->with( $env_info, $local_path, $remote_path );
+
+		$provider = new LocalProvider( $docker_mock );
+		$provider->upload( $env_info, $local_path, $remote_path );
+	}
+
+	public function test_download_delegates_to_docker_copy_from_docker(): void {
+		$docker_mock = $this->createMock( Docker::class );
+
+		$env_info    = $this->createMock( E2EEnvInfo::class );
+		$remote_path = '/var/www/html/file.txt';
+		$local_path  = '/local/file.txt';
+
+		$docker_mock->expects( $this->once() )
+			->method( 'copy_from_docker' )
+			->with( $env_info, $remote_path, $local_path );
+
+		$provider = new LocalProvider( $docker_mock );
+		$provider->download( $env_info, $remote_path, $local_path );
+	}
+
+	public function test_is_healthy_returns_true_when_wp_cli_responds(): void {
+		$docker_mock = $this->createMock( Docker::class );
+		$env_info    = $this->createMock( E2EEnvInfo::class );
+
+		$docker_mock->expects( $this->once() )
+			->method( 'run_inside_docker' )
+			->with( $env_info, [ 'wp', 'eval', 'echo "ok";' ], [], null, 10 )
+			->willReturn( 'ok' );
+
+		$provider = new LocalProvider( $docker_mock );
+		$this->assertTrue( $provider->is_healthy( $env_info ) );
+	}
+
+	public function test_is_healthy_returns_false_when_wp_cli_fails(): void {
+		$docker_mock = $this->createMock( Docker::class );
+		$env_info    = $this->createMock( E2EEnvInfo::class );
+
+		$docker_mock->expects( $this->once() )
+			->method( 'run_inside_docker' )
+			->willThrowException( new \RuntimeException( 'Docker error' ) );
+
+		$provider = new LocalProvider( $docker_mock );
+		$this->assertFalse( $provider->is_healthy( $env_info ) );
+	}
+
+	public function test_is_healthy_returns_false_when_response_is_not_ok(): void {
+		$docker_mock = $this->createMock( Docker::class );
+		$env_info    = $this->createMock( E2EEnvInfo::class );
+
+		$docker_mock->expects( $this->once() )
+			->method( 'run_inside_docker' )
+			->willReturn( 'error: something went wrong' );
+
+		$provider = new LocalProvider( $docker_mock );
+		$this->assertFalse( $provider->is_healthy( $env_info ) );
+	}
+
+	public function test_provision_is_a_noop(): void {
+		$docker_mock = $this->createMock( Docker::class );
+		$env_info    = $this->createMock( E2EEnvInfo::class );
+
+		// Docker should NOT be called during provision for LocalProvider
+		// as provisioning is handled by Environment classes
+		$docker_mock->expects( $this->never() )
+			->method( 'run_inside_docker' );
+
+		$provider = new LocalProvider( $docker_mock );
+		$provider->provision( $env_info );
+
+		// No exception means success
+		$this->assertTrue( true );
+	}
+
+	public function test_destroy_is_a_noop(): void {
+		$docker_mock = $this->createMock( Docker::class );
+		$env_info    = $this->createMock( E2EEnvInfo::class );
+
+		// Docker should NOT be called during destroy for LocalProvider
+		// as cleanup is handled by Environment classes
+		$docker_mock->expects( $this->never() )
+			->method( 'run_inside_docker' );
+
+		$provider = new LocalProvider( $docker_mock );
+		$provider->destroy( $env_info );
+
+		// No exception means success
+		$this->assertTrue( true );
+	}
+
+	public function test_reset_imports_db_snapshot_when_exists(): void {
+		$docker_mock   = $this->createMock( Docker::class );
+		$env_info      = $this->createMock( E2EEnvInfo::class );
+		$temp_dir      = sys_get_temp_dir() . '/qit-test-' . uniqid();
+		$snapshot_path = $temp_dir . '/db-snapshot.sql';
+
+		// Create temporary directory and snapshot file
+		mkdir( $temp_dir, 0755, true );
+		file_put_contents( $snapshot_path, 'SQL DUMP' );
+
+		try {
+			$env_info->temporary_env = $temp_dir;
+
+			$docker_mock->expects( $this->once() )
+				->method( 'run_inside_docker' )
+				->with( $env_info, [ 'wp', 'db', 'import', '/qit/db-snapshot.sql' ], [], null, 300 );
+
+			$provider = new LocalProvider( $docker_mock );
+			$provider->reset( $env_info );
+		} finally {
+			// Cleanup
+			unlink( $snapshot_path );
+			rmdir( $temp_dir );
+		}
+	}
+
+	public function test_reset_does_nothing_when_snapshot_does_not_exist(): void {
+		$docker_mock = $this->createMock( Docker::class );
+		$env_info    = $this->createMock( E2EEnvInfo::class );
+
+		$env_info->temporary_env = '/nonexistent/path';
+
+		// Docker should NOT be called when no snapshot exists
+		$docker_mock->expects( $this->never() )
+			->method( 'run_inside_docker' );
+
+		$provider = new LocalProvider( $docker_mock );
+		$provider->reset( $env_info );
+
+		// No exception means success
+		$this->assertTrue( true );
+	}
+}


### PR DESCRIPTION
## Summary

- Implements QIT-868: Create LocalProvider (Docker Wrapper)
- Creates `LocalProvider` class that wraps the existing `Docker` class to implement the `InfraProvider` interface
- This is part of Phase 1 of the WP Cloud-Hosted QIT Sites project

## Implementation Details

The `LocalProvider` class wraps existing Docker functionality:

| Method | Behavior |
|--------|----------|
| `provision()` | No-op (Docker provisioning handled by Environment classes) |
| `exec()` | Delegates to `Docker::run_inside_docker()` |
| `get_site_url()` | Returns `site_url` or `localhost:{nginx_port}` |
| `reset()` | Imports db-snapshot.sql if exists |
| `destroy()` | No-op (Docker cleanup handled by Environment::down()) |
| `upload()` | Delegates to `Docker::copy_into_docker()` |
| `download()` | Delegates to `Docker::copy_from_docker()` |
| `is_healthy()` | Runs `wp eval 'echo "ok";'` and checks response |
| `get_type()` | Returns `'local'` |

## Files Changed

- **New:** `src/src/Environment/Infra/LocalProvider.php`
- **New:** `tests/unit/Environment/Infra/LocalProviderTest.php`

## Test plan

- [x] 14 unit tests added covering all methods
- [x] All 129 unit tests pass (no regressions)
- [x] Follows TDD approach (tests written first)

## Dependencies

- Depends on QIT-867 (InfraProvider Interface) - already merged

🤖 Generated with [Claude Code](https://claude.ai/code)