### PR TITLE
QIT-1006: Clarify repeatable environment reset contract

### DIFF
--- a/src/src/Commands/Environment/ResetEnvironmentCommand.php
+++ b/src/src/Commands/Environment/ResetEnvironmentCommand.php
@@ -36,6 +36,8 @@ class ResetEnvironmentCommand extends QITCommand {
 			->addArgument( 'env_id', InputArgument::OPTIONAL, 'Environment ID (uses current if not specified)' )
 			->setHelp( <<<HELP
 The <info>env:reset</info> command restores the database to the state saved after running setup phases.
+It can be called repeatedly against the same running environment; each call restores the same
+post-setup database snapshot and flushes the WordPress object cache.
 
 This is useful when:
   • You want to run tests with a clean state
@@ -51,6 +53,9 @@ Examples:
 
 Note: This only works if the environment was started with setup phases
 (i.e., a qit-test.json file was present and --skip-setup was not used).
+
+Scope: env:reset restores database state only. It does not restore uploads, plugin files, other
+filesystem changes, or external services. Test harnesses must contain those side effects separately.
 HELP
 			);
 	}

--- a/src/src/Commands/Environment/ResetEnvironmentCommand.php
+++ b/src/src/Commands/Environment/ResetEnvironmentCommand.php
@@ -32,7 +32,7 @@ class ResetEnvironmentCommand extends QITCommand {
 
 	protected function configure(): void {
 		parent::configure(); // Call parent to set up base options
-		$this->setDescription( 'Reset the database to the post-setup state' )
+		$this->setDescription( 'Restore the post-setup database snapshot and flush the WordPress object cache' )
 			->addArgument( 'env_id', InputArgument::OPTIONAL, 'Environment ID (uses current if not specified)' )
 			->setHelp( <<<HELP
 The <info>env:reset</info> command restores the database to the state saved after running setup phases.
@@ -54,8 +54,9 @@ Examples:
 Note: This only works if the environment was started with setup phases
 (i.e., a qit-test.json file was present and --skip-setup was not used).
 
-Scope: env:reset restores database state only. It does not restore uploads, plugin files, other
-filesystem changes, or external services. Test harnesses must contain those side effects separately.
+Scope: env:reset restores database state and flushes the WordPress object cache. It does not restore
+uploads, plugin files, other filesystem changes, or external services. Test harnesses must contain
+those side effects separately.
 HELP
 			);
 	}
@@ -166,23 +167,25 @@ HELP
 
 			// Clean up the temp file in container
 			$this->docker->run_inside_docker( $env_info, [ 'rm', '-f', $container_path ] );
-
-			$output->writeln( ' <info>Done!</info>' );
-			$output->writeln( '<info>✓ Database restored to post-setup state.</info>' );
-
-			// Clear any caches
-			try {
-				$this->docker->run_inside_docker( $env_info, [ 'sh', '-c', 'wp cache flush --quiet 2>/dev/null' ] );
-			} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-				// Cache flush might fail if no cache plugin active, that's OK
-			}
-
-			return Command::SUCCESS;
-
 		} catch ( \Exception $e ) {
 			$output->writeln( ' <error>Failed!</error>' );
 			$output->writeln( '<error>Database restore failed: ' . $e->getMessage() . '</error>' );
 			return Command::FAILURE;
 		}
+
+		try {
+			// A successful reset requires persistent and in-process object caches to be flushed.
+			$this->docker->run_inside_docker( $env_info, [ 'sh', '-c', 'cd /var/www/html && wp cache flush --quiet' ] );
+		} catch ( \Exception $e ) {
+			$output->writeln( ' <error>Failed!</error>' );
+			$output->writeln( '<error>Object-cache flush failed after database restore: ' . $e->getMessage() . '</error>' );
+			return Command::FAILURE;
+		}
+
+		$output->writeln( ' <info>Done!</info>' );
+		$output->writeln( '<info>✓ Database restored to post-setup state.</info>' );
+		$output->writeln( '<info>✓ WordPress object cache flushed.</info>' );
+
+		return Command::SUCCESS;
 	}
 }

--- a/src/tests/integration/tests/TestPackages/Scenarios/DeveloperWorkflowTest.php
+++ b/src/tests/integration/tests/TestPackages/Scenarios/DeveloperWorkflowTest.php
@@ -175,6 +175,23 @@ class DeveloperWorkflowTest extends BaseScenarioTestCase {
 		] );
 		$this->assertStringContainsString( 'setup_complete_', trim( $restoredMarker ) );
 		$this->assertNotEquals( 'modified_by_test', trim( $restoredMarker ) );
+
+		// A long-running harness can isolate every generated request by restoring the same snapshot
+		// repeatedly. Verify the second reset does not use the state produced by the first reset.
+		qit( [
+			'env:exec',
+			'--env_id=' . $envId,
+			'wp option update qit_main_package_setup_marker "modified_again" --path=/var/www/html'
+		] );
+		qit( [ 'env:reset', $envId ] );
+
+		$restoredAgain = qit( [
+			'env:exec',
+			'--env_id=' . $envId,
+			'wp option get qit_main_package_setup_marker --path=/var/www/html'
+		] );
+		$this->assertStringContainsString( 'setup_complete_', trim( $restoredAgain ) );
+		$this->assertNotEquals( 'modified_again', trim( $restoredAgain ) );
 	}
 	
 	/**

--- a/src/tests/unit/ResetEnvironmentCommandTest.php
+++ b/src/tests/unit/ResetEnvironmentCommandTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use QIT_CLI\Commands\Environment\ResetEnvironmentCommand;
+use QIT_CLI\Environment\Docker;
+use QIT_CLI\Environment\EnvironmentMonitor;
+use QIT_CLI\Environment\Environments\E2E\E2EEnvInfo;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ResetEnvironmentCommandTest extends \QIT_CLI_Tests\QITTestCase {
+	/** @var array<string> */
+	private array $backup_dirs = [];
+
+	public function tearDown(): void {
+		foreach ( $this->backup_dirs as $backup_dir ) {
+			if ( file_exists( $backup_dir . '/setup-complete.sql' ) ) {
+				unlink( $backup_dir . '/setup-complete.sql' );
+			}
+			if ( is_dir( $backup_dir ) ) {
+				rmdir( $backup_dir );
+			}
+		}
+
+		parent::tearDown();
+	}
+
+	public function test_flushes_object_cache_from_wordpress_directory(): void {
+		$env_id   = 'qitenv-reset-cache-success';
+		$env_info = $this->create_environment( $env_id );
+		$commands = [];
+		$docker   = $this->createMock( Docker::class );
+		$docker->expects( $this->once() )
+			->method( 'copy_into_docker' );
+		$docker->expects( $this->exactly( 3 ) )
+			->method( 'run_inside_docker' )
+			->willReturnCallback( static function ( E2EEnvInfo $actual_env, array $command ) use ( $env_info, &$commands ): string {
+				self::assertSame( $env_info, $actual_env );
+				$commands[] = $command;
+				return '';
+			} );
+
+		$tester = $this->create_command_tester( $env_info, $docker );
+		$status = $tester->execute( [ 'env_id' => $env_id ], [ 'interactive' => false ] );
+
+		$this->assertSame( Command::SUCCESS, $status );
+		$this->assertSame( [ 'sh', '-c', 'cd /var/www/html && wp cache flush --quiet' ], $commands[2] );
+		$this->assertStringContainsString( 'WordPress object cache flushed.', $tester->getDisplay() );
+	}
+
+	public function test_fails_reset_when_object_cache_cannot_be_flushed(): void {
+		$env_id   = 'qitenv-reset-cache-failure';
+		$env_info = $this->create_environment( $env_id );
+		$docker   = $this->createMock( Docker::class );
+		$docker->expects( $this->once() )
+			->method( 'copy_into_docker' );
+		$docker->expects( $this->exactly( 3 ) )
+			->method( 'run_inside_docker' )
+			->willReturnCallback( static function ( E2EEnvInfo $actual_env, array $command ) use ( $env_info ): string {
+				self::assertSame( $env_info, $actual_env );
+				if ( $command === [ 'sh', '-c', 'cd /var/www/html && wp cache flush --quiet' ] ) {
+					throw new \RuntimeException( 'Persistent object cache rejected the flush.' );
+				}
+
+				return '';
+			} );
+
+		$tester = $this->create_command_tester( $env_info, $docker );
+		$status = $tester->execute( [ 'env_id' => $env_id ], [ 'interactive' => false ] );
+
+		$this->assertSame( Command::FAILURE, $status );
+		$this->assertStringContainsString( 'Object-cache flush failed after database restore', $tester->getDisplay() );
+		$this->assertStringNotContainsString( 'WordPress object cache flushed.', $tester->getDisplay() );
+	}
+
+	private function create_environment( string $env_id ): E2EEnvInfo {
+		$backup_dir         = sys_get_temp_dir() . '/qit-env-backups/' . $env_id;
+		$this->backup_dirs[] = $backup_dir;
+		if ( ! is_dir( $backup_dir ) ) {
+			mkdir( $backup_dir, 0777, true );
+		}
+		file_put_contents( $backup_dir . '/setup-complete.sql', '-- test backup' );
+
+		$env_info                        = new E2EEnvInfo();
+		$env_info->env_id                = $env_id;
+		$env_info->status                = 'started';
+		$env_info->temporary_env          = sys_get_temp_dir() . '/' . $env_id;
+
+		return $env_info;
+	}
+
+	private function create_command_tester( E2EEnvInfo $env_info, Docker $docker ): CommandTester {
+		$monitor = $this->createMock( EnvironmentMonitor::class );
+		$monitor->expects( $this->once() )
+			->method( 'get_env_info_by_id' )
+			->with( $env_info->env_id )
+			->willReturn( $env_info );
+
+		return new CommandTester( new ResetEnvironmentCommand( $monitor, $docker ) );
+	}
+}


### PR DESCRIPTION
## Summary

This companion change makes the `env:reset` boundary relied on by the QIT-1006 API-fuzz PoC explicit and regression-tested.

- documents that one running environment can restore the same post-setup database snapshot repeatedly;
- makes the WordPress object-cache flush a required reset phase, executed from `/var/www/html`;
- returns a non-zero exit with an explicit error when the cache cannot be flushed, allowing callers
  to distinguish incomplete isolation from a successful clean-state reset;
- clearly states that reset scope is database-only and does not restore uploads, plugin files, other filesystem mutations, or external services;
- extends the integration scenario to mutate and restore the database twice, guarding the repeated-reset workflow used to isolate generated requests.

This does **not** add a public `run:api-fuzz` command or a new public test type. The fuzz orchestration remains in QIT Manager and composes the existing `env:up`, `env:reset`, and `env:down` commands.

Companion QIT Manager implementation: https://github.com/Automattic/compatibility-dashboard/pull/1765

## Why

The schema-driven API-fuzz runner restores its post-setup database snapshot before every generated request, including GET requests, and before each confirmation replay. Test authors need a precise contract for what that reset does and does not isolate.

## Manual QA

Prerequisites: Docker is running and the local QIT CLI is connected.

1. Confirm the clarified help text:

   ```bash
   ./qit env:reset --help
   ```

   Under `Scope`, verify it says database state is restored but filesystem and external-service state are not.

2. Start an environment using the integration fixture:

   ```bash
   ./qit env:up --json --test-package=src/tests/integration/tests/TestPackages/Scenarios/fixtures/scenario-main-package
   ```

3. Copy the returned `env_id`, then set it for the commands below:

   ```bash
   export ENV_ID=qitenv_REPLACE_ME
   ```

4. Verify the setup marker exists:

   ```bash
   ./qit env:exec --env_id="$ENV_ID" 'wp option get qit_main_package_setup_marker --path=/var/www/html'
   ```

   Expected: a value beginning with `setup_complete_`.

5. Mutate the value, reset, and verify the original setup value returns:

   ```bash
   ./qit env:exec --env_id="$ENV_ID" 'wp option update qit_main_package_setup_marker first_mutation --path=/var/www/html'
   ./qit env:reset "$ENV_ID"
   ./qit env:exec --env_id="$ENV_ID" 'wp option get qit_main_package_setup_marker --path=/var/www/html'
   ```

   Expected: the reset exits successfully, reports both `Database restored to post-setup state`
   and `WordPress object cache flushed`, and the value again begins with `setup_complete_`, not
   `first_mutation`.

6. Repeat the mutation and reset once more:

   ```bash
   ./qit env:exec --env_id="$ENV_ID" 'wp option update qit_main_package_setup_marker second_mutation --path=/var/www/html'
   ./qit env:reset "$ENV_ID"
   ./qit env:exec --env_id="$ENV_ID" 'wp option get qit_main_package_setup_marker --path=/var/www/html'
   ```

   Expected: the same post-setup marker is restored a second time.

7. Clean up:

   ```bash
   ./qit env:down "$ENV_ID"
   ```

## Automated checks

- `make phpcs` (passes; one pre-existing `shell_exec()` warning remains elsewhere)
- `make phpstan`
- `make phan`
- focused reset-command tests — 2 tests, 16 assertions
- `make phpunit` — 278 tests, 743 assertions

The Docker-backed integration scenario was not run locally as part of this publish; the manual QA above exercises the same repeated-reset path.
