### PR TITLE
Update dir used for group tests

### DIFF
--- a/.github/workflows/qit-self-group-test.yml
+++ b/.github/workflows/qit-self-group-test.yml
@@ -34,7 +34,7 @@ jobs:
           ini-values: sys_temp_dir=${{ github.workspace }}/tmp
 
       - name: Composer install
-        working-directory: _tests/custom_tests
+        working-directory: src/tests/integration
         run: composer install
 
       - name: Composer install on Src
@@ -42,7 +42,7 @@ jobs:
         run: composer install
 
       - name: Fill in .env
-        working-directory: _tests/custom_tests
+        working-directory: src/tests/integration
         run: |
           echo 'QIT_CUSTOM_TESTS_USER="noop"' >> .env
           echo 'QIT_CUSTOM_TESTS_USER_QIT_TOKEN="noop"' >> .env
@@ -51,7 +51,7 @@ jobs:
           echo 'QIT_CUSTOM_TESTS_ENV="staging"' >> .env
 
       - name: Run group tests
-        working-directory: _tests/custom_tests
+        working-directory: src/tests/integration
         env:
           QIT_NO_PULL: 1
         run: make test-group


### PR DESCRIPTION
The group tests have been failing because the directory changed; so this updates the directory used in the GH action to reflect where they currently live.