### PR TITLE
Fix --json output to decode embedded JSON fields, add --json-results flag

### DIFF
--- a/src/src/Commands/GetCommand.php
+++ b/src/src/Commands/GetCommand.php
@@ -23,6 +23,7 @@ class GetCommand extends QITCommand {
 			->addArgument( 'test_run_id', InputArgument::REQUIRED, 'The ID of the test run.' )
 			->addOption( 'open', 'o', InputOption::VALUE_NEGATABLE, 'Open the test run in the browser.', false )
 			->addOption( 'json', 'j', InputOption::VALUE_NEGATABLE, 'Whether to return raw JSON format.', false )
+			->addOption( 'json-results', null, InputOption::VALUE_NONE, 'Output only the test results as JSON.' )
 			->addOption( 'check_finished', null, InputOption::VALUE_NONE, 'Return success if test has finished. Failure if not.', null );
 	}
 
@@ -62,7 +63,29 @@ class GetCommand extends QITCommand {
 		}
 
 		if ( $input->getOption( 'json' ) ) {
-			$output->write( $json );
+			$data = json_decode( $json, true );
+			if ( is_array( $data ) ) {
+				$this->decode_json_fields( $data );
+			}
+			$output->write( json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+
+			return $exit_status_code;
+		}
+
+		if ( $input->getOption( 'json-results' ) ) {
+			$results = null;
+			if ( ! empty( $test_run['ctrf_json'] ) ) {
+				$results = json_decode( $test_run['ctrf_json'], true );
+			}
+			if ( is_null( $results ) && ! empty( $test_run['test_result_json'] ) ) {
+				$results = json_decode( $test_run['test_result_json'], true );
+			}
+			if ( is_null( $results ) ) {
+				$output->writeln( '<error>No test results available. The test may still be running.</error>' );
+
+				return Command::FAILURE;
+			}
+			$output->write( json_encode( $results, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 
 			return $exit_status_code;
 		}
@@ -166,5 +189,22 @@ class GetCommand extends QITCommand {
 		$table->render();
 
 		return $exit_status_code;
+	}
+
+	/**
+	 * Decode stringified JSON fields into proper arrays.
+	 *
+	 * @param array<string,mixed> $data The test run data to modify in-place.
+	 */
+	private function decode_json_fields( array &$data ): void {
+		$json_fields = [ 'ctrf_json', 'test_result_json', 'debug_log' ];
+		foreach ( $json_fields as $field ) {
+			if ( ! empty( $data[ $field ] ) && is_string( $data[ $field ] ) ) {
+				$decoded = json_decode( $data[ $field ], true );
+				if ( json_last_error() === JSON_ERROR_NONE ) {
+					$data[ $field ] = $decoded;
+				}
+			}
+		}
 	}
 }

--- a/src/src/Commands/GetMultipleCommand.php
+++ b/src/src/Commands/GetMultipleCommand.php
@@ -22,6 +22,7 @@ class GetMultipleCommand extends QITCommand {
 			->addArgument( 'test_run_ids', InputArgument::REQUIRED, 'Comma-separated list of test run IDs.' )
 			->addOption( 'open', 'o', InputOption::VALUE_NEGATABLE, 'Open the test runs in the browser.', false )
 			->addOption( 'json', 'j', InputOption::VALUE_NEGATABLE, 'Whether to return raw JSON format.', false )
+			->addOption( 'json-results', null, InputOption::VALUE_NONE, 'Output only the test results as JSON.' )
 			->addOption( 'check_finished', null, InputOption::VALUE_NONE, 'Return success if all tests have finished. Failure if any not finished.', null );
 	}
 
@@ -71,7 +72,16 @@ class GetMultipleCommand extends QITCommand {
 
 		// If JSON requested, we print raw JSON once and exit.
 		if ( $json_output ) {
-			$output->write( $json );
+			$data = json_decode( $json, true );
+			if ( is_array( $data ) ) {
+				foreach ( $data as &$tr_data ) {
+					if ( is_array( $tr_data ) ) {
+						$this->decode_json_fields( $tr_data );
+					}
+				}
+				unset( $tr_data );
+			}
+			$output->write( json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 			// Determine overall exit code based on each test.
 			foreach ( $test_runs as $tr ) {
 				$code = $this->determine_exit_code( $tr, $status_map, $default_exit_code );
@@ -79,6 +89,29 @@ class GetMultipleCommand extends QITCommand {
 					$overall_exit_code = $code;
 				}
 			}
+
+			return $overall_exit_code;
+		}
+
+		// If JSON results requested, output only the test results.
+		if ( $input->getOption( 'json-results' ) ) {
+			$all_results = [];
+			foreach ( $test_runs as $tr ) {
+				$results = null;
+				if ( ! empty( $tr['ctrf_json'] ) ) {
+					$results = json_decode( $tr['ctrf_json'], true );
+				}
+				if ( is_null( $results ) && ! empty( $tr['test_result_json'] ) ) {
+					$results = json_decode( $tr['test_result_json'], true );
+				}
+				$all_results[] = $results;
+
+				$code = $this->determine_exit_code( $tr, $status_map, $default_exit_code );
+				if ( $code > $overall_exit_code ) {
+					$overall_exit_code = $code;
+				}
+			}
+			$output->write( json_encode( $all_results, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 
 			return $overall_exit_code;
 		}
@@ -219,5 +252,22 @@ class GetMultipleCommand extends QITCommand {
 		}
 
 		return $renamed;
+	}
+
+	/**
+	 * Decode stringified JSON fields into proper arrays.
+	 *
+	 * @param array<string,mixed> $data The test run data to modify in-place.
+	 */
+	private function decode_json_fields( array &$data ): void {
+		$json_fields = [ 'ctrf_json', 'test_result_json', 'debug_log' ];
+		foreach ( $json_fields as $field ) {
+			if ( ! empty( $data[ $field ] ) && is_string( $data[ $field ] ) ) {
+				$decoded = json_decode( $data[ $field ], true );
+				if ( json_last_error() === JSON_ERROR_NONE ) {
+					$data[ $field ] = $decoded;
+				}
+			}
+		}
 	}
 }

--- a/src/src/Commands/RunE2ECommand.php
+++ b/src/src/Commands/RunE2ECommand.php
@@ -682,8 +682,12 @@ class RunE2ECommand extends QITCommand {
 						->with_retry( 3 )
 						->request();
 
-					// Output the Manager API response directly
-					$output->write( $json );
+					// Decode stringified JSON fields for clean output.
+					$data = json_decode( $json, true );
+					if ( is_array( $data ) ) {
+						$this->decode_json_fields( $data );
+					}
+					$output->write( json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 				} catch ( \Exception $e ) {
 					// If we can't fetch from Manager, output minimal info
 					$output->write( json_encode( [
@@ -1886,5 +1890,22 @@ class RunE2ECommand extends QITCommand {
 		// Convert slug to title case
 		$name = str_replace( [ '-', '_' ], ' ', $slug );
 		return ucwords( $name );
+	}
+
+	/**
+	 * Decode stringified JSON fields into proper arrays.
+	 *
+	 * @param array<string,mixed> $data The test run data to modify in-place.
+	 */
+	private function decode_json_fields( array &$data ): void {
+		$json_fields = [ 'ctrf_json', 'test_result_json', 'debug_log' ];
+		foreach ( $json_fields as $field ) {
+			if ( ! empty( $data[ $field ] ) && is_string( $data[ $field ] ) ) {
+				$decoded = json_decode( $data[ $field ], true );
+				if ( json_last_error() === JSON_ERROR_NONE ) {
+					$data[ $field ] = $decoded;
+				}
+			}
+		}
 	}
 }

--- a/src/tests/integration/tests/TestPackages/Scenarios/AutomatedCIPipelineTest.php
+++ b/src/tests/integration/tests/TestPackages/Scenarios/AutomatedCIPipelineTest.php
@@ -52,12 +52,12 @@ class AutomatedCIPipelineTest extends BaseScenarioTestCase {
 		$this->assertArrayHasKey( 'status', $data, 'Should have status field' );
 		$this->assertEquals( 'success', $data['status'], 'Test status should be success' );
 		
-		// CTRF data is now embedded in ctrf_json field
+		// CTRF data is embedded in ctrf_json field as a parsed object.
 		$this->assertArrayHasKey( 'ctrf_json', $data, 'Should have CTRF JSON field' );
-		$ctrf = json_decode( $data['ctrf_json'], true );
-		$this->assertIsArray( $ctrf, 'CTRF should be valid JSON' );
+		$ctrf = $data['ctrf_json'];
+		$this->assertIsArray( $ctrf, 'CTRF should be a parsed array' );
 		$this->assertArrayHasKey( 'results', $ctrf, 'CTRF should have results structure' );
-		
+
 		$summary = $ctrf['results']['summary'] ?? [];
 		// The orchestrator adds lifecycle phase tests (globalSetup, setup, run, teardown, globalTeardown)
 		// So we expect more than just the 2 tests from the package
@@ -195,10 +195,10 @@ fi' );
 		$data = json_decode( $proc->getOutput(), true );
 		$this->assertIsArray( $data, 'Should have valid JSON output' );
 		$this->assertArrayHasKey( 'ctrf_json', $data, 'Should have CTRF JSON field' );
-		
-		$ctrf = json_decode( $data['ctrf_json'], true );
-		$this->assertIsArray( $ctrf, 'CTRF should be valid JSON' );
-		
+
+		$ctrf = $data['ctrf_json'];
+		$this->assertIsArray( $ctrf, 'CTRF should be a parsed array' );
+
 		// Verify that results from both packages are present
 		$summary = $ctrf['results']['summary'] ?? [];
 		// Both packages have 2 tests each, so we expect at least 4 tests total

--- a/src/tests/unit/GetCommandTest.php
+++ b/src/tests/unit/GetCommandTest.php
@@ -1,0 +1,454 @@
+<?php
+
+use QIT_CLI\App;
+use Spatie\Snapshots\MatchesSnapshots;
+use function QIT_CLI\get_manager_url;
+
+class GetCommandTest extends \QIT_CLI_Tests\QITTestCase {
+	use MatchesSnapshots;
+
+	protected $application_tester;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->application_tester = $this->make_application_tester();
+	}
+
+	/**
+	 * Build a realistic API response for a completed E2E test run.
+	 * Contains both ctrf_json and test_result_json as plain JSON strings
+	 * (the Manager decompresses on ingestion).
+	 */
+	private function make_e2e_response(): array {
+		return [
+			'test_run_id'                     => 98765,
+			'run_id'                          => 98765,
+			'test_type'                       => 'e2e',
+			'test_type_display'               => 'E2E',
+			'wordpress_version'               => '6.7',
+			'woocommerce_version'             => '9.5.1',
+			'php_version'                     => '8.2',
+			'max_php_version'                 => '',
+			'min_php_version'                 => '',
+			'additional_woo_plugins'          => [],
+			'additional_wp_plugins'           => [],
+			'test_log'                        => '',
+			'test_result_json'                => json_encode( [
+				'summary'   => 'Tests: 3 total, 2 passed, 1 failed',
+				'testResults' => [
+					[
+						'tests' => [
+							'Checkout flow' => [
+								[ 'status' => 'passed', 'title' => 'can add product to cart' ],
+								[ 'status' => 'passed', 'title' => 'can complete checkout' ],
+								[ 'status' => 'failed', 'title' => 'can apply coupon at checkout' ],
+							],
+						],
+						'status' => 'failed',
+					],
+				],
+			] ),
+			'ctrf_json'                       => json_encode( [
+				'results' => [
+					'tool'    => [ 'name' => 'playwright' ],
+					'summary' => [
+						'tests'   => 3,
+						'passed'  => 2,
+						'failed'  => 1,
+						'pending' => 0,
+						'skipped' => 0,
+						'other'   => 0,
+						'start'   => 1706644023,
+						'stop'    => 1706644043,
+					],
+					'tests'   => [
+						[
+							'name'     => 'can add product to cart',
+							'status'   => 'passed',
+							'duration' => 1200,
+						],
+						[
+							'name'     => 'can complete checkout',
+							'status'   => 'passed',
+							'duration' => 2400,
+						],
+						[
+							'name'     => 'can apply coupon at checkout',
+							'status'   => 'failed',
+							'duration' => 800,
+							'message'  => 'Expected coupon discount to be applied but total remained unchanged.',
+						],
+					],
+				],
+			] ),
+			'performance_results'             => '',
+			'status'                          => 'failed',
+			'test_result_aws_url'             => '',
+			'test_result_aws_expiration'      => 0,
+			'is_development'                  => false,
+			'send_notifications'              => true,
+			'woo_extension'                   => [
+				'id'   => 12345,
+				'host' => 'wccom',
+				'name' => 'My WooCommerce Plugin',
+				'type' => 'plugin',
+			],
+			'client'                          => 'qit_cli',
+			'event'                           => 'cli',
+			'optional_features'               => [ 'hpos' => true, 'new_product_editor' => false ],
+			'test_results_manager_url'        => 'https://qit.woo.com/results/98765.abc123',
+			'test_results_manager_expiration' => 1234567890,
+			'test_summary'                    => 'Tests: 3 total, 2 passed, 1 failed, 0 skipped',
+			'debug_log'                       => '',
+			'version'                         => '1.0.0',
+			'update_complete'                 => true,
+			'ai_suggestion_status'            => 'none',
+			'malware_whitelist_paths'         => [],
+			'workflow_id'                     => '',
+			'runner'                          => '',
+			'test_media'                      => [],
+			'extension_set'                   => '',
+			'phpstan_level'                   => null,
+			'test_variation'                  => '',
+			'test_packages'                   => [],
+			'test_group_id'                   => '',
+			'created_at'                      => '2025-01-15 10:30:00',
+		];
+	}
+
+	/**
+	 * Build a realistic API response for a completed security test.
+	 * Only test_result_json is populated; ctrf_json is empty.
+	 */
+	private function make_security_response(): array {
+		return [
+			'test_run_id'                     => 55555,
+			'run_id'                          => 55555,
+			'test_type'                       => 'security',
+			'test_type_display'               => 'Security',
+			'wordpress_version'               => '6.7',
+			'woocommerce_version'             => '9.5.1',
+			'php_version'                     => '8.2',
+			'max_php_version'                 => '',
+			'min_php_version'                 => '',
+			'additional_woo_plugins'          => [],
+			'additional_wp_plugins'           => [],
+			'test_log'                        => '',
+			'test_result_json'                => json_encode( [
+				'tool'    => 'phpcs-security-audit',
+				'summary' => '2 warnings found',
+				'files'   => [
+					'my-plugin/includes/class-api.php' => [
+						'messages' => [
+							[
+								'message'  => 'Possible SQL injection via $wpdb->prepare() with unquoted placeholder',
+								'source'   => 'PHPCS.Security.SQLInjection',
+								'severity' => 5,
+								'line'     => 42,
+								'column'   => 15,
+								'type'     => 'WARNING',
+							],
+							[
+								'message'  => 'User input detected with $_GET used in output without escaping',
+								'source'   => 'PHPCS.Security.XSSVulnerability',
+								'severity' => 5,
+								'line'     => 88,
+								'column'   => 20,
+								'type'     => 'WARNING',
+							],
+						],
+					],
+				],
+			] ),
+			'ctrf_json'                       => '',
+			'performance_results'             => '',
+			'status'                          => 'warning',
+			'test_result_aws_url'             => '',
+			'test_result_aws_expiration'      => 0,
+			'is_development'                  => false,
+			'send_notifications'              => true,
+			'woo_extension'                   => [
+				'id'   => 12345,
+				'host' => 'wccom',
+				'name' => 'My WooCommerce Plugin',
+				'type' => 'plugin',
+			],
+			'client'                          => 'qit_cli',
+			'event'                           => 'cli',
+			'optional_features'               => [ 'hpos' => false, 'new_product_editor' => false ],
+			'test_results_manager_url'        => 'https://qit.woo.com/results/55555.def456',
+			'test_results_manager_expiration' => 1234567890,
+			'test_summary'                    => '2 warnings found',
+			'debug_log'                       => '',
+			'version'                         => '1.0.0',
+			'update_complete'                 => true,
+			'ai_suggestion_status'            => 'none',
+			'malware_whitelist_paths'         => [],
+			'workflow_id'                     => '',
+			'runner'                          => '',
+			'test_media'                      => [],
+			'extension_set'                   => '',
+			'phpstan_level'                   => null,
+			'test_variation'                  => '',
+			'test_packages'                   => [],
+			'test_group_id'                   => '',
+			'created_at'                      => '2025-01-15 10:30:00',
+		];
+	}
+
+	/**
+	 * Normal (table) output for a completed E2E test.
+	 * Demonstrates that ctrf_json and test_result_json are hidden.
+	 */
+	public function test_get_e2e_table_output(): void {
+		$response = $this->make_e2e_response();
+
+		App::setVar(
+			sprintf( 'mock_%s%s', get_manager_url(), '/wp-json/cd/v1/get-single' ),
+			json_encode( $response )
+		);
+
+		$exit_code = $this->application_tester->run(
+			[
+				'command'     => 'get',
+				'test_run_id' => '98765',
+			],
+			[ 'capture_stderr_separately' => true ]
+		);
+
+		$this->assertSame( 1, $exit_code, 'E2E failed test should exit with 1' );
+		$this->assertMatchesSnapshot( $this->application_tester->getDisplay() );
+	}
+
+	/**
+	 * JSON output for a completed E2E test.
+	 * Demonstrates that ctrf_json and test_result_json are strings, not parsed objects.
+	 */
+	public function test_get_e2e_json_output(): void {
+		$response = $this->make_e2e_response();
+
+		App::setVar(
+			sprintf( 'mock_%s%s', get_manager_url(), '/wp-json/cd/v1/get-single' ),
+			json_encode( $response )
+		);
+
+		$exit_code = $this->application_tester->run(
+			[
+				'command'     => 'get',
+				'test_run_id' => '98765',
+				'--json'      => true,
+			],
+			[ 'capture_stderr_separately' => true ]
+		);
+
+		$this->assertSame( 1, $exit_code, 'E2E failed test should exit with 1' );
+		$raw_output = $this->application_tester->getDisplay();
+		$decoded    = json_decode( $raw_output, true );
+		$this->assertNotNull( $decoded, 'JSON output must be valid JSON' );
+
+		// After fix: ctrf_json and test_result_json are decoded into proper arrays.
+		$this->assertIsArray( $decoded['ctrf_json'], 'ctrf_json should be a parsed object' );
+		$this->assertIsArray( $decoded['test_result_json'], 'test_result_json should be a parsed object' );
+
+		$this->assertMatchesJsonSnapshot( $decoded );
+	}
+
+	/**
+	 * Normal (table) output for a completed security test.
+	 * Shows that result_url is the only actionable piece of info.
+	 */
+	public function test_get_security_table_output(): void {
+		$response = $this->make_security_response();
+
+		App::setVar(
+			sprintf( 'mock_%s%s', get_manager_url(), '/wp-json/cd/v1/get-single' ),
+			json_encode( $response )
+		);
+
+		$exit_code = $this->application_tester->run(
+			[
+				'command'     => 'get',
+				'test_run_id' => '55555',
+			],
+			[ 'capture_stderr_separately' => true ]
+		);
+
+		$this->assertSame( 3, $exit_code, 'Security warning test should exit with 3' );
+		$this->assertMatchesSnapshot( $this->application_tester->getDisplay() );
+	}
+
+	/**
+	 * JSON output for a completed security test.
+	 * Demonstrates that ctrf_json is empty for non-Playwright tests.
+	 */
+	public function test_get_security_json_output(): void {
+		$response = $this->make_security_response();
+
+		App::setVar(
+			sprintf( 'mock_%s%s', get_manager_url(), '/wp-json/cd/v1/get-single' ),
+			json_encode( $response )
+		);
+
+		$exit_code = $this->application_tester->run(
+			[
+				'command'     => 'get',
+				'test_run_id' => '55555',
+				'--json'      => true,
+			],
+			[ 'capture_stderr_separately' => true ]
+		);
+
+		$this->assertSame( 3, $exit_code, 'Security warning test should exit with 3' );
+		$raw_output = $this->application_tester->getDisplay();
+		$decoded    = json_decode( $raw_output, true );
+		$this->assertNotNull( $decoded, 'JSON output must be valid JSON' );
+
+		// ctrf_json is empty for non-Playwright managed tests.
+		$this->assertSame( '', $decoded['ctrf_json'], 'ctrf_json should be empty for security tests' );
+		// test_result_json is decoded into a proper array.
+		$this->assertIsArray( $decoded['test_result_json'], 'test_result_json should be a parsed object' );
+		$this->assertNotEmpty( $decoded['test_result_json'], 'test_result_json should not be empty' );
+
+		$this->assertMatchesJsonSnapshot( $decoded );
+	}
+
+	/**
+	 * Successful E2E test exits with 0.
+	 */
+	public function test_get_successful_test_exits_zero(): void {
+		$response           = $this->make_e2e_response();
+		$response['status'] = 'success';
+
+		App::setVar(
+			sprintf( 'mock_%s%s', get_manager_url(), '/wp-json/cd/v1/get-single' ),
+			json_encode( $response )
+		);
+
+		$exit_code = $this->application_tester->run(
+			[
+				'command'     => 'get',
+				'test_run_id' => '98765',
+				'--json'      => true,
+			],
+			[ 'capture_stderr_separately' => true ]
+		);
+
+		$this->assertSame( 0, $exit_code );
+	}
+
+	/**
+	 * Warning status exits with 3.
+	 */
+	public function test_get_warning_test_exits_three(): void {
+		$response           = $this->make_e2e_response();
+		$response['status'] = 'warning';
+
+		App::setVar(
+			sprintf( 'mock_%s%s', get_manager_url(), '/wp-json/cd/v1/get-single' ),
+			json_encode( $response )
+		);
+
+		$exit_code = $this->application_tester->run(
+			[
+				'command'     => 'get',
+				'test_run_id' => '98765',
+				'--json'      => true,
+			],
+			[ 'capture_stderr_separately' => true ]
+		);
+
+		$this->assertSame( 3, $exit_code );
+	}
+
+	/**
+	 * --json-results for E2E returns parsed CTRF JSON (preferred over test_result_json).
+	 */
+	public function test_get_e2e_json_results_output(): void {
+		$response = $this->make_e2e_response();
+
+		App::setVar(
+			sprintf( 'mock_%s%s', get_manager_url(), '/wp-json/cd/v1/get-single' ),
+			json_encode( $response )
+		);
+
+		$exit_code = $this->application_tester->run(
+			[
+				'command'        => 'get',
+				'test_run_id'    => '98765',
+				'--json-results' => true,
+			],
+			[ 'capture_stderr_separately' => true ]
+		);
+
+		$this->assertSame( 1, $exit_code );
+		$raw_output = $this->application_tester->getDisplay();
+		$decoded    = json_decode( $raw_output, true );
+		$this->assertNotNull( $decoded, 'Output must be valid JSON' );
+
+		// Should be the CTRF results, not test_result_json.
+		$this->assertArrayHasKey( 'results', $decoded );
+		$this->assertArrayHasKey( 'tool', $decoded['results'] );
+		$this->assertSame( 'playwright', $decoded['results']['tool']['name'] );
+
+		$this->assertMatchesJsonSnapshot( $decoded );
+	}
+
+	/**
+	 * --json-results for security falls back to test_result_json when ctrf_json is empty.
+	 */
+	public function test_get_security_json_results_output(): void {
+		$response = $this->make_security_response();
+
+		App::setVar(
+			sprintf( 'mock_%s%s', get_manager_url(), '/wp-json/cd/v1/get-single' ),
+			json_encode( $response )
+		);
+
+		$exit_code = $this->application_tester->run(
+			[
+				'command'        => 'get',
+				'test_run_id'    => '55555',
+				'--json-results' => true,
+			],
+			[ 'capture_stderr_separately' => true ]
+		);
+
+		$this->assertSame( 3, $exit_code );
+		$raw_output = $this->application_tester->getDisplay();
+		$decoded    = json_decode( $raw_output, true );
+		$this->assertNotNull( $decoded, 'Output must be valid JSON' );
+
+		// Should be the security test_result_json.
+		$this->assertArrayHasKey( 'tool', $decoded );
+		$this->assertSame( 'phpcs-security-audit', $decoded['tool'] );
+
+		$this->assertMatchesJsonSnapshot( $decoded );
+	}
+
+	/**
+	 * --json-results with no results available fails with error.
+	 */
+	public function test_get_json_results_no_data(): void {
+		$response                     = $this->make_e2e_response();
+		$response['ctrf_json']        = '';
+		$response['test_result_json'] = '';
+
+		App::setVar(
+			sprintf( 'mock_%s%s', get_manager_url(), '/wp-json/cd/v1/get-single' ),
+			json_encode( $response )
+		);
+
+		$exit_code = $this->application_tester->run(
+			[
+				'command'        => 'get',
+				'test_run_id'    => '98765',
+				'--json-results' => true,
+			],
+			[ 'capture_stderr_separately' => true ]
+		);
+
+		$this->assertSame( 1, $exit_code );
+		$display = $this->application_tester->getDisplay();
+		$this->assertStringContainsString( 'No test results available', $display );
+	}
+}

--- a/src/tests/unit/__snapshots__/GetCommandTest__test_get_e2e_json_output__1.json
+++ b/src/tests/unit/__snapshots__/GetCommandTest__test_get_e2e_json_output__1.json
@@ -1,0 +1,108 @@
+{
+    "test_run_id": 98765,
+    "run_id": 98765,
+    "test_type": "e2e",
+    "test_type_display": "E2E",
+    "wordpress_version": "6.7",
+    "woocommerce_version": "9.5.1",
+    "php_version": "8.2",
+    "max_php_version": "",
+    "min_php_version": "",
+    "additional_woo_plugins": [],
+    "additional_wp_plugins": [],
+    "test_log": "",
+    "test_result_json": {
+        "summary": "Tests: 3 total, 2 passed, 1 failed",
+        "testResults": [
+            {
+                "tests": {
+                    "Checkout flow": [
+                        {
+                            "status": "passed",
+                            "title": "can add product to cart"
+                        },
+                        {
+                            "status": "passed",
+                            "title": "can complete checkout"
+                        },
+                        {
+                            "status": "failed",
+                            "title": "can apply coupon at checkout"
+                        }
+                    ]
+                },
+                "status": "failed"
+            }
+        ]
+    },
+    "ctrf_json": {
+        "results": {
+            "tool": {
+                "name": "playwright"
+            },
+            "summary": {
+                "tests": 3,
+                "passed": 2,
+                "failed": 1,
+                "pending": 0,
+                "skipped": 0,
+                "other": 0,
+                "start": 1706644023,
+                "stop": 1706644043
+            },
+            "tests": [
+                {
+                    "name": "can add product to cart",
+                    "status": "passed",
+                    "duration": 1200
+                },
+                {
+                    "name": "can complete checkout",
+                    "status": "passed",
+                    "duration": 2400
+                },
+                {
+                    "name": "can apply coupon at checkout",
+                    "status": "failed",
+                    "duration": 800,
+                    "message": "Expected coupon discount to be applied but total remained unchanged."
+                }
+            ]
+        }
+    },
+    "performance_results": "",
+    "status": "failed",
+    "test_result_aws_url": "",
+    "test_result_aws_expiration": 0,
+    "is_development": false,
+    "send_notifications": true,
+    "woo_extension": {
+        "id": 12345,
+        "host": "wccom",
+        "name": "My WooCommerce Plugin",
+        "type": "plugin"
+    },
+    "client": "qit_cli",
+    "event": "cli",
+    "optional_features": {
+        "hpos": true,
+        "new_product_editor": false
+    },
+    "test_results_manager_url": "https:\/\/qit.woo.com\/results\/98765.abc123",
+    "test_results_manager_expiration": 1234567890,
+    "test_summary": "Tests: 3 total, 2 passed, 1 failed, 0 skipped",
+    "debug_log": "",
+    "version": "1.0.0",
+    "update_complete": true,
+    "ai_suggestion_status": "none",
+    "malware_whitelist_paths": [],
+    "workflow_id": "",
+    "runner": "",
+    "test_media": [],
+    "extension_set": "",
+    "phpstan_level": null,
+    "test_variation": "",
+    "test_packages": [],
+    "test_group_id": "",
+    "created_at": "2025-01-15 10:30:00"
+}

--- a/src/tests/unit/__snapshots__/GetCommandTest__test_get_e2e_json_results_output__1.json
+++ b/src/tests/unit/__snapshots__/GetCommandTest__test_get_e2e_json_results_output__1.json
@@ -1,0 +1,35 @@
+{
+    "results": {
+        "tool": {
+            "name": "playwright"
+        },
+        "summary": {
+            "tests": 3,
+            "passed": 2,
+            "failed": 1,
+            "pending": 0,
+            "skipped": 0,
+            "other": 0,
+            "start": 1706644023,
+            "stop": 1706644043
+        },
+        "tests": [
+            {
+                "name": "can add product to cart",
+                "status": "passed",
+                "duration": 1200
+            },
+            {
+                "name": "can complete checkout",
+                "status": "passed",
+                "duration": 2400
+            },
+            {
+                "name": "can apply coupon at checkout",
+                "status": "failed",
+                "duration": 800,
+                "message": "Expected coupon discount to be applied but total remained unchanged."
+            }
+        ]
+    }
+}

--- a/src/tests/unit/__snapshots__/GetCommandTest__test_get_e2e_table_output__1.txt
+++ b/src/tests/unit/__snapshots__/GetCommandTest__test_get_e2e_table_output__1.txt
@@ -1,0 +1,11 @@
+Test Run Id         98765                                         
+Test Type Display   E2E                                           
+Wordpress Version   6.7                                           
+Woocommerce Version 9.5.1                                         
+Php Version         8.2                                           
+Status              failed                                        
+Woo Extension       My WooCommerce Plugin                         
+Test Summary        Tests: 3 total, 2 passed, 1 failed, 0 skipped 
+Version             1.0.0                                         
+Created At          2025-01-15 10:30:00                           
+Result Url          https://qit.woo.com/results/98765.abc123      

--- a/src/tests/unit/__snapshots__/GetCommandTest__test_get_security_json_output__1.json
+++ b/src/tests/unit/__snapshots__/GetCommandTest__test_get_security_json_output__1.json
@@ -1,0 +1,76 @@
+{
+    "test_run_id": 55555,
+    "run_id": 55555,
+    "test_type": "security",
+    "test_type_display": "Security",
+    "wordpress_version": "6.7",
+    "woocommerce_version": "9.5.1",
+    "php_version": "8.2",
+    "max_php_version": "",
+    "min_php_version": "",
+    "additional_woo_plugins": [],
+    "additional_wp_plugins": [],
+    "test_log": "",
+    "test_result_json": {
+        "tool": "phpcs-security-audit",
+        "summary": "2 warnings found",
+        "files": {
+            "my-plugin\/includes\/class-api.php": {
+                "messages": [
+                    {
+                        "message": "Possible SQL injection via $wpdb->prepare() with unquoted placeholder",
+                        "source": "PHPCS.Security.SQLInjection",
+                        "severity": 5,
+                        "line": 42,
+                        "column": 15,
+                        "type": "WARNING"
+                    },
+                    {
+                        "message": "User input detected with $_GET used in output without escaping",
+                        "source": "PHPCS.Security.XSSVulnerability",
+                        "severity": 5,
+                        "line": 88,
+                        "column": 20,
+                        "type": "WARNING"
+                    }
+                ]
+            }
+        }
+    },
+    "ctrf_json": "",
+    "performance_results": "",
+    "status": "warning",
+    "test_result_aws_url": "",
+    "test_result_aws_expiration": 0,
+    "is_development": false,
+    "send_notifications": true,
+    "woo_extension": {
+        "id": 12345,
+        "host": "wccom",
+        "name": "My WooCommerce Plugin",
+        "type": "plugin"
+    },
+    "client": "qit_cli",
+    "event": "cli",
+    "optional_features": {
+        "hpos": false,
+        "new_product_editor": false
+    },
+    "test_results_manager_url": "https:\/\/qit.woo.com\/results\/55555.def456",
+    "test_results_manager_expiration": 1234567890,
+    "test_summary": "2 warnings found",
+    "debug_log": "",
+    "version": "1.0.0",
+    "update_complete": true,
+    "ai_suggestion_status": "none",
+    "malware_whitelist_paths": [],
+    "workflow_id": "",
+    "runner": "",
+    "test_media": [],
+    "extension_set": "",
+    "phpstan_level": null,
+    "test_variation": "",
+    "test_packages": [],
+    "test_group_id": "",
+    "created_at": "2025-01-15 10:30:00"
+}

--- a/src/tests/unit/__snapshots__/GetCommandTest__test_get_security_json_results_output__1.json
+++ b/src/tests/unit/__snapshots__/GetCommandTest__test_get_security_json_results_output__1.json
@@ -1,0 +1,26 @@
+{
+    "tool": "phpcs-security-audit",
+    "summary": "2 warnings found",
+    "files": {
+        "my-plugin\/includes\/class-api.php": {
+            "messages": [
+                {
+                    "message": "Possible SQL injection via $wpdb->prepare() with unquoted placeholder",
+                    "source": "PHPCS.Security.SQLInjection",
+                    "severity": 5,
+                    "line": 42,
+                    "column": 15,
+                    "type": "WARNING"
+                },
+                {
+                    "message": "User input detected with $_GET used in output without escaping",
+                    "source": "PHPCS.Security.XSSVulnerability",
+                    "severity": 5,
+                    "line": 88,
+                    "column": 20,
+                    "type": "WARNING"
+                }
+            ]
+        }
+    }
+}

--- a/src/tests/unit/__snapshots__/GetCommandTest__test_get_security_table_output__1.txt
+++ b/src/tests/unit/__snapshots__/GetCommandTest__test_get_security_table_output__1.txt
@@ -1,0 +1,11 @@
+Test Run Id         55555                                    
+Test Type Display   Security                                 
+Wordpress Version   6.7                                      
+Woocommerce Version 9.5.1                                    
+Php Version         8.2                                      
+Status              warning                                  
+Woo Extension       My WooCommerce Plugin                    
+Test Summary        2 warnings found                         
+Version             1.0.0                                    
+Created At          2025-01-15 10:30:00                      
+Result Url          https://qit.woo.com/results/55555.def456 


### PR DESCRIPTION
## Summary

- **`--json` output fixed**: `ctrf_json`, `test_result_json`, and `debug_log` were returned as stringified JSON (JSON-in-JSON), making them unusable for AI agents and hard to parse with `jq`. These fields are now decoded into proper JSON objects in `get`, `get-multiple`, and `run:e2e`.
- **New `--json-results` flag**: Outputs only the test results as clean JSON (CTRF if available, otherwise `test_result_json`) — no metadata, no URLs. Designed for AI agent and script consumption.
- **9 new unit tests** with snapshots covering both output modes for E2E and security test types, plus exit codes and error handling.

## Context

A user reported that `qit get <id>` results are "just links" and even `--json` "just had the same link and not the results." The root cause was double-encoded JSON fields that AI agents couldn't parse.

## Test plan

- [x] Unit tests: 203/203 passing (`./vendor/bin/phpunit`)
- [x] PHPCS clean
- [x] PHPStan clean
- [x] Phan clean
- [ ] Manual: `qit get <test-run-id> --json | jq .ctrf_json` returns an object
- [ ] Manual: `qit get <test-run-id> --json-results | jq .` returns clean results