### PR TITLE
Fix deprecation notice: implicit float-to-int conversion in format_duration

### DIFF
--- a/src/src/Environment/PackageOrchestrator.php
+++ b/src/src/Environment/PackageOrchestrator.php
@@ -494,7 +494,7 @@ class PackageOrchestrator {
 			return round( $seconds, 1 ) . 's';
 		} else {
 			$minutes = floor( $seconds / 60 );
-			$secs    = round( $seconds % 60 );
+			$secs    = round( fmod( $seconds, 60 ) );
 			return "{$minutes}m {$secs}s";
 		}
 	}


### PR DESCRIPTION
I noticed this when using the built binary and checking out the activation tests (I have PHP 8.3 in my shell at the moment) were working:

```
Deprecated: Implicit conversion from float 80.23805785179138 to int loses precision in                      
  phar://qit-cli/qit/src/Environment/PackageOrchestrator.php on line 302                                   
```

This was taking up a lot of space in the console for the tests, so I fixed it and added in `fmod( $seconds, 60 )`.

### Testing
1. Run `make build` on `trunk`
2. Run a test (like `./qit run:activation automatewoo`), ideally with a PHP version greater than 8.1
3. Note the deprecation notice
4. Switch to this branch
5. Run `make build`
6. Run the same test and verify no deprecation notices show