### PR TITLE
Add InfraProviderFactory for provider instantiation

### DIFF
--- a/src/src/Environment/Infra/InfraProviderFactory.php
+++ b/src/src/Environment/Infra/InfraProviderFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace QIT_CLI\Environment\Infra;
+
+/**
+ * Factory for creating infrastructure providers.
+ */
+class InfraProviderFactory {
+	/** @var array<string, class-string<InfraProvider>> */
+	protected array $providers = [
+		'local' => LocalProvider::class,
+		// 'cloud' => CloudProvider::class, // Added in Phase 5 (QIT-882)
+	];
+
+	/**
+	 * Create an infrastructure provider by type.
+	 *
+	 * @param string $type Provider type ('local' or 'cloud').
+	 *
+	 * @return InfraProvider
+	 *
+	 * @throws \InvalidArgumentException If type is unknown.
+	 */
+	public function create( string $type ): InfraProvider {
+		if ( ! isset( $this->providers[ $type ] ) ) {
+			throw new \InvalidArgumentException(
+				sprintf(
+					'Unknown provider type: %s. Available: %s',
+					$type,
+					implode( ', ', array_keys( $this->providers ) )
+				)
+			);
+		}
+
+		$class = $this->providers[ $type ];
+
+		return new $class();
+	}
+
+	/**
+	 * Get available provider types.
+	 *
+	 * @return array<string>
+	 */
+	public function get_available_types(): array {
+		return array_keys( $this->providers );
+	}
+
+	/**
+	 * Register a new provider type.
+	 *
+	 * @param string $type           Provider type identifier.
+	 * @param string $provider_class Provider class name implementing InfraProvider.
+	 */
+	public function register( string $type, string $provider_class ): void {
+		$this->providers[ $type ] = $provider_class;
+	}
+}

--- a/src/tests/unit/Environment/Infra/InfraProviderFactoryTest.php
+++ b/src/tests/unit/Environment/Infra/InfraProviderFactoryTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace QIT_CLI_Tests\Environment\Infra;
+
+use PHPUnit\Framework\TestCase;
+use QIT_CLI\Environment\Infra\InfraProvider;
+use QIT_CLI\Environment\Infra\InfraProviderFactory;
+use QIT_CLI\Environment\Infra\LocalProvider;
+
+class InfraProviderFactoryTest extends TestCase {
+	public function test_create_local_provider(): void {
+		$factory  = new InfraProviderFactory();
+		$provider = $factory->create( 'local' );
+
+		$this->assertInstanceOf( LocalProvider::class, $provider );
+		$this->assertInstanceOf( InfraProvider::class, $provider );
+	}
+
+	public function test_create_throws_for_unknown_type(): void {
+		$factory = new InfraProviderFactory();
+
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Unknown provider type: unknown' );
+
+		$factory->create( 'unknown' );
+	}
+
+	public function test_create_exception_lists_available_types(): void {
+		$factory = new InfraProviderFactory();
+
+		try {
+			$factory->create( 'invalid' );
+			$this->fail( 'Expected InvalidArgumentException was not thrown' );
+		} catch ( \InvalidArgumentException $e ) {
+			$this->assertStringContainsString( 'Available: local', $e->getMessage() );
+		}
+	}
+
+	public function test_get_available_types(): void {
+		$factory = new InfraProviderFactory();
+		$types   = $factory->get_available_types();
+
+		$this->assertContains( 'local', $types );
+	}
+
+	public function test_register_custom_provider(): void {
+		$factory = new InfraProviderFactory();
+		$factory->register( 'custom', LocalProvider::class );
+
+		$this->assertContains( 'custom', $factory->get_available_types() );
+	}
+
+	public function test_register_can_override_existing_type(): void {
+		$factory = new InfraProviderFactory();
+
+		// Create a mock provider class reference (use LocalProvider as a stand-in)
+		$factory->register( 'local', LocalProvider::class );
+
+		$provider = $factory->create( 'local' );
+		$this->assertInstanceOf( LocalProvider::class, $provider );
+	}
+
+	public function test_create_returns_new_instance_each_time(): void {
+		$factory   = new InfraProviderFactory();
+		$provider1 = $factory->create( 'local' );
+		$provider2 = $factory->create( 'local' );
+
+		$this->assertNotSame( $provider1, $provider2 );
+	}
+}


### PR DESCRIPTION
## Summary

- Add `InfraProviderFactory` class for creating infrastructure providers by type
- Initially registers `local` provider (`LocalProvider::class`)
- `cloud` provider will be added in Phase 5 (QIT-882)
- Add unit tests for factory functionality

## Test plan
No need to perform manual testing, a code review is enough at this point.

- [x] `create('local')` returns a `LocalProvider` instance
- [x] `create('unknown')` throws `InvalidArgumentException` with helpful message
- [x] `get_available_types()` returns array of registered type strings
- [x] `register()` allows adding new provider types at runtime
- [x] All unit tests pass (7 tests, 9 assertions)
- [x] PHPCS passes

Closes QIT-869

🤖 Generated with [Claude Code](https://claude.com/claude-code)