### PR TITLE
Remove unused bootstrap_log

### DIFF
--- a/src/src/Utils/LocalTestRunNotifier.php
+++ b/src/src/Utils/LocalTestRunNotifier.php
@@ -369,7 +369,6 @@ class LocalTestRunNotifier {
 			'test_run_id'               => $test_run_id,
 			'test_result_json'          => '',
 			'test_result_json_original' => $test_result_json_original,
-			'bootstrap_log'             => json_encode( $test_result->bootstrap ),
 			'debug_log'                 => $debug_log_compressed,
 			'status'                    => $status,
 			'ctrf_json'                 => $ctrf_encoded,


### PR DESCRIPTION
This PR removes the unused `bootstrap_log` which wasn't being consumed on the backend or written to.

I don't believe we ever really used this for anything, so just some minor code cleanup.