### PR TITLE
Better handling around expired credentials

### DIFF
--- a/src/src/Diagnosis.php
+++ b/src/src/Diagnosis.php
@@ -52,7 +52,11 @@ class Diagnosis {
 		$output->write( PHP_EOL );
 
 		if ( $connection_to_internet && $connection_to_manager ) {
-			$output->writeln( 'Both the internet and QIT server connections were successful. This is likely an internal issue with the QIT servers. Please try again later.' );
+			$output->writeln( 'Both the internet and QIT server connections were successful.' );
+			$output->writeln( 'This could be caused by expired or revoked credentials. Try refreshing them:' );
+			$output->writeln( '  1. qit partner:remove' );
+			$output->writeln( '  2. qit connect' );
+			$output->writeln( 'If the issue persists, it may be an internal issue with the QIT servers. Please try again later.' );
 		}
 
 		if ( $connection_to_internet && ! $connection_to_manager ) {

--- a/src/src/ManagerSync.php
+++ b/src/src/ManagerSync.php
@@ -88,7 +88,7 @@ class ManagerSync {
 		}
 
 		$start    = microtime( true );
-		$response = $this->request_v2( 'cli/sync' );
+		$response = $this->request_v2( 'cli/sync', false );
 
 		if ( $this->output->isVerbose() ) {
 			$this->output->writeln( sprintf( 'Done in %s seconds.', number_format( microtime( true ) - $start, 2 ) ) );
@@ -172,12 +172,17 @@ class ManagerSync {
 	 * @return string The response body.
 	 * @throws NetworkErrorException If the Manager is unreachable.
 	 */
-	private function request_v2( string $route ): string {
+	private function request_v2( string $route, bool $authenticated = true ): string {
 		try {
-			return ( new RequestBuilder( get_manager_url() . '/wp-json/cd/v2/' . $route ) )
+			$builder = ( new RequestBuilder( get_manager_url() . '/wp-json/cd/v2/' . $route ) )
 				->with_retry( 2 )
-				->with_method( 'POST' )
-				->request();
+				->with_method( 'POST' );
+
+			if ( ! $authenticated ) {
+				$builder->without_auth();
+			}
+
+			return $builder->request();
 		} catch ( DoingAutocompleteException $e ) {
 			return '{}';
 		} catch ( NetworkErrorException $e ) {

--- a/src/src/RequestBuilder.php
+++ b/src/src/RequestBuilder.php
@@ -24,6 +24,9 @@ class RequestBuilder {
 	/** @var bool $onboarding */
 	protected $onboarding = false;
 
+	/** @var bool $skip_auth */
+	protected $skip_auth = false;
+
 	/** @var array<int> */
 	protected $expected_status_codes = [ 200 ];
 
@@ -113,6 +116,17 @@ class RequestBuilder {
 	}
 
 	/**
+	 * Skip automatic credential injection for this request.
+	 *
+	 * @return $this
+	 */
+	public function without_auth(): self {
+		$this->skip_auth = true;
+
+		return $this;
+	}
+
+	/**
 	 * @param int $retry
 	 *
 	 * @return RequestBuilder
@@ -189,6 +203,11 @@ class RequestBuilder {
 
 			App::setVar( 'mocked_request', $this->to_array() );
 
+			// Accumulate all requests with builder state for tests that inspect multiple requests.
+			$all   = App::getVar( 'mocked_requests' ) ?? [];
+			$all[] = array_merge( $this->to_array(), [ 'skip_auth' => $this->skip_auth ] );
+			App::setVar( 'mocked_requests', $all );
+
 			return $mocked;
 		}
 
@@ -259,7 +278,7 @@ class RequestBuilder {
 			$proxied                              = true;
 			$curl_parameters[ CURLOPT_PROXY ]     = Config::get_proxy_url();
 			$curl_parameters[ CURLOPT_PROXYTYPE ] = CURLPROXY_SOCKS5;
-		} else {
+		} elseif ( ! $this->skip_auth ) {
 			if ( ! is_null( App::make( Auth::class )->get_manager_secret() ) ) {
 				$this->post_body['manager_secret'] = App::make( Auth::class )->get_manager_secret();
 				// Connections using the MANAGER_SECRET that are not local must go through Automattic Proxy.

--- a/src/tests/unit/SyncAuthTest.php
+++ b/src/tests/unit/SyncAuthTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace QIT_CLI_Tests;
+
+use QIT_CLI\App;
+use QIT_CLI\Cache;
+use QIT_CLI\ManagerSync;
+use QIT_CLI\RequestBuilder;
+
+class SyncAuthTest extends QITTestCase {
+
+	/**
+	 * Verify that without_auth() sets the skip_auth flag on the builder.
+	 */
+	public function test_without_auth_sets_skip_auth_flag() {
+		$builder = new class( 'https://example.com/test' ) extends RequestBuilder {
+			public function is_skip_auth(): bool {
+				return $this->skip_auth;
+			}
+		};
+
+		$this->assertFalse( $builder->is_skip_auth() );
+		$builder->without_auth();
+		$this->assertTrue( $builder->is_skip_auth() );
+	}
+
+	/**
+	 * Verify that without_auth() returns $this for fluent chaining.
+	 */
+	public function test_without_auth_is_fluent() {
+		$builder = new RequestBuilder( 'https://example.com/test' );
+		$this->assertSame( $builder, $builder->without_auth() );
+	}
+
+	/**
+	 * Verify that bootstrap sync (cli/sync) skips auth while
+	 * extensions sync (cli/sync/extensions) uses auth.
+	 *
+	 * This locks in the split so a future refactor cannot silently
+	 * reintroduce credentials on the bootstrap route.
+	 */
+	public function test_bootstrap_sync_skips_auth_and_extensions_sync_uses_auth() {
+		App::setVar( 'mocked_requests', [] );
+
+		App::make( Cache::class )->set( 'manager_secret', 'test-secret', -1 );
+		App::make( ManagerSync::class )->maybe_sync( true );
+
+		$requests = App::getVar( 'mocked_requests' );
+
+		$bootstrap_request  = null;
+		$extensions_request = null;
+
+		foreach ( $requests as $req ) {
+			if ( strpos( $req['url'], 'cli/sync/extensions' ) !== false ) {
+				$extensions_request = $req;
+			} elseif ( strpos( $req['url'], 'cli/sync' ) !== false ) {
+				$bootstrap_request = $req;
+			}
+		}
+
+		$this->assertNotNull( $bootstrap_request, 'Bootstrap sync request was made.' );
+		$this->assertNotNull( $extensions_request, 'Extensions sync request was made.' );
+
+		$this->assertTrue( $bootstrap_request['skip_auth'], 'Bootstrap sync must not send credentials.' );
+		$this->assertFalse( $extensions_request['skip_auth'], 'Extensions sync must send credentials.' );
+	}
+}


### PR DESCRIPTION
Closes https://github.com/woocommerce/qit-cli/issues/443

 ## Summary

  - The bootstrap sync endpoint (`/cli/sync`) doesn't require authentication, but `RequestBuilder` was unconditionally injecting `partner_app_pass` into every request. When credentials are expired/revoked, the server hangs indefinitely instead of returning 401 — making every CLI command time out for 90s before falling into offline mode.
  - Added `without_auth()` to `RequestBuilder` so callers can opt out of credential injection. Bootstrap sync now uses it; extensions sync remains authenticated.
  - Updated `Diagnosis` messaging to suggest credential refresh when connectivity is fine but sync fails, instead of only blaming servers.