### PR TITLE
Add --provider flag to UpEnvironmentCommand

### DIFF
--- a/src/src/Commands/Environment/UpEnvironmentCommand.php
+++ b/src/src/Commands/Environment/UpEnvironmentCommand.php
@@ -11,6 +11,7 @@ use QIT_CLI\Environment\Environments\E2E\E2EEnvInfo;
 use QIT_CLI\Environment\Environments\Performance\PerformanceEnvironment;
 use QIT_CLI\Environment\Environments\Performance\PerformanceEnvInfo;
 use QIT_CLI\Environment\Environments\QITEnvInfo;
+use QIT_CLI\Environment\Infra\InfraProviderFactory;
 use QIT_CLI\QITInput;
 use QIT_CLI\Tunnel\TunnelRunner;
 use Symfony\Component\Console\Command\Command;
@@ -91,6 +92,7 @@ class UpEnvironmentCommand extends QITCommand {
 			->addOption( 'skip_activating_plugins', null, InputOption::VALUE_NONE, 'Skip activating plugins during environment setup' )
 			->addOption( 'skip_activating_themes', null, InputOption::VALUE_NONE, 'Skip activating themes during environment setup' )
 			->addOption( 'json', 'j', InputOption::VALUE_NONE, 'Machine‑readable JSON output' )
+			->addOption( 'provider', null, InputOption::VALUE_OPTIONAL, 'Infrastructure provider (currently only "local" is available)', InfraProviderFactory::PROVIDER_LOCAL )
 			->setHelp( $this->getHelpText() );
 	}
 
@@ -104,6 +106,21 @@ class UpEnvironmentCommand extends QITCommand {
 		if ( is_windows() ) {
 			$output->writeln( '<comment>QIT environments require WSL on Windows.</comment>' );
 
+			return Command::FAILURE;
+		}
+
+		/* ─ Validate provider type ─ */
+		$provider_type = $input->getOption( 'provider' );
+		if ( ! in_array( $provider_type, InfraProviderFactory::ALLOWED_TYPES, true ) ) {
+			$error_message = sprintf( 'Invalid provider "%s". Must be one of: %s.', $provider_type, implode( ', ', InfraProviderFactory::ALLOWED_TYPES ) );
+			if ( $input->getOption( 'json' ) ) {
+				$output->writeln( json_encode( [
+					'error'   => true,
+					'message' => $error_message,
+				] ) );
+			} else {
+				$output->writeln( '<error>' . $error_message . '</error>' );
+			}
 			return Command::FAILURE;
 		}
 
@@ -660,6 +677,7 @@ class UpEnvironmentCommand extends QITCommand {
 		$env_info = $env_info_class::from_array( [
 			'env_id'                  => 'qitenv' . bin2hex( random_bytes( 8 ) ),
 			'environment'             => $environment_type,
+			'provider_type'           => $provider_type,
 			'php_version'             => $env_config['php_version'] ?? '8.2',
 			'wordpress_version'       => $env_config['wordpress_version'] ?? 'stable',
 			'woocommerce_version'     => $env_config['woocommerce_version'] ?? '',
@@ -1534,13 +1552,13 @@ HELP;
 	 * Extract requirements from a test package manifest.
 	 *
 	 * @param \QIT_CLI\PreCommand\Objects\TestPackageManifest $manifest The manifest to extract from.
-	 * @param string $package_ref The package reference for tracking which package requires what.
-	 * @param array<string,array<string>> &$required_plugins By-reference array to append plugin requirements to.
-	 * @param array<string,array<string>> &$required_themes By-reference array to append theme requirements to.
-	 * @param array<string,array<string>> &$required_secrets By-reference array to append secret requirements to.
-	 * @param bool &$requires_network By-reference flag to set if package requires network.
-	 * @param bool &$requires_tunnel By-reference flag to set if package requires tunnel.
-	 * @param OutputInterface $output The output interface for verbose messages.
+	 * @param string                                          $package_ref The package reference for tracking which package requires what.
+	 * @param array<string,array<string>>                     &$required_plugins By-reference array to append plugin requirements to.
+	 * @param array<string,array<string>>                     &$required_themes By-reference array to append theme requirements to.
+	 * @param array<string,array<string>>                     &$required_secrets By-reference array to append secret requirements to.
+	 * @param bool                                            &$requires_network By-reference flag to set if package requires network.
+	 * @param bool                                            &$requires_tunnel By-reference flag to set if package requires tunnel.
+	 * @param OutputInterface                                 $output The output interface for verbose messages.
 	 */
 	private function extractManifestRequirements(
 		\QIT_CLI\PreCommand\Objects\TestPackageManifest $manifest,

--- a/src/src/Commands/TestPackages/PackageShowCommand.php
+++ b/src/src/Commands/TestPackages/PackageShowCommand.php
@@ -168,11 +168,11 @@ class PackageShowCommand extends QITCommand {
 				foreach ( [ 'globalSetup', 'setup', 'run', 'teardown', 'globalTeardown' ] as $phase_name ) {
 					$commands = $phases[ $phase_name ] ?? [];
 					if ( ! empty( $commands ) && is_array( $commands ) ) {
-						$command_str         = implode( "\n        ", $commands );
-						$phase_info[]        = sprintf( '  <info>✓ %s:</info>', $phase_name );
-						$phase_info[]        = '        ' . $command_str;
+						$command_str  = implode( "\n        ", $commands );
+						$phase_info[] = sprintf( '  <info>✓ %s:</info>', $phase_name );
+						$phase_info[] = '        ' . $command_str;
 					} else {
-						$status = ( $phase_name === 'run' && $is_utility ) ?
+						$status       = ( $phase_name === 'run' && $is_utility ) ?
 							'<comment>✗ ' . $phase_name . ': (none - this is a utility package)</comment>' :
 							'  <fg=gray>✗ ' . $phase_name . ': (none)</>';
 						$phase_info[] = $status;

--- a/src/src/Environment/Infra/InfraProviderFactory.php
+++ b/src/src/Environment/Infra/InfraProviderFactory.php
@@ -8,16 +8,27 @@ namespace QIT_CLI\Environment\Infra;
  * Factory for creating infrastructure providers.
  */
 class InfraProviderFactory {
+	/** Provider type: Local Docker environment */
+	public const PROVIDER_LOCAL = 'local';
+
+	/**
+	 * All valid provider types for user input validation.
+	 *
+	 * @var array<string>
+	 */
+	public const ALLOWED_TYPES = [
+		self::PROVIDER_LOCAL,
+	];
+
 	/** @var array<string, class-string<InfraProvider>> */
 	protected array $providers = [
-		'local' => LocalProvider::class,
-		// 'cloud' => CloudProvider::class, // Added in Phase 5 (QIT-882)
+		self::PROVIDER_LOCAL => LocalProvider::class,
 	];
 
 	/**
 	 * Create an infrastructure provider by type.
 	 *
-	 * @param string $type Provider type ('local' or 'cloud').
+	 * @param string $type Provider type (e.g., 'local').
 	 *
 	 * @return InfraProvider
 	 *

--- a/src/src/PreCommand/Objects/TestPackageManifest.php
+++ b/src/src/PreCommand/Objects/TestPackageManifest.php
@@ -101,8 +101,8 @@ final class TestPackageManifest {
 		$this->package_type = $data['package_type'] ?? $this->derive_package_type();
 		$this->test_type    = $data['test_type'] ?? 'e2e';
 		$this->test_dir     = $data['test_dir'] ?? './';
-		$this->description = $data['description'] ?? '';
-		$this->requires    = $data['requires'] ?? [];
+		$this->description  = $data['description'] ?? '';
+		$this->requires     = $data['requires'] ?? [];
 
 		// Validate secrets format if present (security check)
 		if ( isset( $this->requires['secrets'] ) && is_array( $this->requires['secrets'] ) ) {

--- a/src/tests/integration/tests/Commands/UpEnvironmentCommandTest.php
+++ b/src/tests/integration/tests/Commands/UpEnvironmentCommandTest.php
@@ -791,7 +791,7 @@ class UpEnvironmentCommandTest extends TestCase {
 				],
 			],
 		];
-		
+
 		$output = qit_run_env_up( [
 			'env:up',
 			'--json',
@@ -804,25 +804,123 @@ class UpEnvironmentCommandTest extends TestCase {
 			'--object_cache',
 		], $config );
 		$data = json_decode( $output, true );
-		
+
 		// Check everything
 		$this->assertEquals( 'e2e', $data['environment'] );
 		$this->assertEquals( '8.2', $data['php_version'] ); // CLI override
 		$this->assertEquals( '6.2', $data['wordpress_version'] ); // From config
 		$this->assertTrue( $data['object_cache'] );
-		
+
 		// Plugins
 		$pluginSlugs = array_column( $data['plugins'], 'slug' );
 		$this->assertContains( 'woocommerce', $pluginSlugs ); // From --woo
 		$this->assertContains( 'akismet', $pluginSlugs ); // From config
 		$this->assertContains( 'jetpack', $pluginSlugs ); // From CLI
-		
+
 		// Themes
 		$themeSlugs = array_column( $data['themes'], 'slug' );
 		$this->assertContains( 'twentytwentythree', $themeSlugs ); // From config
 		$this->assertContains( 'storefront', $themeSlugs ); // From CLI
-		
+
 		// PHP extensions
 		$this->assertContains( 'gd', $data['php_extensions'] );
+	}
+
+	/*******************************************************************
+	 * Provider Flag Tests (QIT-871)
+	 ******************************************************************/
+
+	/**
+	 * Test env:up without --provider uses 'local' by default (backward compatible).
+	 */
+	public function test_env_up_provider_defaults_to_local(): void {
+		$output = qit_run_env_up( [ 'env:up', '--json' ] );
+		$data = json_decode( $output, true );
+
+		// Should default to 'local' provider
+		$this->assertArrayHasKey( 'provider_type', $data );
+		$this->assertEquals( 'local', $data['provider_type'] );
+	}
+
+	/**
+	 * Test env:up with explicit --provider=local.
+	 */
+	public function test_env_up_provider_explicit_local(): void {
+		$output = qit_run_env_up( [
+			'env:up',
+			'--json',
+			'--provider', 'local',
+		] );
+		$data = json_decode( $output, true );
+
+		// Should use 'local' provider
+		$this->assertArrayHasKey( 'provider_type', $data );
+		$this->assertEquals( 'local', $data['provider_type'] );
+	}
+
+	/**
+	 * Test env:up with --provider=cloud is rejected (not yet implemented).
+	 */
+	public function test_env_up_provider_cloud_not_implemented(): void {
+		// Cloud provider is not yet implemented, should be rejected
+		$output = qit_run_env_up(
+			[
+				'env:up',
+				'--json',
+				'--provider', 'cloud',
+			],
+			[],
+			1 // Expect failure
+		);
+
+		// The output should contain an error message about invalid provider
+		$this->assertStringContainsString( 'Invalid provider', $output );
+	}
+
+	/**
+	 * Test env:up with invalid --provider throws exception.
+	 */
+	public function test_env_up_provider_invalid_throws_exception(): void {
+		// Invalid provider should throw an exception with exit code 1
+		$output = qit_run_env_up(
+			[
+				'env:up',
+				'--json',
+				'--provider', 'invalid_provider',
+			],
+			[],
+			1 // Expect failure
+		);
+
+		// The output should contain an error message about invalid provider
+		$this->assertStringContainsString( 'Invalid provider', $output );
+	}
+
+	/**
+	 * Test env:up provider with config uses local provider.
+	 */
+	public function test_env_up_provider_with_config(): void {
+		$config = [
+			'environments' => [
+				'default' => [
+					'php_version' => '8.2',
+					'wordpress_version' => '6.5',
+				],
+			],
+		];
+
+		// With config, --provider=local should work and config values applied
+		$output = qit_run_env_up( [
+			'env:up',
+			'--json',
+			'--provider', 'local',
+		], $config );
+		$data = json_decode( $output, true );
+
+		// Should use 'local' provider
+		$this->assertEquals( 'local', $data['provider_type'] );
+		// Config values should still be applied
+		$this->assertEquals( '8.2', $data['php_version'] );
+		$this->assertEquals( '6.5', $data['wordpress_version'] );
 	}
 }

--- a/src/tests/integration/tests/Commands/UpEnvironmentCommandTest.php
+++ b/src/tests/integration/tests/Commands/UpEnvironmentCommandTest.php
@@ -827,7 +827,7 @@ class UpEnvironmentCommandTest extends TestCase {
 	}
 
 	/*******************************************************************
-	 * Provider Flag Tests (QIT-871)
+	 * Provider Flag Tests
 	 ******************************************************************/
 
 	/**


### PR DESCRIPTION
## Summary
- Adds `--provider` option to `env:up` command with 'local' as default
- Adds `PROVIDER_LOCAL` constant and `ALLOWED_TYPES` to `InfraProviderFactory` for centralized provider type management
- Validates provider type and sets `provider_type` on `env_info`
- Adds integration tests for provider flag behavior

Currently only 'local' provider is available.

Closes QIT-871

## Test plan
- [x] `qit env:up` defaults to `provider_type: local`
- [x] `qit env:up --provider=local` explicitly sets local provider
- [x] `qit env:up --provider=cloud` is rejected with error message
- [x] `qit env:up --provider=invalid` is rejected with error message
- [x] Unit tests pass (144 tests, 409 assertions)
- [x] PHPStan passes
- [x] PHPCS passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)