### PR TITLE
Re-sync on stale manager sync bucket to fix cold-CI race (qit-984)

### DIFF
--- a/src/src/Cache.php
+++ b/src/src/Cache.php
@@ -144,6 +144,19 @@ class Cache {
 
 		$bucket_data = $this->get( $cache_key );
 
+		/*
+		 * The bucket can be pruned mid-process when slow setup steps (e.g. cold-CI
+		 * package download, npm install, Playwright browser install) push the elapsed
+		 * time past the bootstrap cache TTL between the startup sync and this read.
+		 * Re-sync once and retry before giving up. Non-forced on purpose: the entry is
+		 * already gone, so sync() will re-fetch it, and we avoid needlessly busting the
+		 * extensions cache or hitting the network when a key is genuinely absent.
+		 */
+		if ( ! is_array( $bucket_data ) ) {
+			$manager_sync->maybe_sync();
+			$bucket_data = $this->get( $cache_key );
+		}
+
 		if ( ! is_array( $bucket_data ) ) {
 			throw new \UnexpectedValueException( "The manager sync data bucket for '$key' is not available." );
 		}

--- a/src/tests/unit/CacheResyncTest.php
+++ b/src/tests/unit/CacheResyncTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace QIT_CLI_Tests;
+
+use QIT_CLI\App;
+use QIT_CLI\Cache;
+use QIT_CLI\ManagerSync;
+
+class CacheResyncTest extends QITTestCase {
+
+	/**
+	 * The bootstrap bucket (which holds "versions") has a short TTL. On cold-CI
+	 * runs, slow setup steps (package download, npm install, Playwright browser
+	 * install) can elapse past that TTL between the startup sync and the point
+	 * where a version like "rc" is resolved, so Cache::get() prunes the bucket.
+	 *
+	 * Reading a bootstrap key in that state must transparently re-sync and return
+	 * the value, not throw "The manager sync data bucket is not available."
+	 */
+	public function test_get_manager_sync_data_resyncs_when_bucket_pruned() {
+		$cache        = App::make( Cache::class );
+		$manager_sync = App::make( ManagerSync::class );
+
+		// setUp() already synced, so the bucket is present.
+		$this->assertIsArray( $cache->get( $manager_sync->bootstrap_cache_key ), 'Bootstrap bucket is populated after setUp().' );
+
+		// Simulate the bucket being pruned mid-process once its TTL elapsed.
+		$cache->delete( $manager_sync->bootstrap_cache_key );
+		$this->assertNull( $cache->get( $manager_sync->bootstrap_cache_key ), 'Bootstrap bucket is gone after pruning.' );
+
+		// Should re-sync transparently rather than throw.
+		$versions = $cache->get_manager_sync_data( 'versions' );
+
+		$this->assertIsArray( $versions );
+		$this->assertArrayHasKey( 'woocommerce', $versions );
+		$this->assertSame( '10.6.1', $versions['woocommerce']['rc_unsynced'] );
+
+		// The bucket is repopulated, so subsequent reads hit the warm cache.
+		$this->assertIsArray( $cache->get( $manager_sync->bootstrap_cache_key ), 'Bootstrap bucket is repopulated after re-sync.' );
+	}
+
+	/**
+	 * A key that genuinely does not exist in a present bucket must still throw,
+	 * so the re-sync path doesn't mask real "missing key" errors.
+	 */
+	public function test_get_manager_sync_data_throws_for_unknown_key_in_present_bucket() {
+		$this->expectException( \UnexpectedValueException::class );
+		$this->expectExceptionMessage( "does not have the key 'this_key_does_not_exist'" );
+
+		App::make( Cache::class )->get_manager_sync_data( 'this_key_does_not_exist' );
+	}
+}


### PR DESCRIPTION
## Problem

Cold-CI test runs (e.g. `run:woo-api` / `run:woo-e2e` with `--woocommerce_version=rc --wordpress_version=rc`) intermittently failed with:

```
Failed to parse environment JSON. Output:
{"error":"Command failed with non-JSON output","output":"The manager sync data bucket for 'versions' is not available."}
```

The same commands pass on warm local runs.

## Root cause

The `bootstrap` sync bucket (which holds `versions`) is cached with a **60s TTL** and is only refreshed by `ManagerSync::maybe_sync()` at CLI startup. Resolving a special version like `rc`/`nightly` reads that bucket via `Cache::get_manager_sync_data('versions')` (`PreCommand/Extensions/VersionResolver`).

On cold CI, the slow setup steps between startup and environment build — package download, `npm install`, and the Playwright browser install ("this may take a few minutes") — easily elapse past 60s. By the time `rc` is resolved, `Cache::get()` has already **pruned** the expired bucket, and `get_manager_sync_data()` threw instead of re-fetching.

Because `env:up` runs through the `qit_json` stream filter, that exception surfaced as a non-JSON error envelope, and the parent reported `Failed to parse environment JSON`.

Warm local runs keep setup under the TTL, so the bucket is still alive — which is why this only reproduced in CI.

## Fix

When a bucket read misses, **re-sync once and retry** before throwing.

`maybe_sync()` is called **non-forced** on purpose:
- The entry is already pruned, so `sync()` re-fetches it without needing `force`.
- Avoids needlessly busting the extensions cache (an authed network round-trip) on every miss.
- A key that is genuinely absent from a present bucket still falls through to its proper `"does not have the key"` error rather than triggering pointless re-syncs.

The fix is self-limiting: the first miss in a process repopulates the whole bootstrap bucket, so later reads hit the warm cache. No recursion risk — `sync()` uses the raw cache, not `get_manager_sync_data()`. If the Manager is genuinely down, `sync()` now surfaces `NetworkErrorException` ("Failed to sync with Manager") instead of the misleading "bucket not available".

## Test notes

New `src/tests/unit/CacheResyncTest.php`:
- `test_get_manager_sync_data_resyncs_when_bucket_pruned` — deletes the bootstrap bucket to simulate mid-process TTL pruning, then asserts the read transparently re-syncs, returns the correct value (incl. `woocommerce.rc_unsynced` — the exact field the failing run needed), and repopulates the cache.
- `test_get_manager_sync_data_throws_for_unknown_key_in_present_bucket` — guards that the re-sync path does not mask real "missing key" errors.

Verification:
- `php -l` clean
- `make phpcs` clean (only a pre-existing, unrelated warning)
- `make phpstan` clean
- `make phpunit ARGS="tests/unit"` — **233 tests, 628 assertions, all passing** (2 new)

## Follow-up (not in this PR)

The `bootstrap` `$ttl` (60s) in `ManagerSync::sync()` was left untouched — the lazy re-sync is the real fix. Bumping the TTL is a complementary option to reduce miss-path round-trips if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)