### PR TITLE
Update snapshots

### DIFF
--- a/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_generic_woorc_php74_wprc_334048b547066d6408232a37d57ddff2__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_generic_woorc_php74_wprc_334048b547066d6408232a37d57ddff2__1.php
@@ -662,10 +662,6 @@
                         "message": "PHP Notice: Notice on all requests in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 16"
                     },
                     {
-                        "count": "1",
-                        "message": "PHP Notice: Trying to access array offset on value of type null in \\/var\\/www\\/html\\/wp-includes\\/taxonomy.php on line {LINE}"
-                    },
-                    {
                         "count": "6",
                         "message": "PHP Warning: Warning on all requests in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 12"
                     }

--- a/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_php82_woorc_php82_wprc_b401265b202fc3b86b98faf66ab1e3f7__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ActivationTest__test_activation_php82_woorc_php82_wprc_b401265b202fc3b86b98faf66ab1e3f7__1.php
@@ -641,18 +641,6 @@
                     {
                         "count": "Between 10 and 149, normalized to 75",
                         "message": "PHP Deprecated: Function utf8_encode() is deprecated in \\/var\\/www\\/html\\/wp-content\\/plugins\\/woocommerce-product-feeds\\/woocommerce-product-feeds.php on line 37"
-                    },
-                    {
-                        "count": "Between 10 and 149, normalized to 75",
-                        "message": "PHP Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in \\/var\\/www\\/html\\/wp-includes\\/class-wp-block-parser.php on line {LINE}"
-                    },
-                    {
-                        "count": "Between 10 and 149, normalized to 75",
-                        "message": "PHP Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in \\/var\\/www\\/html\\/wp-includes\\/class-wp-block-parser.php on line {LINE}"
-                    },
-                    {
-                        "count": "1",
-                        "message": "PHP Warning: Trying to access array offset on value of type null in \\/var\\/www\\/html\\/wp-includes\\/taxonomy.php on line {LINE}"
                     }
                 ]
             }

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_main_plugin_woo_php_wp_08cb3463942aa74df688a3f4a807718e__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_main_plugin_woo_php_wp_08cb3463942aa74df688a3f4a807718e__1.php
@@ -34,7 +34,7 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Errors: 1 Warnings: 2",
+            "test_summary": "Errors: 3 Warnings: 2",
             "debug_log": "",
             "version": "Undefined",
             "update_complete": true,

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_main_theme_woo_php_wp_3976d011ae5709242b883dfb4863e252__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_main_theme_woo_php_wp_3976d011ae5709242b883dfb4863e252__1.php
@@ -34,7 +34,7 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Errors: 1 Warnings: 1",
+            "test_summary": "Errors: 3 Warnings: 1",
             "debug_log": "",
             "version": "1.0.15",
             "update_complete": true,

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_missing_plugin_woo_php_wp_b2f118a836d0b8cf4a8f3ca7c3af96c6__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_missing_plugin_woo_php_wp_b2f118a836d0b8cf4a8f3ca7c3af96c6__1.php
@@ -34,7 +34,7 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Errors: 2 Warnings: 6",
+            "test_summary": "Errors: 6 Warnings: 2",
             "debug_log": "",
             "version": "Undefined",
             "update_complete": true,

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_missing_theme_woo_php_wp_0f4ea06ab85fe945af93b8dc42336c32__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_missing_theme_woo_php_wp_0f4ea06ab85fe945af93b8dc42336c32__1.php
@@ -34,7 +34,7 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Errors: 1 Warnings: 6",
+            "test_summary": "Errors: 5 Warnings: 2",
             "debug_log": "",
             "version": "1.0.15",
             "update_complete": true,

--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_plugin_readme_woo_php_wp_e77ebed808cac5ec958e0ed7397b9ef4__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_plugin_readme_woo_php_wp_e77ebed808cac5ec958e0ed7397b9ef4__1.php
@@ -34,7 +34,7 @@
             },
             "test_results_manager_url": "https:\\/\\/test-results-manager.com",
             "test_results_manager_expiration": 1234567890,
-            "test_summary": "Errors: 1 Warnings: 0",
+            "test_summary": "Errors: 3 Warnings: 0",
             "debug_log": "",
             "version": "Undefined",
             "update_complete": true,


### PR DESCRIPTION
### Validation test

Differences comes from recent refactors to Validation Test.

 | Header | Value | Validation Path | Result |
  |--------|-------|-----------------|--------|
  | Requires PHP | "7.4" | `validate_should_be_present` (has value) | info |                                                                                                                                                                                                                                                
  | Requires at least | "5.8" | `requires_value_validation`, `always_valid` → true | info |
  | Tested up to | "5.8" | `validate_wordpress_version_support` → major 5 vs latest WP 6.x → `error` | **+1 error** |                                                                                                                                                                                                       
  | WC requires at least | "5.8" | `always_valid` → true | info |                  
  | WC tested up to | "5.8" | `validate_woocommerce_version_support` → major 5 vs latest Woo 10.x → `error` | **+1 error** |
  | Woo | false | `should_not_be_present`, empty → info | info |
  | License | false | `requires_value_validation`, empty → severity `error` | **+1 error** |

And has_readme: false → +1 warning. 

### Activation test

Some warnings are gone, most likely from upstream WP/Woo Core.