### PR TITLE
Fix WooCommerce dev ZIP resolution

### DIFF
--- a/src/src/Environment/EnvUpChecker.php
+++ b/src/src/Environment/EnvUpChecker.php
@@ -63,7 +63,6 @@ class EnvUpChecker {
 		curl_setopt( $ch, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3' );
 		curl_exec( $ch );
 		$http_code = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
-		curl_close( $ch );
 
 		// 502 = Bad Gateway. This can happen for a short period, especially when using Jurassic Tube.
 		if ( $http_code === 502 && $retries < 3 ) { // @phpstan-ignore-line

--- a/src/src/OptionReuseTrait.php
+++ b/src/src/OptionReuseTrait.php
@@ -35,7 +35,9 @@ trait OptionReuseTrait {
 
 		// Using reflection to access the 'mode' private property of the option.
 		$reflected_option = new ReflectionProperty( InputOption::class, 'mode' );
-		$reflected_option->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$reflected_option->setAccessible( true );
+		}
 		$mode = $reflected_option->getValue( $option );
 
 		if ( $mode === InputOption::VALUE_NONE ) {

--- a/src/src/PreCommand/Extensions/ExtensionCacheManager.php
+++ b/src/src/PreCommand/Extensions/ExtensionCacheManager.php
@@ -371,7 +371,7 @@ class ExtensionCacheManager {
 
 			// Check if this is a special version that changes frequently
 			$is_special_version = in_array( $extension->version, [ 'rc', 'nightly' ], true ) ||
-									( $extension->slug === 'woocommerce' && in_array( $extension->version, [ 'rc', 'nightly' ], true ) );
+									( $extension->slug === 'woocommerce' && preg_match( '/^\d+\.\d+\.\d+-dev$/', (string) $extension->version ) === 1 );
 
 			if ( $is_special_version ) {
 				// RC and nightly versions change frequently, so short cache

--- a/src/src/PreCommand/Extensions/ExtensionResolver.php
+++ b/src/src/PreCommand/Extensions/ExtensionResolver.php
@@ -192,15 +192,18 @@ class ExtensionResolver {
 
 		// For remote sources, check if we have the necessary info
 		if ( $extension->from === 'wporg' ) {
-			// For WPORG, we just need the version - but special tags like nightly/rc require further resolution.
+			// For WPORG, we just need the version - but channel aliases like
+			// nightly/rc require further resolution.
 			$version_lower = strtolower( (string) $extension->version );
-			$special_tag   = in_array( $version_lower, [ 'nightly', 'rc' ], true ) || str_contains( $version_lower, '-rc' );
+			$special_tag   = in_array( $version_lower, [ 'nightly', 'rc' ], true );
 
-			// WooCommerce dev/nightly/rc builds are served from GitHub releases, not
+			// WooCommerce dev builds are served from GitHub releases, not
 			// WordPress.org. A wporg source pinned to such a version is NOT resolved -
 			// it must be routed through resolve_extension_source() so the version
 			// resolver can map it to a real GitHub release URL instead of a dead
-			// downloads.wordpress.org/plugin/woocommerce.{version}.zip URL.
+			// downloads.wordpress.org/plugin/woocommerce.{version}.zip URL. Explicit
+			// beta/RC versions (e.g. 10.9.0-beta.1, 10.9.0-rc.1) are valid WP.org
+			// downloads and should stay on the WP.org path.
 			if ( $extension->slug === 'woocommerce' && $this->version_resolver->is_woo_special_version( (string) $extension->version ) ) {
 				return false;
 			}
@@ -229,8 +232,8 @@ class ExtensionResolver {
 			return; // Local sources are resolved
 		}
 
-		// WooCommerce dev/nightly/rc builds live on GitHub releases, not WordPress.org.
-		// Resolve them to the correct URL up front so a pinned dev/nightly/rc version
+		// WooCommerce dev builds and channel aliases live on GitHub releases, not WordPress.org.
+		// Resolve them to the correct URL up front so a pinned dev version
 		// (whether declared as a plugin entry or via --woo) doesn't fall through to a
 		// non-existent downloads.wordpress.org/plugin/woocommerce.{version}.zip URL.
 		if ( $extension->slug === 'woocommerce' && ! empty( $extension->version ) ) {

--- a/src/src/PreCommand/Extensions/ExtensionResolver.php
+++ b/src/src/PreCommand/Extensions/ExtensionResolver.php
@@ -196,6 +196,15 @@ class ExtensionResolver {
 			$version_lower = strtolower( (string) $extension->version );
 			$special_tag   = in_array( $version_lower, [ 'nightly', 'rc' ], true ) || str_contains( $version_lower, '-rc' );
 
+			// WooCommerce dev/nightly/rc builds are served from GitHub releases, not
+			// WordPress.org. A wporg source pinned to such a version is NOT resolved -
+			// it must be routed through resolve_extension_source() so the version
+			// resolver can map it to a real GitHub release URL instead of a dead
+			// downloads.wordpress.org/plugin/woocommerce.{version}.zip URL.
+			if ( $extension->slug === 'woocommerce' && $this->version_resolver->is_woo_special_version( (string) $extension->version ) ) {
+				return false;
+			}
+
 			return ! empty( $extension->version ) && ! $special_tag;
 		}
 
@@ -213,18 +222,33 @@ class ExtensionResolver {
 	protected function resolve_extension_source( Extension $extension ): void {
 		debug_log( "ExtensionResolver: Resolving source for '{$extension->slug}'" );
 
-		// Handle explicit source types
-		if ( ! empty( $extension->from ) ) {
-			if ( in_array( $extension->from, [ 'local', 'url', 'build' ], true ) ) {
-				debug_log( "  Extension has explicit local/non-remote source: {$extension->from}" );
+		// Handle explicit local/non-remote source types (already resolved).
+		if ( ! empty( $extension->from ) && in_array( $extension->from, [ 'local', 'url', 'build' ], true ) ) {
+			debug_log( "  Extension has explicit local/non-remote source: {$extension->from}" );
 
-				return; // Local sources are resolved
-			}
-			if ( in_array( $extension->from, [ 'wporg', 'wccom' ], true ) && ! empty( $extension->source ) && ! empty( $extension->version ) ) {
-				debug_log( '  Extension has complete remote source information' );
+			return; // Local sources are resolved
+		}
 
-				return; // Remote sources with metadata are resolved
+		// WooCommerce dev/nightly/rc builds live on GitHub releases, not WordPress.org.
+		// Resolve them to the correct URL up front so a pinned dev/nightly/rc version
+		// (whether declared as a plugin entry or via --woo) doesn't fall through to a
+		// non-existent downloads.wordpress.org/plugin/woocommerce.{version}.zip URL.
+		if ( $extension->slug === 'woocommerce' && ! empty( $extension->version ) ) {
+			$woo_url = $this->version_resolver->resolve_woo( (string) $extension->version );
+			if ( $woo_url !== null ) {
+				$extension->from   = 'url';
+				$extension->source = $woo_url;
+				debug_log( "  Resolved WooCommerce '{$extension->version}' to GitHub release URL: {$woo_url}" );
+
+				return;
 			}
+		}
+
+		// Handle explicit remote source types with complete metadata.
+		if ( ! empty( $extension->from ) && in_array( $extension->from, [ 'wporg', 'wccom' ], true ) && ! empty( $extension->source ) && ! empty( $extension->version ) ) {
+			debug_log( '  Extension has complete remote source information' );
+
+			return; // Remote sources with metadata are resolved
 		}
 
 		// Version resolution is now handled explicitly in UpEnvironmentCommand

--- a/src/src/PreCommand/Extensions/VersionResolver.php
+++ b/src/src/PreCommand/Extensions/VersionResolver.php
@@ -32,6 +32,24 @@ class VersionResolver {
 	}
 
 	/**
+	 * Whether a WooCommerce version selector is a "special" version that must be
+	 * resolved to a GitHub release URL rather than a WordPress.org download.
+	 *
+	 * Mirrors the cases handled by {@see resolve_woo()}: the `rc` and `nightly`
+	 * channels and explicit development builds (e.g. `11.0.0-dev`). WordPress.org
+	 * only hosts released tags, so treating one of these as an ordinary wporg
+	 * version produces a dead `downloads.wordpress.org/.../{slug}.{version}.zip`
+	 * URL (HTTP 404), which later surfaces as a misleading "invalid zip" error.
+	 *
+	 * This is a side-effect-free predicate (unlike resolve_woo(), which may hit
+	 * the manager sync cache for `rc`), so it is safe to call from cache checks.
+	 */
+	public function is_woo_special_version( string $version ): bool {
+		return in_array( $version, [ 'rc', 'nightly' ], true )
+			|| preg_match( '/^\d+\.\d+\.\d+-dev$/', $version ) === 1;
+	}
+
+	/**
 	 * Resolve WordPress special versions (rc only).
 	 * Only handles RC - no fallbacks.
 	 */

--- a/src/src/RequestBuilder.php
+++ b/src/src/RequestBuilder.php
@@ -360,7 +360,6 @@ class RequestBuilder {
 		$body        = substr( $result, $header_size );
 
 		$response_status_code = curl_getinfo( $curl, CURLINFO_HTTP_CODE );
-		curl_close( $curl );
 
 		if ( ! in_array( $response_status_code, $this->expected_status_codes, true ) ) {
 			if ( $proxied && $result === false ) {
@@ -565,7 +564,6 @@ class RequestBuilder {
 		$curl_error    = curl_error( $curl );
 		$http_code     = (int) curl_getinfo( $curl, CURLINFO_HTTP_CODE );
 		$effective_url = curl_getinfo( $curl, CURLINFO_EFFECTIVE_URL );
-		curl_close( $curl );
 		fclose( $fp );
 
 		if ( $curl_error ) {

--- a/src/src/RequestBuilder.php
+++ b/src/src/RequestBuilder.php
@@ -460,10 +460,27 @@ class RequestBuilder {
 				throw new \RuntimeException( $error_message );
 			}
 
+			if ( is_array( $mocked ) ) {
+				$mock_body = (string) ( $mocked['body'] ?? '' );
+				if ( file_put_contents( $file_path, $mock_body ) === false ) {
+					throw new \RuntimeException( 'Could not write mock response to file: ' . $file_path );
+				}
+
+				$mock_status = isset( $mocked['status'] ) ? (int) $mocked['status'] : 200;
+				self::assert_download_succeeded( $mock_status, $url, $file_path, $mocked['effective_url'] ?? null );
+
+				if ( $output->isVerbose() ) {
+					$output->writeln( "Used mock response for $url, written to $file_path" );
+				}
+
+				return;
+			}
+
 			// Write mock response to file
 			if ( file_put_contents( $file_path, $mocked ) === false ) {
 				throw new \RuntimeException( 'Could not write mock response to file: ' . $file_path );
 			}
+			self::assert_download_succeeded( 200, $url, $file_path );
 
 			if ( $output->isVerbose() ) {
 				$output->writeln( "Used mock response for $url, written to $file_path" );
@@ -545,14 +562,92 @@ class RequestBuilder {
 		if ( $output->isVerbose() && ! is_ci() ) {
 			$output->writeln( sprintf( 'Downloaded %s in %f seconds.', $url, microtime( true ) - $start ) );
 		}
-		$curl_error = curl_error( $curl );
+		$curl_error    = curl_error( $curl );
+		$http_code     = (int) curl_getinfo( $curl, CURLINFO_HTTP_CODE );
+		$effective_url = curl_getinfo( $curl, CURLINFO_EFFECTIVE_URL );
 		curl_close( $curl );
 		fclose( $fp );
 
 		if ( $curl_error ) {
 			// Delete the potentially partially written file.
-			unlink( $file_path );
+			self::delete_download_file( $file_path );
 			throw new \RuntimeException( 'Curl ' . $curl_error );
+		}
+
+		self::assert_download_succeeded( $http_code, $url, $file_path, $effective_url );
+	}
+
+	/**
+	 * Validate a completed file download and remove unusable files before throwing.
+	 */
+	protected static function assert_download_succeeded( int $http_code, string $url, string $file_path, ?string $effective_url = null ): void {
+		// A transport-level success can still be an HTTP error (404, 403, 5xx). With
+		// CURLOPT_FILE the error body is streamed to $file_path, so without this guard
+		// a 404 "Not found" page (e.g. a WordPress.org download URL for a version that
+		// does not exist) masquerades as the downloaded zip and only fails later as a
+		// misleading "invalid zip" error. Fail loudly here, naming the real cause.
+		$http_error = self::download_http_error_message( $http_code, $url, $file_path, $effective_url );
+		if ( $http_error !== null ) {
+			self::delete_download_file( $file_path );
+			throw new \RuntimeException( $http_error );
+		}
+
+		clearstatcache( true, $file_path );
+		$file_size = file_exists( $file_path ) ? filesize( $file_path ) : false;
+		if ( $file_size === false || $file_size <= 0 ) {
+			self::delete_download_file( $file_path );
+			throw new \RuntimeException( 'Download failed: empty response for ' . self::sanitize_download_url_for_logs( $effective_url ?: $url ) );
+		}
+	}
+
+	/**
+	 * Build an error message when a download returned an HTTP error status, or null
+	 * when the status is acceptable. Extracted so the branch is unit-testable
+	 * without performing a real network download.
+	 */
+	protected static function download_http_error_message( int $http_code, string $url, string $file_path, ?string $effective_url = null ): ?string {
+		if ( $http_code >= 200 && $http_code < 300 ) {
+			return null;
+		}
+
+		$snippet = '';
+		if ( is_readable( $file_path ) ) {
+			$body    = (string) file_get_contents( $file_path, false, null, 0, 200 );
+			$snippet = trim( (string) preg_replace( '/\s+/', ' ', $body ) );
+		}
+
+		$url_for_logs           = self::sanitize_download_url_for_logs( $url );
+		$effective_url_for_logs = $effective_url !== null ? self::sanitize_download_url_for_logs( $effective_url ) : null;
+		$effective_url_suffix   = $effective_url_for_logs !== null && $effective_url_for_logs !== $url_for_logs
+			? sprintf( ' (effective URL: %s)', $effective_url_for_logs )
+			: '';
+
+		return sprintf(
+			'Download failed: HTTP %d for %s%s',
+			$http_code,
+			$url_for_logs,
+			$effective_url_suffix . ( $snippet !== '' ? ' - response body starts with: ' . $snippet : '' )
+		);
+	}
+
+	protected static function sanitize_download_url_for_logs( string $url ): string {
+		$parts = parse_url( $url );
+		if ( $parts === false || ! isset( $parts['scheme'], $parts['host'] ) ) {
+			return (string) preg_replace( '/[?#].*$/', '', $url );
+		}
+
+		$sanitized = $parts['scheme'] . '://' . $parts['host'];
+		if ( isset( $parts['port'] ) ) {
+			$sanitized .= ':' . $parts['port'];
+		}
+		$sanitized .= $parts['path'] ?? '';
+
+		return $sanitized;
+	}
+
+	protected static function delete_download_file( string $file_path ): void {
+		if ( file_exists( $file_path ) ) {
+			unlink( $file_path );
 		}
 	}
 

--- a/src/tests/unit/ExtensionCacheManagerTest.php
+++ b/src/tests/unit/ExtensionCacheManagerTest.php
@@ -34,6 +34,51 @@ class ExtensionCacheManagerTest extends QITTestCase {
 		return (string) $content;
 	}
 
+	private function validate_cache( ExtensionCacheManager $cache_manager, string $zip_path, Extension $extension ): bool {
+		$ref = new \ReflectionMethod( ExtensionCacheManager::class, 'validate_cache' );
+		$ref->setAccessible( true );
+
+		return (bool) $ref->invoke( $cache_manager, $zip_path, $extension );
+	}
+
+	public function test_woocommerce_dev_cache_expires_after_five_minutes(): void {
+		$cache_manager = App::make( ExtensionCacheManager::class );
+		$slug          = 'woocommerce';
+		$cache_file    = sys_get_temp_dir() . "/qit-cache-test-dev-$slug.zip";
+
+		$this->write_plugin_zip( $cache_file, $slug, '11.0.0-dev' );
+		touch( $cache_file, time() - 6 * MINUTE_IN_SECONDS );
+		clearstatcache( true, $cache_file );
+
+		$ext          = new Extension( $slug, 'plugin', 'https://github.com/woocommerce/woocommerce/releases/download/11.0.0-dev/woocommerce.zip' );
+		$ext->from    = 'url';
+		$ext->version = '11.0.0-dev';
+
+		$this->assertFalse(
+			$this->validate_cache( $cache_manager, $cache_file, $ext ),
+			'WooCommerce dev builds should refresh after the short cache window.'
+		);
+	}
+
+	public function test_regular_version_cache_survives_five_minutes(): void {
+		$cache_manager = App::make( ExtensionCacheManager::class );
+		$slug          = 'woocommerce';
+		$cache_file    = sys_get_temp_dir() . "/qit-cache-test-stable-$slug.zip";
+
+		$this->write_plugin_zip( $cache_file, $slug, '9.5.0' );
+		touch( $cache_file, time() - 6 * MINUTE_IN_SECONDS );
+		clearstatcache( true, $cache_file );
+
+		$ext          = new Extension( $slug, 'plugin', 'https://downloads.wordpress.org/plugin/woocommerce.9.5.0.zip' );
+		$ext->from    = 'wporg';
+		$ext->version = '9.5.0';
+
+		$this->assertTrue(
+			$this->validate_cache( $cache_manager, $cache_file, $ext ),
+			'Regular released versions should keep the longer cache window.'
+		);
+	}
+
 	/**
 	 * Rebuilding a local zip in place (same path) must invalidate the path-based
 	 * cache. Previously the copy was skipped whenever a cache file already existed,

--- a/src/tests/unit/ExtensionResolverWooVersionTest.php
+++ b/src/tests/unit/ExtensionResolverWooVersionTest.php
@@ -48,6 +48,24 @@ class ExtensionResolverWooVersionTest extends QITTestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider wporg_prerelease_provider
+	 */
+	public function test_woo_beta_and_rc_wporg_versions_remain_resolved( string $version ): void {
+		$this->assertTrue(
+			$this->invoke( $this->resolver(), 'is_source_resolved', $this->woo( $version ) ),
+			'Explicit WooCommerce beta/RC versions are legitimately available on WordPress.org.'
+		);
+	}
+
+	/** @return array<string,array{0:string}> */
+	public function wporg_prerelease_provider(): array {
+		return [
+			'explicit beta' => [ '10.9.0-beta.1' ],
+			'explicit rc'   => [ '10.9.0-rc.1' ],
+		];
+	}
+
 	public function test_resolve_source_maps_woo_dev_to_github_url(): void {
 		$ext = $this->woo( '11.0.0-dev' );
 		$this->invoke( $this->resolver(), 'resolve_extension_source', $ext );

--- a/src/tests/unit/ExtensionResolverWooVersionTest.php
+++ b/src/tests/unit/ExtensionResolverWooVersionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace QIT_CLI_Tests;
+
+use QIT_CLI\App;
+use QIT_CLI\PreCommand\Extensions\ExtensionResolver;
+use QIT_CLI\PreCommand\Objects\Extension;
+
+/**
+ * Regression coverage for QIT-997: a WooCommerce dev/nightly version pinned as a
+ * wporg plugin must NOT resolve to a non-existent WordPress.org download URL.
+ * WordPress.org only hosts released tags, so
+ * `downloads.wordpress.org/plugin/woocommerce.11.0.0-dev.zip` returns HTTP 404,
+ * whose body was previously written to disk and surfaced as "invalid zip".
+ */
+class ExtensionResolverWooVersionTest extends QITTestCase {
+	private function resolver(): ExtensionResolver {
+		return App::make( ExtensionResolver::class );
+	}
+
+	private function woo( string $version, ?string $from = 'wporg' ): Extension {
+		$ext          = new Extension( 'woocommerce', 'plugin' );
+		$ext->from    = $from;
+		$ext->version = $version;
+
+		return $ext;
+	}
+
+	/** @return mixed */
+	private function invoke( ExtensionResolver $resolver, string $method, Extension $ext ) {
+		$ref = new \ReflectionMethod( ExtensionResolver::class, $method );
+		$ref->setAccessible( true );
+
+		return $ref->invoke( $resolver, $ext );
+	}
+
+	public function test_woo_dev_wporg_source_is_not_considered_resolved(): void {
+		$this->assertFalse(
+			$this->invoke( $this->resolver(), 'is_source_resolved', $this->woo( '11.0.0-dev' ) ),
+			'WooCommerce dev version on wporg must be flagged unresolved so it routes through the version resolver.'
+		);
+	}
+
+	public function test_woo_stable_wporg_source_remains_resolved(): void {
+		$this->assertTrue(
+			$this->invoke( $this->resolver(), 'is_source_resolved', $this->woo( '9.5.0' ) ),
+			'A stable WooCommerce version is legitimately available on WordPress.org.'
+		);
+	}
+
+	public function test_resolve_source_maps_woo_dev_to_github_url(): void {
+		$ext = $this->woo( '11.0.0-dev' );
+		$this->invoke( $this->resolver(), 'resolve_extension_source', $ext );
+
+		$this->assertSame( 'url', $ext->from );
+		$this->assertSame(
+			'https://github.com/woocommerce/woocommerce/releases/download/11.0.0-dev/woocommerce.zip',
+			$ext->source
+		);
+	}
+
+	public function test_resolve_source_maps_woo_nightly_to_github_url(): void {
+		$ext = $this->woo( 'nightly' );
+		$this->invoke( $this->resolver(), 'resolve_extension_source', $ext );
+
+		$this->assertSame( 'url', $ext->from );
+		$this->assertSame(
+			'https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip',
+			$ext->source
+		);
+	}
+
+	public function test_resolve_source_leaves_woo_dev_url_untouched_when_already_a_url(): void {
+		$ext          = $this->woo( '11.0.0-dev', 'url' );
+		$ext->source  = 'https://example.com/custom-woocommerce.zip';
+		$this->invoke( $this->resolver(), 'resolve_extension_source', $ext );
+
+		// An explicit url source is already resolved and must not be overridden.
+		$this->assertSame( 'url', $ext->from );
+		$this->assertSame( 'https://example.com/custom-woocommerce.zip', $ext->source );
+	}
+}

--- a/src/tests/unit/RequestBuilderHttpStatusTest.php
+++ b/src/tests/unit/RequestBuilderHttpStatusTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace QIT_CLI_Tests;
+
+use QIT_CLI\App;
+use QIT_CLI\RequestBuilder;
+
+/**
+ * Coverage for QIT-997: download_file() must reject HTTP error responses instead
+ * of writing the error body (e.g. a 404 "Not found" page) to disk, where it would
+ * later fail as a misleading "invalid zip".
+ */
+class RequestBuilderHttpStatusTest extends QITTestCase {
+	/** @var string[] */
+	private $tmp_files = [];
+
+	public function tearDown(): void {
+		foreach ( $this->tmp_files as $f ) {
+			if ( file_exists( $f ) ) {
+				unlink( $f );
+			}
+		}
+		parent::tearDown();
+	}
+
+	private function error_message( int $http_code, string $url, string $file_path ): ?string {
+		$ref = new \ReflectionMethod( RequestBuilder::class, 'download_http_error_message' );
+		$ref->setAccessible( true );
+
+		return $ref->invoke( null, $http_code, $url, $file_path );
+	}
+
+	private function tmp_file_with( string $contents ): string {
+		$path = tempnam( sys_get_temp_dir(), 'qit-dl-' );
+		file_put_contents( $path, $contents );
+		$this->tmp_files[] = $path;
+
+		return $path;
+	}
+
+	public function test_successful_status_returns_null(): void {
+		$path = $this->tmp_file_with( 'PK...zip bytes...' );
+		$this->assertNull( $this->error_message( 200, 'https://example.com/x.zip', $path ) );
+	}
+
+	public function test_404_returns_message_with_status_url_and_body_snippet(): void {
+		$url     = 'https://downloads.wordpress.org/plugin/woocommerce.11.0.0-dev.zip?token=secret';
+		$path    = $this->tmp_file_with( "Not found" );
+		$message = $this->error_message( 404, $url, $path );
+
+		$this->assertNotNull( $message );
+		$this->assertStringContainsString( 'HTTP 404', $message );
+		$this->assertStringContainsString( 'https://downloads.wordpress.org/plugin/woocommerce.11.0.0-dev.zip', $message );
+		$this->assertStringNotContainsString( 'token=secret', $message );
+		$this->assertStringContainsString( 'Not found', $message );
+	}
+
+	public function test_5xx_without_readable_body_omits_snippet(): void {
+		$message = $this->error_message( 503, 'https://example.com/x.zip', '/no/such/file/here' );
+
+		$this->assertNotNull( $message );
+		$this->assertStringContainsString( 'HTTP 503', $message );
+		$this->assertStringNotContainsString( 'response body starts with', $message );
+	}
+
+	public function test_download_file_deletes_http_error_body(): void {
+		$url  = 'https://downloads.wordpress.org/plugin/woocommerce.11.0.0-dev.zip?token=secret';
+		$path = $this->tmp_file_with( '' );
+		unlink( $path );
+
+		App::setVar( 'mock_' . $url, [
+			'status' => 404,
+			'body'   => 'Not found',
+		] );
+
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessage( 'HTTP 404' );
+
+		try {
+			RequestBuilder::download_file( $url, $path );
+		} finally {
+			$this->assertFileNotExists( $path );
+		}
+	}
+
+	public function test_download_file_deletes_empty_success_response(): void {
+		$url  = 'https://example.com/empty.zip?signature=secret';
+		$path = $this->tmp_file_with( '' );
+		unlink( $path );
+
+		App::setVar( 'mock_' . $url, [
+			'status' => 200,
+			'body'   => '',
+		] );
+
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessage( 'empty response' );
+
+		try {
+			RequestBuilder::download_file( $url, $path );
+		} finally {
+			$this->assertFileNotExists( $path );
+		}
+	}
+
+	public function test_download_file_accepts_successful_mock_response(): void {
+		$url  = 'https://example.com/plugin.zip';
+		$path = $this->tmp_file_with( '' );
+		unlink( $path );
+		$this->tmp_files[] = $path;
+
+		App::setVar( 'mock_' . $url, [
+			'status' => 200,
+			'body'   => 'zip bytes',
+		] );
+
+		RequestBuilder::download_file( $url, $path );
+
+		$this->assertSame( 'zip bytes', file_get_contents( $path ) );
+	}
+}

--- a/src/tests/unit/VersionResolverTest.php
+++ b/src/tests/unit/VersionResolverTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace QIT_CLI_Tests;
+
+use QIT_CLI\App;
+use QIT_CLI\PreCommand\Extensions\VersionResolver;
+
+class VersionResolverTest extends QITTestCase {
+	private function resolver(): VersionResolver {
+		return App::make( VersionResolver::class );
+	}
+
+	public function test_resolve_woo_dev_version_maps_to_github_release(): void {
+		$this->assertSame(
+			'https://github.com/woocommerce/woocommerce/releases/download/11.0.0-dev/woocommerce.zip',
+			$this->resolver()->resolve_woo( '11.0.0-dev' )
+		);
+	}
+
+	public function test_resolve_woo_nightly_maps_to_trunk_nightly(): void {
+		$this->assertSame(
+			'https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip',
+			$this->resolver()->resolve_woo( 'nightly' )
+		);
+	}
+
+	public function test_resolve_woo_returns_null_for_regular_and_stable_versions(): void {
+		$this->assertNull( $this->resolver()->resolve_woo( '9.5.0' ) );
+		$this->assertNull( $this->resolver()->resolve_woo( 'stable' ) );
+	}
+
+	/**
+	 * @dataProvider special_version_provider
+	 */
+	public function test_is_woo_special_version( string $version, bool $expected ): void {
+		$this->assertSame( $expected, $this->resolver()->is_woo_special_version( $version ) );
+	}
+
+	/** @return array<string,array{0:string,1:bool}> */
+	public function special_version_provider(): array {
+		return [
+			'nightly channel'   => [ 'nightly', true ],
+			'rc channel'        => [ 'rc', true ],
+			'explicit dev build' => [ '11.0.0-dev', true ],
+			'other dev build'   => [ '9.9.0-dev', true ],
+			'stable keyword'    => [ 'stable', false ],
+			'regular version'   => [ '9.5.0', false ],
+			'undefined'         => [ 'undefined', false ],
+			// Explicit rc/beta tags are not handled by resolve_woo() (separate follow-up).
+			'explicit rc tag'   => [ '11.0.0-rc.1', false ],
+		];
+	}
+}


### PR DESCRIPTION
## Summary

Fixes QIT CLI handling for WooCommerce `*-dev` versions, specifically `11.0.0-dev`, when WooCommerce is provided as a pinned plugin entry instead of via the `--woo` scalar.

Previously, that path treated `woocommerce:11.0.0-dev` as a WordPress.org plugin version and downloaded:

```text
https://downloads.wordpress.org/plugin/woocommerce.11.0.0-dev.zip
```

WordPress.org returns a 404 body for that URL, but `RequestBuilder::download_file()` wrote the body to disk and only failed later as an "invalid ZIP". This change routes WooCommerce dev builds to the existing GitHub release resolver and hardens file downloads so HTTP errors and empty responses fail immediately with clearer diagnostics.

## Changes

- Route WooCommerce `rc`, `nightly`, and `X.Y.Z-dev` versions through `VersionResolver` when supplied as plugin entries.
- Reject non-2xx file downloads before ZIP validation.
- Reject empty successful file downloads.
- Redact query strings/fragments from download URLs in error messages.
- Short-cache WooCommerce `*-dev` ZIPs like other moving WooCommerce builds.
- Add regression coverage for resolver parity, HTTP download failures, and dev-build cache freshness.

## Testing

```bash
qit env:up --woo=11.0.0-dev --wp=latest --php=8.3 --skip-setup --json
```

Expected result: WooCommerce resolves to the GitHub `11.0.0-dev` release ZIP, not `downloads.wordpress.org/plugin/woocommerce.11.0.0-dev.zip`, and environment setup should not fail with a misleading invalid ZIP error.
