### PR TITLE
Require Docker Compose v2 instead of silently falling back to EOL v1

### DIFF
--- a/src/src/Environment/Docker.php
+++ b/src/src/Environment/Docker.php
@@ -454,34 +454,48 @@ class Docker {
 	}
 
 	/**
+	 * Docker Compose v1 is end-of-life and cannot run QIT environments. The environment files
+	 * we generate omit the top-level "version" key, which v1 resolves to Compose file format 1.
+	 * On that path v1 interpolates with Python's stdlib string.Template, which does not
+	 * understand "${VAR:-default}" (nor "${VAR-default}"), and fails with "Invalid
+	 * interpolation format".
+	 *
+	 * Note that the binary name does not identify the major version: Compose v2 ships both as a
+	 * "docker compose" CLI plugin and as a standalone "docker-compose" binary, so both
+	 * candidates have to be probed for their reported version.
+	 *
 	 * @return array<string> The docker-compose command to use, in a Symfony Process format.
 	 */
 	public function find_docker_compose(): array {
-		$output     = [];
-		$return_var = 0;
+		$candidates = [
+			[ 'docker', 'compose' ],
+			[ 'docker-compose' ],
+		];
 
-		// Docker Compose v2.
-		exec( 'docker compose version >/dev/null 2>&1', $output, $return_var );
-		if ( $return_var === 0 ) {
-			return [ 'docker', 'compose' ];
+		$found_unsupported = null;
+
+		foreach ( $candidates as $candidate ) {
+			$major = $this->get_docker_compose_major_version( $candidate );
+
+			if ( is_null( $major ) ) {
+				continue;
+			}
+
+			if ( $major >= 2 ) {
+				return $candidate;
+			}
+
+			// Installed, but too old. Keep probing: a supported version may exist under the other name.
+			$found_unsupported = implode( ' ', $candidate );
 		}
 
-		/*
-		 * The legacy standalone "docker-compose" (v1) is end-of-life and cannot run QIT
-		 * environments. The environment files we generate omit the top-level "version" key,
-		 * which v1 resolves to Compose file format 1. On that path v1 interpolates with
-		 * Python's stdlib string.Template, which does not understand "${VAR:-default}"
-		 * (nor "${VAR-default}"), and fails with "Invalid interpolation format".
-		 *
-		 * Falling back to it silently produced confusing downstream errors, so refuse it
-		 * explicitly and tell the user how to install v2.
-		 */
-		exec( 'docker-compose version >/dev/null 2>&1', $output, $return_var );
-		if ( $return_var === 0 ) {
+		if ( ! is_null( $found_unsupported ) ) {
 			throw new \RuntimeException(
-				"Docker Compose v2 is required, but only the legacy \"docker-compose\" (v1) was found.\n" .
-				"Docker Compose v1 is end-of-life and cannot run QIT environments.\n\n" .
-				"Install the Compose v2 plugin, then verify with: docker compose version\n" .
+				sprintf(
+					"Docker Compose v2 or higher is required, but \"%s\" reports v1, which is end-of-life and cannot run QIT environments.\n\n",
+					$found_unsupported
+				) .
+				"Upgrade Docker Compose, then verify with: docker compose version\n" .
 				"  Debian/Ubuntu: sudo apt-get install docker-compose-plugin\n" .
 				"  RHEL/Fedora:   sudo dnf install docker-compose-plugin\n" .
 				'  Other systems: https://docs.docker.com/compose/install/'
@@ -489,12 +503,38 @@ class Docker {
 		}
 
 		throw new \RuntimeException(
-			"Could not find Docker Compose v2.\n\n" .
+			"Could not find Docker Compose v2 or higher.\n\n" .
 			"Install it, then verify with: docker compose version\n" .
 			"  Debian/Ubuntu: sudo apt-get install docker-compose-plugin\n" .
 			"  RHEL/Fedora:   sudo dnf install docker-compose-plugin\n" .
 			'  Other systems: https://docs.docker.com/compose/install/'
 		);
+	}
+
+	/**
+	 * @param array<string> $command The Docker Compose command to probe.
+	 *
+	 * @return int|null The reported major version, or null if the command is unavailable or unparseable.
+	 */
+	protected function get_docker_compose_major_version( array $command ): ?int {
+		$output     = [];
+		$return_var = 0;
+
+		exec( implode( ' ', $command ) . ' version 2>&1', $output, $return_var );
+
+		if ( $return_var !== 0 ) {
+			return null;
+		}
+
+		/*
+		 * v1: "docker-compose version 1.29.2, build 5becea4c"
+		 * v2: "Docker Compose version v2.24.5"
+		 */
+		if ( ! preg_match( '/\bversion\s+v?(\d+)\./i', implode( "\n", $output ), $matches ) ) {
+			return null;
+		}
+
+		return (int) $matches[1];
 	}
 
 	public function maybe_pull_docker_compose( string $docker_compose_path, string $environment_type ): void {

--- a/src/src/Environment/Docker.php
+++ b/src/src/Environment/Docker.php
@@ -460,18 +460,41 @@ class Docker {
 		$output     = [];
 		$return_var = 0;
 
-		// Prefer Docker Compose v2 over v1.
+		// Docker Compose v2.
 		exec( 'docker compose version >/dev/null 2>&1', $output, $return_var );
 		if ( $return_var === 0 ) {
 			return [ 'docker', 'compose' ];
 		}
 
+		/*
+		 * The legacy standalone "docker-compose" (v1) is end-of-life and cannot run QIT
+		 * environments. The environment files we generate omit the top-level "version" key,
+		 * which v1 resolves to Compose file format 1. On that path v1 interpolates with
+		 * Python's stdlib string.Template, which does not understand "${VAR:-default}"
+		 * (nor "${VAR-default}"), and fails with "Invalid interpolation format".
+		 *
+		 * Falling back to it silently produced confusing downstream errors, so refuse it
+		 * explicitly and tell the user how to install v2.
+		 */
 		exec( 'docker-compose version >/dev/null 2>&1', $output, $return_var );
 		if ( $return_var === 0 ) {
-			return [ 'docker-compose' ];
+			throw new \RuntimeException(
+				"Docker Compose v2 is required, but only the legacy \"docker-compose\" (v1) was found.\n" .
+				"Docker Compose v1 is end-of-life and cannot run QIT environments.\n\n" .
+				"Install the Compose v2 plugin, then verify with: docker compose version\n" .
+				"  Debian/Ubuntu: sudo apt-get install docker-compose-plugin\n" .
+				"  RHEL/Fedora:   sudo dnf install docker-compose-plugin\n" .
+				'  Other systems: https://docs.docker.com/compose/install/'
+			);
 		}
 
-		throw new \RuntimeException( 'Could not find docker compose or docker-compose' );
+		throw new \RuntimeException(
+			"Could not find Docker Compose v2.\n\n" .
+			"Install it, then verify with: docker compose version\n" .
+			"  Debian/Ubuntu: sudo apt-get install docker-compose-plugin\n" .
+			"  RHEL/Fedora:   sudo dnf install docker-compose-plugin\n" .
+			'  Other systems: https://docs.docker.com/compose/install/'
+		);
 	}
 
 	public function maybe_pull_docker_compose( string $docker_compose_path, string $environment_type ): void {

--- a/src/tests/unit/DockerComposeDiscoveryTest.php
+++ b/src/tests/unit/DockerComposeDiscoveryTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace QIT_CLI_Tests;
+
+use PHPUnit\Framework\TestCase;
+use QIT_CLI\Environment\Docker;
+
+/**
+ * Coverage for QIT-1003: falling back to the legacy standalone "docker-compose" (v1)
+ * surfaced as "Failed to parse environment JSON" for vendors. Compose v1 resolves our
+ * version-less environment files to Compose file format 1, where it interpolates with
+ * Python's stdlib string.Template and rejects "${FIXUID:-1000}" outright.
+ *
+ * We now refuse v1 explicitly rather than limping along on it.
+ */
+class DockerComposeDiscoveryTest extends TestCase {
+	/** @var string */
+	private $fake_bin;
+
+	/** @var string|false */
+	private $original_path;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		if ( stripos( PHP_OS, 'WIN' ) === 0 ) {
+			$this->markTestSkipped( 'Relies on POSIX shell stubs on PATH.' );
+		}
+
+		$this->original_path = getenv( 'PATH' );
+		$this->fake_bin      = sys_get_temp_dir() . '/qit-1003-' . uniqid();
+
+		mkdir( $this->fake_bin );
+	}
+
+	protected function tearDown(): void {
+		foreach ( glob( $this->fake_bin . '/*' ) ?: [] as $stub ) {
+			unlink( $stub );
+		}
+
+		if ( is_dir( $this->fake_bin ) ) {
+			rmdir( $this->fake_bin );
+		}
+
+		putenv( 'PATH=' . $this->original_path );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Write an executable stub onto a PATH that contains nothing else, so discovery
+	 * only ever sees the binaries a given test declares.
+	 */
+	private function stub( string $name, string $body ): void {
+		$path = $this->fake_bin . '/' . $name;
+
+		file_put_contents( $path, "#!/bin/sh\n" . $body . "\n" );
+		chmod( $path, 0755 );
+	}
+
+	private function find_docker_compose(): array {
+		putenv( 'PATH=' . $this->fake_bin );
+
+		$docker = ( new \ReflectionClass( Docker::class ) )->newInstanceWithoutConstructor();
+
+		return $docker->find_docker_compose();
+	}
+
+	public function test_it_prefers_docker_compose_v2(): void {
+		$this->stub( 'docker', '[ "$1" = "compose" ] && exit 0; exit 0' );
+
+		$this->assertSame( [ 'docker', 'compose' ], $this->find_docker_compose() );
+	}
+
+	public function test_it_refuses_the_legacy_v1_binary_instead_of_falling_back(): void {
+		// The vendor's box: modern Docker Engine, no compose plugin, standalone v1 present.
+		$this->stub( 'docker', '[ "$1" = "compose" ] && exit 1; exit 0' );
+		$this->stub( 'docker-compose', 'echo "docker-compose version 1.25.0, build unknown"; exit 0' );
+
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessageMatches( '/legacy "docker-compose" \(v1\)/' );
+
+		$this->find_docker_compose();
+	}
+
+	public function test_it_explains_how_to_install_when_nothing_is_found(): void {
+		$this->stub( 'docker', '[ "$1" = "compose" ] && exit 1; exit 0' );
+
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessageMatches( '/Could not find Docker Compose v2/' );
+
+		$this->find_docker_compose();
+	}
+}

--- a/src/tests/unit/DockerComposeDiscoveryTest.php
+++ b/src/tests/unit/DockerComposeDiscoveryTest.php
@@ -11,7 +11,9 @@ use QIT_CLI\Environment\Docker;
  * version-less environment files to Compose file format 1, where it interpolates with
  * Python's stdlib string.Template and rejects "${FIXUID:-1000}" outright.
  *
- * We now refuse v1 explicitly rather than limping along on it.
+ * We refuse v1 explicitly rather than limping along on it. Note that the binary name does
+ * not identify the major version -- Compose v2 also ships as a standalone "docker-compose"
+ * binary -- so discovery gates on the reported version, not on which binary answered.
  */
 class DockerComposeDiscoveryTest extends TestCase {
 	/** @var string */
@@ -58,6 +60,22 @@ class DockerComposeDiscoveryTest extends TestCase {
 		chmod( $path, 0755 );
 	}
 
+	/**
+	 * Stub "docker", where "docker compose version" prints $version_output. A null
+	 * $version_output means the CLI plugin is absent, which Docker reports as a non-zero exit.
+	 */
+	private function stub_docker( ?string $version_output ): void {
+		$compose = is_null( $version_output )
+			? 'echo "docker: \'compose\' is not a docker command." >&2; exit 1'
+			: sprintf( 'echo "%s"; exit 0', $version_output );
+
+		$this->stub( 'docker', sprintf( 'if [ "$1" = "compose" ]; then %s; fi; exit 0', $compose ) );
+	}
+
+	private function stub_docker_compose( string $version_output ): void {
+		$this->stub( 'docker-compose', sprintf( 'echo "%s"; exit 0', $version_output ) );
+	}
+
 	private function find_docker_compose(): array {
 		putenv( 'PATH=' . $this->fake_bin );
 
@@ -66,28 +84,61 @@ class DockerComposeDiscoveryTest extends TestCase {
 		return $docker->find_docker_compose();
 	}
 
-	public function test_it_prefers_docker_compose_v2(): void {
-		$this->stub( 'docker', '[ "$1" = "compose" ] && exit 0; exit 0' );
+	public function test_it_prefers_the_v2_cli_plugin(): void {
+		$this->stub_docker( 'Docker Compose version v2.24.5' );
+		$this->stub_docker_compose( 'docker-compose version 1.29.2, build 5becea4c' );
+
+		$this->assertSame( [ 'docker', 'compose' ], $this->find_docker_compose() );
+	}
+
+	/**
+	 * The regression the version gate exists to prevent: modern Docker Engine without the CLI
+	 * plugin, but with the standalone Compose v2 binary. Gating on the binary name would
+	 * hard-fail this working setup while claiming it was running EOL v1.
+	 */
+	public function test_it_accepts_the_standalone_v2_binary(): void {
+		$this->stub_docker( null );
+		$this->stub_docker_compose( 'Docker Compose version v2.24.5' );
+
+		$this->assertSame( [ 'docker-compose' ], $this->find_docker_compose() );
+	}
+
+	/**
+	 * We reject v1 specifically, not "everything that isn't v2" -- a future major must not
+	 * start failing against an equality check.
+	 */
+	public function test_it_accepts_a_future_major_version(): void {
+		$this->stub_docker( 'Docker Compose version v3.0.1' );
 
 		$this->assertSame( [ 'docker', 'compose' ], $this->find_docker_compose() );
 	}
 
 	public function test_it_refuses_the_legacy_v1_binary_instead_of_falling_back(): void {
 		// The vendor's box: modern Docker Engine, no compose plugin, standalone v1 present.
-		$this->stub( 'docker', '[ "$1" = "compose" ] && exit 1; exit 0' );
-		$this->stub( 'docker-compose', 'echo "docker-compose version 1.25.0, build unknown"; exit 0' );
+		$this->stub_docker( null );
+		$this->stub_docker_compose( 'docker-compose version 1.25.0, build unknown' );
 
 		$this->expectException( \RuntimeException::class );
-		$this->expectExceptionMessageMatches( '/legacy "docker-compose" \(v1\)/' );
+		$this->expectExceptionMessageMatches( '/"docker-compose" reports v1/' );
 
 		$this->find_docker_compose();
 	}
 
+	/**
+	 * A v1 answering under one name must not mask a usable v2 under the other.
+	 */
+	public function test_it_keeps_probing_past_a_v1_plugin_to_find_a_v2_binary(): void {
+		$this->stub_docker( 'docker-compose version 1.29.2, build 5becea4c' );
+		$this->stub_docker_compose( 'Docker Compose version v2.24.5' );
+
+		$this->assertSame( [ 'docker-compose' ], $this->find_docker_compose() );
+	}
+
 	public function test_it_explains_how_to_install_when_nothing_is_found(): void {
-		$this->stub( 'docker', '[ "$1" = "compose" ] && exit 1; exit 0' );
+		$this->stub_docker( null );
 
 		$this->expectException( \RuntimeException::class );
-		$this->expectExceptionMessageMatches( '/Could not find Docker Compose v2/' );
+		$this->expectExceptionMessageMatches( '/Could not find Docker Compose v2 or higher/' );
 
 		$this->find_docker_compose();
 	}


### PR DESCRIPTION
## Fixes QIT-1003: `Failed to parse environment JSON` on older Docker Compose

### Problem

Users running the legacy standalone `docker-compose` (v1) can't start an environment. Any test run ends in:

```
Failed to parse environment JSON. Output:
{"error":"Command failed with non-JSON output","output":"Failed to start the environment. Output:
ERROR: Invalid interpolation format for "qit_env_php_<id>" option in service "services": "${FIXUID:-1000}:${FIXGID:-1000}""}
```

This happens on systems that have Docker Engine installed **without** the `docker-compose-plugin` — `docker compose` (v2) isn't available, so `find_docker_compose()` silently fell back to the standalone `docker-compose` binary. Compose v1 has been EOL since 2023 and cannot parse the environment files QIT generates.

The real failure was the silent fallback: the error surfaced three layers downstream, with nothing connecting it back to "install the Compose plugin."

### Why Compose v1 fails

1. Our generated compose files omit a top-level `version:` key.
2. With no `version` key, v1 resolves the file to **Compose file format 1** (`config.py:195`).
3. On that path v1 interpolates with Python's stdlib `string.Template`, not its own `TemplateWithDefaults` (`interpolation.py:32-36`).
4. Stdlib `Template` rejects any `${VAR-default}` suffix → `Invalid interpolation format`.
5. Under format-1, top-level `services` is read as a *service name* — hence the odd `option "qit_env_php_…" in service "services"` wording.

Docker Compose **v2 parses the same file correctly.** The compose files are valid; this is purely a v1 problem.

### Fix

`find_docker_compose()` no longer silently degrades to v1. If only the legacy binary is present, it throws with install instructions:

```
Docker Compose v2 is required, but only the legacy "docker-compose" (v1) was found.
Docker Compose v1 is end-of-life and cannot run QIT environments.

Install the Compose v2 plugin, then verify with: docker compose version
  Debian/Ubuntu: sudo apt-get install docker-compose-plugin
  RHEL/Fedora:   sudo dnf install docker-compose-plugin
  Other systems: https://docs.docker.com/compose/install/
```

The "nothing found at all" message got the same treatment.

### Why not just patch the compose files?

The obvious-looking fix — changing `${FIXUID:-1000}` to `${FIXUID-1000}` — **does not work**, and was tried and reverted. Compose v1 rejects the suffix whether or not there's a colon (step 4 above). Worse, it's an active regression: under Compose v2 an *empty* `FIXUID` renders `user: ":"` with the single-dash form, while `:-` correctly falls back to `1000`. Empty values are reachable via `QIT_DOCKER_USER` / `QIT_DOCKER_GROUP`.

Adding `version: "2.1"` back to the generators would work, but means carrying a key Compose v2 warns about, forever, to satisfy a dead parser — and still breaks on v1 < 1.11.

Compose v1 doesn't fail in one place, it fails in many. Refusing it once is bounded work; patching symptoms is not.

### ⚠️ Breaking change

Users still on Compose v1 go from "fails confusingly" to "fails clearly, with instructions." That's the intent — v1 never actually worked with these files. Worth a release-notes line.

`Makefile`, `ci/` and `.github/` all use `docker compose`, so **runners are unaffected.**

### Testing

Reproduce by stubbing `PATH` (no v1 install needed):

```bash
mkdir -p /tmp/fakebin

# `docker compose` unavailable; standalone `docker-compose` present → should throw the v1 message
printf '#!/bin/sh\n[ "$1" = "compose" ] && exit 1\nexit 0\n' > /tmp/fakebin/docker
printf '#!/bin/sh\necho "docker-compose version 1.25.0"\n' > /tmp/fakebin/docker-compose
chmod +x /tmp/fakebin/*

PATH="/tmp/fakebin:$PATH" qit env:up
# Expect: "Docker Compose v2 is required..." — not "Failed to parse environment JSON"

# Remove the v1 stub → should throw "Could not find Docker Compose v2."
rm /tmp/fakebin/docker-compose
PATH="/tmp/fakebin:$PATH" qit env:up
```

Regression check with a normal Compose v2 install, `qit env:up` behaves exactly as before.
