### PR TITLE
Revert validation snapshot: "Tested up to" back to "5.8" for themes

### DIFF
--- a/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_main_theme_woo_php_wp_3976d011ae5709242b883dfb4863e252__1.php
+++ b/_tests/managed_tests/tests/__snapshots__/ValidationTest__test_validation_main_theme_woo_php_wp_3976d011ae5709242b883dfb4863e252__1.php
@@ -55,7 +55,7 @@
                 "headers": {
                     "Requires PHP": "7.4",
                     "Requires at least": "5.6",
-                    "Tested up to": false,
+                    "Tested up to": "5.8",
                     "WC requires at least": "5.8",
                     "WC tested up to": "5.8",
                     "Woo": false,


### PR DESCRIPTION
## What

Reverts the `main_theme` validation snapshot change from #469, restoring `"Tested up to": "5.8"`.

## Why

The self-test started failing when production began returning `"Tested up to": false` for themes. #469 papered over that by updating the snapshot to match the broken output. The actual bug was **manager-side theme header extraction**: it reflected over `WP_Theme`'s private `headers` property, which doesn't expose `Tested up to`, so the value fell through to `false`.

That root cause is fixed in compatibility-dashboard (`f4793ba`), which reads theme headers via `get_file_data()` with an explicit header map. The manager side is now **deployed**, so themes again report the value declared in `style.css` (`"Tested up to": "5.8"`).

This PR returns the snapshot to its original, correct value. The validation self-test on this PR verifies against the fixed production behavior.

## Sequencing

- ✅ Manager-side fix deployed to production
- ➡️ This revert — safe to merge once the self-test passes green here

🤖 Generated with [Claude Code](https://claude.com/claude-code)