### PR TITLE
Add provider_type and cloud_environment_id to QITEnvInfo

### DIFF
--- a/src/src/Environment/Environments/QITEnvInfo.php
+++ b/src/src/Environment/Environments/QITEnvInfo.php
@@ -7,6 +7,21 @@ namespace QIT_CLI\Environment\Environments;
  * Contains common properties shared across different test environment types.
  */
 abstract class QITEnvInfo extends EnvInfo {
+	/**
+	 * Infrastructure provider type.
+	 *
+	 * @var string 'local' (Docker) or 'cloud'
+	 */
+	public string $provider_type = 'local';
+
+	/**
+	 * Cloud environment ID for cloud provider.
+	 * Used to identify the environment in Manager API calls.
+	 *
+	 * @var string|null
+	 */
+	public ?string $cloud_environment_id = null;
+
 	/** @var string WordPress version */
 	public string $wordpress_version = '';
 

--- a/src/tests/unit/EnvInfoTest.php
+++ b/src/tests/unit/EnvInfoTest.php
@@ -29,4 +29,94 @@ class EnvInfoTests extends QITTestCase {
 		$this->assertEquals( 'running', $env_info['status'] );
 		$this->assertEquals( [ 'test1', 'test2' ], $env_info['docker_images'] );
 	}
+
+	public function test_provider_type_defaults_to_local() {
+		$array    = [ 'environment' => 'e2e' ];
+		$env_info = EnvInfo::from_array( $array );
+
+		$this->assertEquals( 'local', $env_info->provider_type );
+	}
+
+	public function test_cloud_environment_id_defaults_to_null() {
+		$array    = [ 'environment' => 'e2e' ];
+		$env_info = EnvInfo::from_array( $array );
+
+		$this->assertNull( $env_info->cloud_environment_id );
+	}
+
+	public function test_provider_type_is_deserialized_from_array() {
+		$array = [
+			'environment'   => 'e2e',
+			'provider_type' => 'cloud',
+		];
+		$env_info = EnvInfo::from_array( $array );
+
+		$this->assertEquals( 'cloud', $env_info->provider_type );
+	}
+
+	public function test_cloud_environment_id_is_deserialized_from_array() {
+		$array = [
+			'environment'           => 'e2e',
+			'cloud_environment_id'  => 'cloud-env-abc123',
+		];
+		$env_info = EnvInfo::from_array( $array );
+
+		$this->assertEquals( 'cloud-env-abc123', $env_info->cloud_environment_id );
+	}
+
+	public function test_provider_type_is_serialized_to_json() {
+		$array                   = [ 'environment' => 'e2e' ];
+		$env_info                = EnvInfo::from_array( $array );
+		$env_info->provider_type = 'cloud';
+
+		$serialized = json_decode( json_encode( $env_info ), true );
+
+		$this->assertArrayHasKey( 'provider_type', $serialized );
+		$this->assertEquals( 'cloud', $serialized['provider_type'] );
+	}
+
+	public function test_cloud_environment_id_is_serialized_to_json() {
+		$array                          = [ 'environment' => 'e2e' ];
+		$env_info                       = EnvInfo::from_array( $array );
+		$env_info->cloud_environment_id = 'cloud-env-xyz789';
+
+		$serialized = json_decode( json_encode( $env_info ), true );
+
+		$this->assertArrayHasKey( 'cloud_environment_id', $serialized );
+		$this->assertEquals( 'cloud-env-xyz789', $serialized['cloud_environment_id'] );
+	}
+
+	public function test_backward_compatibility_without_provider_fields() {
+		// Simulate loading old cached data without provider fields
+		$old_cached_data = [
+			'environment'    => 'e2e',
+			'temporary_env'  => '/tmp/old-env',
+			'created_at'     => 12345,
+			'status'         => 'running',
+			'docker_images'  => [ 'image1' ],
+		];
+		$env_info = EnvInfo::from_array( $old_cached_data );
+
+		// Should use default values
+		$this->assertEquals( 'local', $env_info->provider_type );
+		$this->assertNull( $env_info->cloud_environment_id );
+
+		// Existing fields should still work
+		$this->assertEquals( '/tmp/old-env', $env_info->temporary_env );
+		$this->assertEquals( 12345, $env_info->created_at );
+	}
+
+	public function test_provider_type_roundtrip() {
+		$original = [
+			'environment'          => 'e2e',
+			'provider_type'        => 'cloud',
+			'cloud_environment_id' => 'test-cloud-id',
+		];
+		$env_info   = EnvInfo::from_array( $original );
+		$serialized = json_decode( json_encode( $env_info ), true );
+		$restored   = EnvInfo::from_array( $serialized );
+
+		$this->assertEquals( 'cloud', $restored->provider_type );
+		$this->assertEquals( 'test-cloud-id', $restored->cloud_environment_id );
+	}
 }

--- a/src/tests/unit/__snapshots__/EnvInfoTests__test_serialize_env_info__1.json
+++ b/src/tests/unit/__snapshots__/EnvInfoTests__test_serialize_env_info__1.json
@@ -21,6 +21,8 @@
     "tunnel_type": "no_tunnel",
     "site_url": "",
     "domain": "localhost",
+    "provider_type": "local",
+    "cloud_environment_id": null,
     "wordpress_version": "",
     "woocommerce_version": "",
     "php_version": "",

--- a/src/tests/unit/__snapshots__/EnvironmentMonitorTest__test_environment_add__1.json
+++ b/src/tests/unit/__snapshots__/EnvironmentMonitorTest__test_environment_add__1.json
@@ -19,6 +19,8 @@
         "tunnel_type": "no_tunnel",
         "site_url": "",
         "domain": "localhost",
+        "provider_type": "local",
+        "cloud_environment_id": null,
         "wordpress_version": "",
         "woocommerce_version": "",
         "php_version": "",

--- a/src/tests/unit/__snapshots__/EnvironmentMonitorTest__test_environment_adds_multiple__1.json
+++ b/src/tests/unit/__snapshots__/EnvironmentMonitorTest__test_environment_adds_multiple__1.json
@@ -19,6 +19,8 @@
         "tunnel_type": "no_tunnel",
         "site_url": "",
         "domain": "localhost",
+        "provider_type": "local",
+        "cloud_environment_id": null,
         "wordpress_version": "",
         "woocommerce_version": "",
         "php_version": "",

--- a/src/tests/unit/__snapshots__/EnvironmentMonitorTest__test_environment_stops_with_multiple__1.json
+++ b/src/tests/unit/__snapshots__/EnvironmentMonitorTest__test_environment_stops_with_multiple__1.json
@@ -19,6 +19,8 @@
         "tunnel_type": "no_tunnel",
         "site_url": "",
         "domain": "localhost",
+        "provider_type": "local",
+        "cloud_environment_id": null,
         "wordpress_version": "",
         "woocommerce_version": "",
         "php_version": "",

--- a/src/tests/unit/__snapshots__/EnvironmentMonitorTest__test_environment_updated__1.json
+++ b/src/tests/unit/__snapshots__/EnvironmentMonitorTest__test_environment_updated__1.json
@@ -19,6 +19,8 @@
         "tunnel_type": "no_tunnel",
         "site_url": "",
         "domain": "localhost",
+        "provider_type": "local",
+        "cloud_environment_id": null,
         "wordpress_version": "",
         "woocommerce_version": "",
         "php_version": "",

--- a/src/tests/unit/__snapshots__/EnvironmentMonitorTest__test_makes_env_info_from_path__1.json
+++ b/src/tests/unit/__snapshots__/EnvironmentMonitorTest__test_makes_env_info_from_path__1.json
@@ -18,6 +18,8 @@
     "tunnel_type": "no_tunnel",
     "site_url": "",
     "domain": "localhost",
+    "provider_type": "local",
+    "cloud_environment_id": null,
     "wordpress_version": "",
     "woocommerce_version": "",
     "php_version": "",


### PR DESCRIPTION
## Summary

- Add `provider_type` property to `QITEnvInfo` with default value `'local'`
- Add `cloud_environment_id` property to `QITEnvInfo` with default value `null`
- Add 8 unit tests covering defaults, serialization, deserialization, and backward compatibility

These properties enable QIT to track which infrastructure provider is being used for test environments, supporting the upcoming cloud integration (Phase 1 of WP Cloud-Hosted QIT Sites project).

## Changes

**`QITEnvInfo.php`:**
```php
public string $provider_type = 'local';
public ?string $cloud_environment_id = null;
```

**No changes needed to `from_array()` or `to_array()`** - the existing dynamic property handling automatically supports the new fields.

## Test plan

- [x] All 137 unit tests pass
- [x] PHPStan passes with no errors
- [x] PHPCS passes
- [x] New tests verify:
  - Default values (`local` and `null`)
  - Serialization to JSON
  - Deserialization from array
  - Backward compatibility with old cached data
  - Roundtrip serialization/deserialization

Closes QIT-870

🤖 Generated with [Claude Code](https://claude.ai/code)