### PR TITLE
QIT-1013: Reduce API-fuzz reset overhead

### DIFF
--- a/src/src/Commands/Environment/ResetEnvironmentCommand.php
+++ b/src/src/Commands/Environment/ResetEnvironmentCommand.php
@@ -262,7 +262,7 @@ HELP
 			];
 		}
 
-		$result = json_decode( trim( $helper_output ), true );
+		$result = $this->parse_staged_helper_output( $helper_output );
 		if ( ! is_array( $result ) || ! isset( $result['status'], $result['phases'] ) || ! is_array( $result['phases'] ) ) {
 			$phases['database_import'] = [
 				'status'  => 'failed',
@@ -299,6 +299,27 @@ HELP
 			'failed_phase' => null,
 			'message'      => '',
 		];
+	}
+
+	/**
+	 * Extract the last JSON object emitted by the staged helper, ignoring Docker, PHP, and WP-CLI noise.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	private function parse_staged_helper_output( string $helper_output ): ?array {
+		$lines = preg_split( '/\R/', $helper_output );
+		if ( ! is_array( $lines ) ) {
+			return null;
+		}
+
+		foreach ( array_reverse( $lines ) as $line ) {
+			$candidate = json_decode( trim( $line ), true );
+			if ( is_array( $candidate ) ) {
+				return $candidate;
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/src/src/Commands/Environment/ResetEnvironmentCommand.php
+++ b/src/src/Commands/Environment/ResetEnvironmentCommand.php
@@ -6,9 +6,11 @@ namespace QIT_CLI\Commands\Environment;
 use QIT_CLI\Commands\QITCommand;
 use QIT_CLI\Environment\Docker;
 use QIT_CLI\Environment\EnvironmentMonitor;
+use QIT_CLI\Environment\Environments\EnvInfo;
 use QIT_CLI\QITInput;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 
@@ -34,6 +36,7 @@ class ResetEnvironmentCommand extends QITCommand {
 		parent::configure(); // Call parent to set up base options
 		$this->setDescription( 'Restore the post-setup database snapshot and flush the WordPress object cache' )
 			->addArgument( 'env_id', InputArgument::OPTIONAL, 'Environment ID (uses current if not specified)' )
+			->addOption( 'json', 'j', InputOption::VALUE_NONE, 'Machine-readable reset result and phase timings' )
 			->setHelp( <<<HELP
 The <info>env:reset</info> command restores the database to the state saved after running setup phases.
 It can be called repeatedly against the same running environment; each call restores the same
@@ -62,8 +65,14 @@ HELP
 	}
 
 	protected function doExecute( QITInput $input, OutputInterface $output ): int {
+		$started  = microtime( true );
+		$json     = (bool) $input->getOption( 'json' );
+		$phases   = $this->initial_phases();
+		$strategy = 'unknown';
+
 		// Get environment ID
-		$env_id = $input->getArgument( 'env_id' );
+		$env_id        = $input->getArgument( 'env_id' );
+		$phase_started = microtime( true );
 
 		if ( ! $env_id ) {
 			// Get list of all environments
@@ -78,8 +87,8 @@ HELP
 			}
 
 			if ( empty( $environments ) ) {
-				$output->writeln( '<error>No running environments found.</error>' );
-				return Command::FAILURE;
+				$phases['environment_lookup'] = $this->phase( 'failed', $phase_started );
+				return $this->failure( $output, $json, $env_id, $strategy, 'environment_lookup', 'No running environments found.', $started, $phases );
 			}
 
 			if ( count( $environments ) === 1 ) {
@@ -131,61 +140,282 @@ HELP
 			try {
 				$env_info = $this->environment_monitor->get_env_info_by_id( $env_id );
 			} catch ( \Exception $e ) {
-				$output->writeln( "<error>Environment '{$env_id}' not found.</error>" );
-				return Command::FAILURE;
+				$phases['environment_lookup'] = $this->phase( 'failed', $phase_started );
+				return $this->failure( $output, $json, $env_id, $strategy, 'environment_lookup', "Environment '{$env_id}' not found.", $started, $phases );
 			}
 		}
+		$phases['environment_lookup'] = $this->phase( 'completed', $phase_started );
 
 		// Check if backup exists
 		$backup_dir  = sys_get_temp_dir() . '/qit-env-backups/' . $env_id;
 		$backup_file = $backup_dir . '/setup-complete.sql';
 
 		if ( ! file_exists( $backup_file ) ) {
-			$output->writeln( '<error>No database backup found for this environment.</error>' );
-			$output->writeln( '<comment>Database backups are created when running "qit env:up" with a qit-test.json file.</comment>' );
-			return Command::FAILURE;
+			$phases['snapshot_copy'] = [
+				'status'  => 'failed',
+				'seconds' => 0.0,
+			];
+			return $this->failure( $output, $json, $env_id, $strategy, 'snapshot_copy', 'No database backup found for this environment. Database backups are created when running "qit env:up" with a qit-test.json file.', $started, $phases );
 		}
 
 		// Load metadata to show info
 		$metadata_file = $backup_dir . '/metadata.json';
+		$metadata      = [];
 		if ( file_exists( $metadata_file ) ) {
-			$metadata = json_decode( file_get_contents( $metadata_file ), true );
+			$decoded  = json_decode( file_get_contents( $metadata_file ), true );
+			$metadata = is_array( $decoded ) ? $decoded : [];
 			$created  = isset( $metadata['created'] ) ? gmdate( 'Y-m-d H:i:s', $metadata['created'] ) : 'unknown';
-			$output->writeln( "<info>Restoring database backup from: {$created}</info>" );
+			if ( ! $json ) {
+				$output->writeln( "<info>Restoring database backup from: {$created}</info>" );
+			}
 		}
 
-		// Copy backup to container
-		$output->write( 'Restoring database...' );
-
-		try {
-			// Copy SQL file to container
-			$container_path = '/tmp/restore-' . uniqid() . '.sql';
-			$this->docker->copy_into_docker( $env_info, $backup_file, $container_path );
-
-			// Import the database - run in WordPress directory with defaults
-			$this->docker->run_inside_docker( $env_info, [ 'sh', '-c', "cd /var/www/html && wp db import {$container_path} --defaults --quiet" ] );
-
-			// Clean up the temp file in container
-			$this->docker->run_inside_docker( $env_info, [ 'rm', '-f', $container_path ] );
-		} catch ( \Exception $e ) {
-			$output->writeln( ' <error>Failed!</error>' );
-			$output->writeln( '<error>Database restore failed: ' . $e->getMessage() . '</error>' );
-			return Command::FAILURE;
+		if ( ! $json ) {
+			$output->write( 'Restoring database...' );
 		}
 
-		try {
-			// A successful reset requires persistent and in-process object caches to be flushed.
-			$this->docker->run_inside_docker( $env_info, [ 'sh', '-c', 'cd /var/www/html && wp cache flush --quiet' ] );
-		} catch ( \Exception $e ) {
-			$output->writeln( ' <error>Failed!</error>' );
-			$output->writeln( '<error>Object-cache flush failed after database restore: ' . $e->getMessage() . '</error>' );
-			return Command::FAILURE;
+		if ( isset( $metadata['snapshot_strategy'] ) && $metadata['snapshot_strategy'] === 'container_staged' ) {
+			$strategy = 'container_staged';
+			$status   = $this->restore_staged( $env_info, $metadata, $phases );
+		} else {
+			$strategy = 'copy_per_reset';
+			$status   = $this->restore_legacy( $env_info, $backup_file, $phases );
 		}
 
-		$output->writeln( ' <info>Done!</info>' );
-		$output->writeln( '<info>✓ Database restored to post-setup state.</info>' );
-		$output->writeln( '<info>✓ WordPress object cache flushed.</info>' );
+		if ( $status['failed_phase'] !== null ) {
+			return $this->failure( $output, $json, $env_id, $strategy, $status['failed_phase'], $status['message'], $started, $phases );
+		}
+
+		if ( $json ) {
+			$this->write_json( $output, 'success', $env_id, $strategy, null, '', $started, $phases );
+		} else {
+			$output->writeln( ' <info>Done!</info>' );
+			$output->writeln( '<info>✓ Database restored to post-setup state.</info>' );
+			$output->writeln( '<info>✓ WordPress object cache flushed.</info>' );
+		}
 
 		return Command::SUCCESS;
+	}
+
+	/**
+	 * @return array<string,array{status:string,seconds:float}>
+	 */
+	private function initial_phases(): array {
+		return array_fill_keys(
+			[ 'environment_lookup', 'snapshot_copy', 'database_import', 'temporary_file_cleanup', 'object_cache_flush' ],
+			[
+				'status'  => 'not_started',
+				'seconds' => 0.0,
+			]
+		);
+	}
+
+	/**
+	 * @return array{status:string,seconds:float}
+	 */
+	private function phase( string $status, float $started ): array {
+		return [
+			'status'  => $status,
+			'seconds' => round( microtime( true ) - $started, 6 ),
+		];
+	}
+
+	/**
+	 * @param EnvInfo                                          $env_info Environment to reset.
+	 * @param array<string,mixed>                              $metadata Snapshot metadata.
+	 * @param array<string,array{status:string,seconds:float}> $phases   Timed reset phases.
+	 * @return array{failed_phase:?string,message:string}
+	 */
+	private function restore_staged( EnvInfo $env_info, array $metadata, array &$phases ): array {
+		$phases['snapshot_copy']          = [
+			'status'  => 'skipped',
+			'seconds' => 0.0,
+		];
+		$phases['temporary_file_cleanup'] = [
+			'status'  => 'skipped',
+			'seconds' => 0.0,
+		];
+		$snapshot                         = $metadata['container_snapshot'] ?? '';
+		$checksum                         = $metadata['snapshot_sha256'] ?? '';
+		$helper                           = $metadata['reset_helper'] ?? '';
+		if ( ! is_string( $snapshot ) || ! is_string( $checksum ) || ! is_string( $helper ) || $snapshot === '' || $checksum === '' || $helper === '' ) {
+			$phases['database_import'] = [
+				'status'  => 'failed',
+				'seconds' => 0.0,
+			];
+			return [
+				'failed_phase' => 'database_import',
+				'message'      => 'Staged reset metadata is incomplete.',
+			];
+		}
+
+		try {
+			$helper_output = $this->docker->run_inside_docker( $env_info, [ 'php', $helper, $snapshot, $checksum ] );
+		} catch ( \Exception $e ) {
+			$phases['database_import'] = [
+				'status'  => 'failed',
+				'seconds' => 0.0,
+			];
+			return [
+				'failed_phase' => 'database_import',
+				'message'      => 'Database restore failed: ' . $e->getMessage(),
+			];
+		}
+
+		$result = json_decode( trim( $helper_output ), true );
+		if ( ! is_array( $result ) || ! isset( $result['status'], $result['phases'] ) || ! is_array( $result['phases'] ) ) {
+			$phases['database_import'] = [
+				'status'  => 'failed',
+				'seconds' => 0.0,
+			];
+			return [
+				'failed_phase' => 'database_import',
+				'message'      => 'The staged reset helper returned an invalid result.',
+			];
+		}
+
+		foreach ( [ 'database_import', 'object_cache_flush' ] as $phase_name ) {
+			if ( isset( $result['phases'][ $phase_name ] ) && is_array( $result['phases'][ $phase_name ] ) ) {
+				$phases[ $phase_name ] = [
+					'status'  => (string) ( $result['phases'][ $phase_name ]['status'] ?? 'failed' ),
+					'seconds' => round( (float) ( $result['phases'][ $phase_name ]['seconds'] ?? 0.0 ), 6 ),
+				];
+			}
+		}
+
+		if ( $result['status'] !== 'success' ) {
+			$failed_phase = (string) ( $result['failed_phase'] ?? 'database_import' );
+			if ( ! isset( $phases[ $failed_phase ] ) ) {
+				$failed_phase = 'database_import';
+			}
+			$message = trim( (string) ( $result['message'] ?? '' ) );
+			return [
+				'failed_phase' => $failed_phase,
+				'message'      => $message !== '' ? $message : 'The staged environment reset failed.',
+			];
+		}
+
+		return [
+			'failed_phase' => null,
+			'message'      => '',
+		];
+	}
+
+	/**
+	 * @param EnvInfo                                          $env_info   Environment to reset.
+	 * @param string                                           $backup_file Host snapshot path.
+	 * @param array<string,array{status:string,seconds:float}> $phases     Timed reset phases.
+	 * @return array{failed_phase:?string,message:string}
+	 */
+	private function restore_legacy( EnvInfo $env_info, string $backup_file, array &$phases ): array {
+		$container_path = '/tmp/restore-' . uniqid() . '.sql';
+		$phase_started  = microtime( true );
+		try {
+			$this->docker->copy_into_docker( $env_info, $backup_file, $container_path );
+			$phases['snapshot_copy'] = $this->phase( 'completed', $phase_started );
+		} catch ( \Exception $e ) {
+			$phases['snapshot_copy'] = $this->phase( 'failed', $phase_started );
+			return [
+				'failed_phase' => 'snapshot_copy',
+				'message'      => 'Database snapshot copy failed: ' . $e->getMessage(),
+			];
+		}
+
+		$phase_started = microtime( true );
+		try {
+			$this->docker->run_inside_docker( $env_info, [ 'sh', '-c', "cd /var/www/html && wp db import {$container_path} --defaults --quiet" ] );
+			$phases['database_import'] = $this->phase( 'completed', $phase_started );
+		} catch ( \Exception $e ) {
+			$phases['database_import'] = $this->phase( 'failed', $phase_started );
+			$this->cleanup_legacy_snapshot( $env_info, $container_path, $phases );
+			return [
+				'failed_phase' => 'database_import',
+				'message'      => 'Database restore failed: ' . $e->getMessage(),
+			];
+		}
+
+		$cleanup_error = $this->cleanup_legacy_snapshot( $env_info, $container_path, $phases );
+		if ( $cleanup_error !== null ) {
+			return [
+				'failed_phase' => 'temporary_file_cleanup',
+				'message'      => $cleanup_error,
+			];
+		}
+
+		$phase_started = microtime( true );
+		try {
+			$this->docker->run_inside_docker( $env_info, [ 'sh', '-c', 'cd /var/www/html && wp cache flush --quiet' ] );
+			$phases['object_cache_flush'] = $this->phase( 'completed', $phase_started );
+		} catch ( \Exception $e ) {
+			$phases['object_cache_flush'] = $this->phase( 'failed', $phase_started );
+			return [
+				'failed_phase' => 'object_cache_flush',
+				'message'      => 'Object-cache flush failed after database restore: ' . $e->getMessage(),
+			];
+		}
+
+		return [
+			'failed_phase' => null,
+			'message'      => '',
+		];
+	}
+
+	/**
+	 * @param EnvInfo                                          $env_info      Environment to reset.
+	 * @param string                                           $container_path Temporary snapshot path.
+	 * @param array<string,array{status:string,seconds:float}> $phases        Timed reset phases.
+	 */
+	private function cleanup_legacy_snapshot( EnvInfo $env_info, string $container_path, array &$phases ): ?string {
+		$phase_started = microtime( true );
+		try {
+			$this->docker->run_inside_docker( $env_info, [ 'rm', '-f', $container_path ] );
+			$phases['temporary_file_cleanup'] = $this->phase( 'completed', $phase_started );
+			return null;
+		} catch ( \Exception $e ) {
+			$phases['temporary_file_cleanup'] = $this->phase( 'failed', $phase_started );
+			return 'Temporary snapshot cleanup failed: ' . $e->getMessage();
+		}
+	}
+
+	/**
+	 * @param OutputInterface                                  $output       Console output.
+	 * @param bool                                             $json         Whether to emit JSON.
+	 * @param string|null                                      $env_id       Environment ID.
+	 * @param string                                           $strategy     Reset strategy.
+	 * @param string                                           $failed_phase Failed phase name.
+	 * @param string                                           $message      Failure detail.
+	 * @param float                                            $started      Reset start timestamp.
+	 * @param array<string,array{status:string,seconds:float}> $phases       Timed reset phases.
+	 */
+	private function failure( OutputInterface $output, bool $json, ?string $env_id, string $strategy, string $failed_phase, string $message, float $started, array $phases ): int {
+		if ( $json ) {
+			$this->write_json( $output, 'failed', $env_id, $strategy, $failed_phase, $message, $started, $phases );
+		} else {
+			$output->writeln( ' <error>Failed!</error>' );
+			$output->writeln( '<error>' . $message . '</error>' );
+		}
+		return Command::FAILURE;
+	}
+
+	/**
+	 * @param OutputInterface                                  $output       Console output.
+	 * @param string                                           $status       Overall reset status.
+	 * @param string|null                                      $env_id       Environment ID.
+	 * @param string                                           $strategy     Reset strategy.
+	 * @param string|null                                      $failed_phase Failed phase name.
+	 * @param string                                           $message      Failure detail.
+	 * @param float                                            $started      Reset start timestamp.
+	 * @param array<string,array{status:string,seconds:float}> $phases       Timed reset phases.
+	 */
+	private function write_json( OutputInterface $output, string $status, ?string $env_id, string $strategy, ?string $failed_phase, string $message, float $started, array $phases ): void {
+		$output->writeln( json_encode( [
+			'status'        => $status,
+			'env_id'        => $env_id,
+			'strategy'      => $strategy,
+			'total_seconds' => round( microtime( true ) - $started, 6 ),
+			'failed_phase'  => $failed_phase,
+			'message'       => $message,
+			'phases'        => $phases,
+		], JSON_UNESCAPED_SLASHES ) );
 	}
 }

--- a/src/src/Commands/Environment/ResetEnvironmentCommand.php
+++ b/src/src/Commands/Environment/ResetEnvironmentCommand.php
@@ -59,7 +59,8 @@ Note: This only works if the environment was started with setup phases
 
 Scope: env:reset restores database state and flushes the WordPress object cache. It does not restore
 uploads, plugin files, other filesystem changes, or external services. Test harnesses must contain
-those side effects separately.
+those side effects separately. If a staged snapshot is unavailable, env:reset uses the host backup
+only after verifying it against the checksum recorded during env:up.
 HELP
 			);
 	}
@@ -177,6 +178,23 @@ HELP
 		if ( isset( $metadata['snapshot_strategy'] ) && $metadata['snapshot_strategy'] === 'container_staged' ) {
 			$strategy = 'container_staged';
 			$status   = $this->restore_staged( $env_info, $metadata, $phases );
+			if ( $status['fallback_to_legacy'] ) {
+				$strategy             = 'copy_per_reset';
+				$verification_started = microtime( true );
+				$expected_checksum    = $metadata['snapshot_sha256'] ?? '';
+				$actual_checksum      = is_readable( $backup_file ) ? hash_file( 'sha256', $backup_file ) : false;
+				$verification_seconds = microtime( true ) - $verification_started;
+				if ( ! is_string( $expected_checksum ) || ! is_string( $actual_checksum ) || ! hash_equals( $expected_checksum, $actual_checksum ) ) {
+					$phases['snapshot_copy'] = $this->phase( 'failed', $verification_started );
+					$status                  = [
+						'failed_phase' => 'snapshot_copy',
+						'message'      => 'The staged database snapshot is unavailable and the host backup failed checksum verification.',
+					];
+				} else {
+					$status                             = $this->restore_legacy( $env_info, $backup_file, $phases );
+					$phases['snapshot_copy']['seconds'] = round( $phases['snapshot_copy']['seconds'] + $verification_seconds, 6 );
+				}
+			}
 		} else {
 			$strategy = 'copy_per_reset';
 			$status   = $this->restore_legacy( $env_info, $backup_file, $phases );
@@ -224,7 +242,7 @@ HELP
 	 * @param EnvInfo                                          $env_info Environment to reset.
 	 * @param array<string,mixed>                              $metadata Snapshot metadata.
 	 * @param array<string,array{status:string,seconds:float}> $phases   Timed reset phases.
-	 * @return array{failed_phase:?string,message:string}
+	 * @return array{failed_phase:?string,message:string,fallback_to_legacy:bool}
 	 */
 	private function restore_staged( EnvInfo $env_info, array $metadata, array &$phases ): array {
 		$phases['snapshot_copy']          = [
@@ -244,8 +262,9 @@ HELP
 				'seconds' => 0.0,
 			];
 			return [
-				'failed_phase' => 'database_import',
-				'message'      => 'Staged reset metadata is incomplete.',
+				'failed_phase'       => 'database_import',
+				'message'            => 'Staged reset metadata is incomplete.',
+				'fallback_to_legacy' => false,
 			];
 		}
 
@@ -257,8 +276,9 @@ HELP
 				'seconds' => 0.0,
 			];
 			return [
-				'failed_phase' => 'database_import',
-				'message'      => 'Database restore failed: ' . $e->getMessage(),
+				'failed_phase'       => 'database_import',
+				'message'            => 'Database restore failed: ' . $e->getMessage(),
+				'fallback_to_legacy' => false,
 			];
 		}
 
@@ -269,8 +289,9 @@ HELP
 				'seconds' => 0.0,
 			];
 			return [
-				'failed_phase' => 'database_import',
-				'message'      => 'The staged reset helper returned an invalid result.',
+				'failed_phase'       => 'database_import',
+				'message'            => 'The staged reset helper returned an invalid result.',
+				'fallback_to_legacy' => false,
 			];
 		}
 
@@ -290,14 +311,16 @@ HELP
 			}
 			$message = trim( (string) ( $result['message'] ?? '' ) );
 			return [
-				'failed_phase' => $failed_phase,
-				'message'      => $message !== '' ? $message : 'The staged environment reset failed.',
+				'failed_phase'       => $failed_phase,
+				'message'            => $message !== '' ? $message : 'The staged environment reset failed.',
+				'fallback_to_legacy' => $failed_phase === 'database_import' && ( $result['failure_code'] ?? '' ) === 'snapshot_unavailable',
 			];
 		}
 
 		return [
-			'failed_phase' => null,
-			'message'      => '',
+			'failed_phase'       => null,
+			'message'            => '',
+			'fallback_to_legacy' => false,
 		];
 	}
 

--- a/src/src/Commands/Environment/ResetEnvironmentCommand.php
+++ b/src/src/Commands/Environment/ResetEnvironmentCommand.php
@@ -106,7 +106,9 @@ HELP
 					} );
 					$env_info = reset( $environments );
 					$env_id   = $env_info->env_id;
-					$output->writeln( "<info>Multiple environments found. Using most recent: {$env_id}</info>" );
+					if ( ! $json ) {
+						$output->writeln( "<info>Multiple environments found. Using most recent: {$env_id}</info>" );
+					}
 				} else {
 					// Interactive mode - ask user to choose
 					$helper  = $this->getHelper( 'question' );
@@ -131,9 +133,11 @@ HELP
 						0
 					);
 
-					$selected = $helper->ask( $input, $output, $question );
-					$env_id   = array_search( $selected, $choices, true );
-					$env_info = $environments[ $env_id ];
+					$prompt_started = microtime( true );
+					$selected       = $helper->ask( $input, $output, $question );
+					$phase_started += microtime( true ) - $prompt_started;
+					$env_id         = array_search( $selected, $choices, true );
+					$env_info       = $environments[ $env_id ];
 				}
 			}
 		} else {
@@ -473,6 +477,6 @@ HELP
 			'failed_phase'  => $failed_phase,
 			'message'       => $message,
 			'phases'        => $phases,
-		], JSON_UNESCAPED_SLASHES ) );
+		], JSON_UNESCAPED_SLASHES ), OutputInterface::OUTPUT_RAW );
 	}
 }

--- a/src/src/Commands/Environment/ResetEnvironmentCommand.php
+++ b/src/src/Commands/Environment/ResetEnvironmentCommand.php
@@ -304,6 +304,19 @@ HELP
 			}
 		}
 
+		if ( $result['status'] === 'success' ) {
+			foreach ( [ 'database_import', 'object_cache_flush' ] as $phase_name ) {
+				if ( $phases[ $phase_name ]['status'] !== 'completed' ) {
+					$phases[ $phase_name ]['status'] = 'failed';
+					return [
+						'failed_phase'       => $phase_name,
+						'message'            => sprintf( 'The staged reset helper reported success without completing %s.', str_replace( '_', ' ', $phase_name ) ),
+						'fallback_to_legacy' => false,
+					];
+				}
+			}
+		}
+
 		if ( $result['status'] !== 'success' ) {
 			$failed_phase = (string) ( $result['failed_phase'] ?? 'database_import' );
 			if ( ! isset( $phases[ $failed_phase ] ) ) {

--- a/src/src/Commands/Environment/ResetEnvironmentHelper.php
+++ b/src/src/Commands/Environment/ResetEnvironmentHelper.php
@@ -62,11 +62,12 @@ function qit_reset_run( string $command ): array {
 /**
  * @param array<string,array{status:string,seconds:float}> $phase_values
  */
-function qit_reset_finish( string $status, ?string $failed_phase, string $message, array $phase_values ): void {
+function qit_reset_finish( string $status, ?string $failed_phase, string $message, array $phase_values, ?string $failure_code = null ): void {
 	global $started;
 	echo json_encode( [
 		'status'       => $status,
 		'failed_phase' => $failed_phase,
+		'failure_code'  => $failure_code,
 		'message'      => $message,
 		'total_seconds' => qit_reset_elapsed( $started ),
 		'phases'       => $phase_values,
@@ -81,11 +82,16 @@ $phase_started = microtime( true );
 if (
 	$snapshot === '' ||
 	$checksum === '' ||
-	! is_readable( $snapshot ) ||
-	! hash_equals( $checksum, (string) hash_file( 'sha256', $snapshot ) )
+	! is_readable( $snapshot )
 ) {
 	$phases['database_import'] = [ 'status' => 'failed', 'seconds' => qit_reset_elapsed( $phase_started ) ];
-	qit_reset_finish( 'failed', 'database_import', 'The staged database snapshot is missing or failed checksum verification.', $phases );
+	qit_reset_finish( 'failed', 'database_import', 'The staged database snapshot is missing or unreadable.', $phases, 'snapshot_unavailable' );
+}
+
+$actual_checksum = hash_file( 'sha256', $snapshot );
+if ( ! is_string( $actual_checksum ) || ! hash_equals( $checksum, $actual_checksum ) ) {
+	$phases['database_import'] = [ 'status' => 'failed', 'seconds' => qit_reset_elapsed( $phase_started ) ];
+	qit_reset_finish( 'failed', 'database_import', 'The staged database snapshot failed checksum verification.', $phases, 'snapshot_checksum_mismatch' );
 }
 
 $import = qit_reset_run(

--- a/src/src/Commands/Environment/ResetEnvironmentHelper.php
+++ b/src/src/Commands/Environment/ResetEnvironmentHelper.php
@@ -1,0 +1,117 @@
+<?php
+declare( strict_types=1 );
+
+namespace QIT_CLI\Commands\Environment;
+
+/**
+ * Shared constants and the small in-container helper used by env:reset.
+ *
+ * The helper keeps the database import and object-cache flush in one Docker execution while
+ * retaining phase-level timings and explicit failure reporting.
+ */
+class ResetEnvironmentHelper {
+	public const CONTAINER_SNAPSHOT_PATH = '/tmp/qit-env-reset/setup-complete.sql';
+	public const CONTAINER_HELPER_PATH   = '/qit/bin/qit-env-reset.php';
+
+	/**
+	 * Return the PHP helper staged through the environment's existing /qit/bin bind mount.
+	 */
+	public static function script(): string {
+		return <<<'PHP'
+<?php
+
+$started = hrtime( true );
+$phases  = [
+	'database_import'    => [ 'status' => 'not_started', 'seconds' => 0.0 ],
+	'object_cache_flush' => [ 'status' => 'not_started', 'seconds' => 0.0 ],
+];
+
+/**
+ * @return float
+ */
+function qit_reset_elapsed( int $phase_started ): float {
+	return round( ( hrtime( true ) - $phase_started ) / 1000000000, 6 );
+}
+
+/**
+ * @return array{exit_code:int,stdout:string,stderr:string}
+ */
+function qit_reset_run( string $command ): array {
+	$descriptors = [
+		1 => [ 'pipe', 'w' ],
+		2 => [ 'pipe', 'w' ],
+	];
+	$pipes       = [];
+	$process     = proc_open( $command, $descriptors, $pipes, '/var/www/html' );
+	if ( ! is_resource( $process ) ) {
+		return [ 'exit_code' => 1, 'stdout' => '', 'stderr' => 'Unable to start reset command.' ];
+	}
+
+	$stdout = stream_get_contents( $pipes[1] );
+	$stderr = stream_get_contents( $pipes[2] );
+	fclose( $pipes[1] );
+	fclose( $pipes[2] );
+
+	return [
+		'exit_code' => proc_close( $process ),
+		'stdout'    => is_string( $stdout ) ? $stdout : '',
+		'stderr'    => is_string( $stderr ) ? $stderr : '',
+	];
+}
+
+/**
+ * @param array<string,array{status:string,seconds:float}> $phase_values
+ */
+function qit_reset_finish( string $status, ?string $failed_phase, string $message, array $phase_values ): void {
+	global $started;
+	echo json_encode( [
+		'status'       => $status,
+		'failed_phase' => $failed_phase,
+		'message'      => $message,
+		'total_seconds' => qit_reset_elapsed( $started ),
+		'phases'       => $phase_values,
+	], JSON_UNESCAPED_SLASHES );
+	exit( 0 );
+}
+
+$snapshot = $argv[1] ?? '';
+$checksum = $argv[2] ?? '';
+
+$phase_started = hrtime( true );
+if (
+	$snapshot === '' ||
+	$checksum === '' ||
+	! is_readable( $snapshot ) ||
+	! hash_equals( $checksum, (string) hash_file( 'sha256', $snapshot ) )
+) {
+	$phases['database_import'] = [ 'status' => 'failed', 'seconds' => qit_reset_elapsed( $phase_started ) ];
+	qit_reset_finish( 'failed', 'database_import', 'The staged database snapshot is missing or failed checksum verification.', $phases );
+}
+
+$import = qit_reset_run(
+	'wp db import ' . escapeshellarg( $snapshot ) . ' --defaults --quiet'
+);
+$phases['database_import'] = [
+	'status'  => $import['exit_code'] === 0 ? 'completed' : 'failed',
+	'seconds' => qit_reset_elapsed( $phase_started ),
+];
+if ( $import['exit_code'] !== 0 ) {
+	$message = trim( $import['stderr'] !== '' ? $import['stderr'] : $import['stdout'] );
+	qit_reset_finish( 'failed', 'database_import', substr( $message, -2000 ), $phases );
+}
+
+$phase_started = hrtime( true );
+$flush         = qit_reset_run( 'wp cache flush --quiet' );
+$phases['object_cache_flush'] = [
+	'status'  => $flush['exit_code'] === 0 ? 'completed' : 'failed',
+	'seconds' => qit_reset_elapsed( $phase_started ),
+];
+if ( $flush['exit_code'] !== 0 ) {
+	$message = trim( $flush['stderr'] !== '' ? $flush['stderr'] : $flush['stdout'] );
+	qit_reset_finish( 'failed', 'object_cache_flush', substr( $message, -2000 ), $phases );
+}
+
+qit_reset_finish( 'success', null, '', $phases );
+PHP;
+	}
+}

--- a/src/src/Commands/Environment/ResetEnvironmentHelper.php
+++ b/src/src/Commands/Environment/ResetEnvironmentHelper.php
@@ -20,7 +20,7 @@ class ResetEnvironmentHelper {
 		return <<<'PHP'
 <?php
 
-$started = hrtime( true );
+$started = microtime( true );
 $phases  = [
 	'database_import'    => [ 'status' => 'not_started', 'seconds' => 0.0 ],
 	'object_cache_flush' => [ 'status' => 'not_started', 'seconds' => 0.0 ],
@@ -29,8 +29,8 @@ $phases  = [
 /**
  * @return float
  */
-function qit_reset_elapsed( int $phase_started ): float {
-	return round( ( hrtime( true ) - $phase_started ) / 1000000000, 6 );
+function qit_reset_elapsed( float $phase_started ): float {
+	return round( microtime( true ) - $phase_started, 6 );
 }
 
 /**
@@ -77,7 +77,7 @@ function qit_reset_finish( string $status, ?string $failed_phase, string $messag
 $snapshot = $argv[1] ?? '';
 $checksum = $argv[2] ?? '';
 
-$phase_started = hrtime( true );
+$phase_started = microtime( true );
 if (
 	$snapshot === '' ||
 	$checksum === '' ||
@@ -100,7 +100,7 @@ if ( $import['exit_code'] !== 0 ) {
 	qit_reset_finish( 'failed', 'database_import', substr( $message, -2000 ), $phases );
 }
 
-$phase_started = hrtime( true );
+$phase_started = microtime( true );
 $flush         = qit_reset_run( 'wp cache flush --quiet' );
 $phases['object_cache_flush'] = [
 	'status'  => $flush['exit_code'] === 0 ? 'completed' : 'failed',

--- a/src/src/Commands/Environment/ResetEnvironmentHelper.php
+++ b/src/src/Commands/Environment/ResetEnvironmentHelper.php
@@ -47,15 +47,50 @@ function qit_reset_run( string $command ): array {
 		return [ 'exit_code' => 1, 'stdout' => '', 'stderr' => 'Unable to start reset command.' ];
 	}
 
-	$stdout = stream_get_contents( $pipes[1] );
-	$stderr = stream_get_contents( $pipes[2] );
-	fclose( $pipes[1] );
-	fclose( $pipes[2] );
+	$stdout  = '';
+	$stderr  = '';
+	$streams = [
+		'stdout' => $pipes[1],
+		'stderr' => $pipes[2],
+	];
+	foreach ( $streams as $stream ) {
+		stream_set_blocking( $stream, false );
+	}
+
+	while ( ! empty( $streams ) ) {
+		$read     = array_values( $streams );
+		$write    = null;
+		$except   = null;
+		$selected = stream_select( $read, $write, $except, 1 );
+		if ( $selected === false ) {
+			foreach ( $streams as $stream ) {
+				fclose( $stream );
+			}
+			proc_terminate( $process );
+			proc_close( $process );
+			return [ 'exit_code' => 1, 'stdout' => $stdout, 'stderr' => 'Unable to read reset command output.' ];
+		}
+
+		foreach ( $read as $stream ) {
+			$name  = array_search( $stream, $streams, true );
+			$chunk = stream_get_contents( $stream );
+			if ( $name === 'stdout' && is_string( $chunk ) ) {
+				$stdout .= $chunk;
+			} elseif ( $name === 'stderr' && is_string( $chunk ) ) {
+				$stderr .= $chunk;
+			}
+
+			if ( $name !== false && feof( $stream ) ) {
+				fclose( $stream );
+				unset( $streams[ $name ] );
+			}
+		}
+	}
 
 	return [
 		'exit_code' => proc_close( $process ),
-		'stdout'    => is_string( $stdout ) ? $stdout : '',
-		'stderr'    => is_string( $stderr ) ? $stderr : '',
+		'stdout'    => $stdout,
+		'stderr'    => $stderr,
 	];
 }
 

--- a/src/src/Commands/Environment/UpEnvironmentCommand.php
+++ b/src/src/Commands/Environment/UpEnvironmentCommand.php
@@ -1636,9 +1636,35 @@ HELP;
 			// Get Docker instance
 			$docker = \QIT_CLI\App::make( \QIT_CLI\Environment\Docker::class );
 
-			// Export database - run in WordPress directory with defaults
-			$sql_dump = $docker->run_inside_docker( $env_info, [ 'sh', '-c', 'cd /var/www/html && wp db export --defaults --quiet - 2>/dev/null' ] );
-			file_put_contents( $backup_dir . '/setup-complete.sql', $sql_dump );
+			// Make the in-container reset helper available through the existing /qit/bin bind mount.
+			$helper_file = rtrim( $env_info->temporary_env, '/' ) . '/bin/qit-env-reset.php';
+			if ( file_put_contents( $helper_file, ResetEnvironmentHelper::script() ) === false ) {
+				throw new \RuntimeException( 'Unable to stage the environment reset helper.' );
+			}
+			chmod( $helper_file, 0444 );
+
+			// Export once into the running container, make the snapshot immutable to the web process,
+			// and retain the host copy used by older env:reset implementations.
+			$container_snapshot = ResetEnvironmentHelper::CONTAINER_SNAPSHOT_PATH;
+			$container_dir      = dirname( $container_snapshot );
+			$docker->run_inside_docker(
+				$env_info,
+				[
+					'sh',
+					'-c',
+					sprintf(
+						'mkdir -p %1$s && chmod 0755 %1$s && rm -f %2$s && cd /var/www/html && wp db export %2$s --defaults --quiet && chmod 0444 %2$s && chmod 0555 %1$s',
+						escapeshellarg( $container_dir ),
+						escapeshellarg( $container_snapshot )
+					),
+				]
+			);
+			$backup_file = $backup_dir . '/setup-complete.sql';
+			$docker->copy_from_docker( $env_info, $container_snapshot, $backup_file );
+			$checksum = hash_file( 'sha256', $backup_file );
+			if ( ! is_string( $checksum ) ) {
+				throw new \RuntimeException( 'Unable to checksum the staged database snapshot.' );
+			}
 
 			// Save metadata about what was backed up
 			$metadata = [
@@ -1648,6 +1674,10 @@ HELP;
 				'php_version'         => $env_info->php_version,
 				'wordpress_version'   => $env_info->wordpress_version,
 				'woocommerce_version' => $env_info->woocommerce_version ?? '',
+				'snapshot_strategy'   => 'container_staged',
+				'container_snapshot'  => $container_snapshot,
+				'snapshot_sha256'     => $checksum,
+				'reset_helper'        => ResetEnvironmentHelper::CONTAINER_HELPER_PATH,
 			];
 			file_put_contents( $backup_dir . '/metadata.json', json_encode( $metadata, JSON_PRETTY_PRINT ) );
 

--- a/src/tests/integration/tests/TestPackages/Scenarios/DeveloperWorkflowTest.php
+++ b/src/tests/integration/tests/TestPackages/Scenarios/DeveloperWorkflowTest.php
@@ -135,6 +135,7 @@ class DeveloperWorkflowTest extends BaseScenarioTestCase {
 		$output = qit( [ 
 			'env:up', 
 			'--json',
+			'--object_cache',
 			'--test-package=' . __DIR__ . '/fixtures/scenario-main-package'
 		] );
 		$data = json_decode( $output, true );
@@ -163,9 +164,18 @@ class DeveloperWorkflowTest extends BaseScenarioTestCase {
 			'wp option get qit_main_package_setup_marker --path=/var/www/html'
 		] );
 		$this->assertEquals( 'modified_by_test', trim( $modifiedMarker ) );
+		qit( [
+			'env:exec',
+			'--env_id=' . $envId,
+			'wp eval \'wp_cache_set( "qit_reset_sentinel", "dirty" );\' --path=/var/www/html'
+		] );
 		
 		// Run env:reset with explicit env_id for deterministic behavior
-		qit( [ 'env:reset', $envId ] );
+		$firstReset = json_decode( qit( [ 'env:reset', $envId, '--json' ] ), true );
+		$this->assertSame( 'success', $firstReset['status'] );
+		$this->assertSame( 'container_staged', $firstReset['strategy'] );
+		$this->assertSame( 'completed', $firstReset['phases']['database_import']['status'] );
+		$this->assertSame( 'completed', $firstReset['phases']['object_cache_flush']['status'] );
 		
 		// Check that database was restored to post-setup state
 		$restoredMarker = qit( [ 
@@ -175,6 +185,12 @@ class DeveloperWorkflowTest extends BaseScenarioTestCase {
 		] );
 		$this->assertStringContainsString( 'setup_complete_', trim( $restoredMarker ) );
 		$this->assertNotEquals( 'modified_by_test', trim( $restoredMarker ) );
+		$cacheAfterFirstReset = qit( [
+			'env:exec',
+			'--env_id=' . $envId,
+			'wp eval \'var_export( wp_cache_get( "qit_reset_sentinel" ) );\' --path=/var/www/html'
+		] );
+		$this->assertSame( 'false', trim( $cacheAfterFirstReset ) );
 
 		// A long-running harness can isolate every generated request by restoring the same snapshot
 		// repeatedly. Verify the second reset does not use the state produced by the first reset.
@@ -183,7 +199,14 @@ class DeveloperWorkflowTest extends BaseScenarioTestCase {
 			'--env_id=' . $envId,
 			'wp option update qit_main_package_setup_marker "modified_again" --path=/var/www/html'
 		] );
-		qit( [ 'env:reset', $envId ] );
+		qit( [
+			'env:exec',
+			'--env_id=' . $envId,
+			'wp eval \'wp_cache_set( "qit_reset_sentinel", "dirty_again" );\' --path=/var/www/html'
+		] );
+		$secondReset = json_decode( qit( [ 'env:reset', $envId, '--json' ] ), true );
+		$this->assertSame( 'success', $secondReset['status'] );
+		$this->assertSame( 'container_staged', $secondReset['strategy'] );
 
 		$restoredAgain = qit( [
 			'env:exec',
@@ -192,6 +215,12 @@ class DeveloperWorkflowTest extends BaseScenarioTestCase {
 		] );
 		$this->assertStringContainsString( 'setup_complete_', trim( $restoredAgain ) );
 		$this->assertNotEquals( 'modified_again', trim( $restoredAgain ) );
+		$cacheAfterSecondReset = qit( [
+			'env:exec',
+			'--env_id=' . $envId,
+			'wp eval \'var_export( wp_cache_get( "qit_reset_sentinel" ) );\' --path=/var/www/html'
+		] );
+		$this->assertSame( 'false', trim( $cacheAfterSecondReset ) );
 	}
 	
 	/**

--- a/src/tests/unit/ResetEnvironmentCommandTest.php
+++ b/src/tests/unit/ResetEnvironmentCommandTest.php
@@ -34,6 +34,8 @@ class ResetEnvironmentCommandTest extends \QIT_CLI_Tests\QITTestCase {
 		$this->assertStringContainsString( '$started = microtime( true );', $script );
 		$this->assertStringContainsString( 'function qit_reset_elapsed( float $phase_started ): float', $script );
 		$this->assertStringContainsString( 'return round( microtime( true ) - $phase_started, 6 );', $script );
+		$this->assertStringContainsString( "'snapshot_unavailable'", $script );
+		$this->assertStringContainsString( "'snapshot_checksum_mismatch'", $script );
 	}
 
 	public function test_flushes_object_cache_from_wordpress_directory(): void {
@@ -144,6 +146,78 @@ class ResetEnvironmentCommandTest extends \QIT_CLI_Tests\QITTestCase {
 		$this->assertSame( 0.25, $result['phases']['object_cache_flush']['seconds'] );
 	}
 
+	public function test_missing_staged_snapshot_uses_checksum_verified_legacy_fallback(): void {
+		$env_id                      = 'qitenv-reset-json-staged-missing';
+		$metadata                    = $this->staged_metadata();
+		$metadata['snapshot_sha256'] = hash( 'sha256', '-- test backup' );
+		$env_info                    = $this->create_environment( $env_id, $metadata );
+		$docker                      = $this->createMock( Docker::class );
+		$docker->expects( $this->once() )
+			->method( 'copy_into_docker' );
+		$docker->expects( $this->exactly( 4 ) )
+			->method( 'run_inside_docker' )
+			->willReturnCallback( static function ( E2EEnvInfo $actual_env, array $command ) use ( $env_info ): string {
+				self::assertSame( $env_info, $actual_env );
+				if ( $command[0] === 'php' ) {
+					return json_encode( [
+						'status'       => 'failed',
+						'failed_phase' => 'database_import',
+						'failure_code'  => 'snapshot_unavailable',
+						'message'      => 'The staged database snapshot is missing or unreadable.',
+						'phases'       => [
+							'database_import'    => [ 'status' => 'failed', 'seconds' => 0.01 ],
+							'object_cache_flush' => [ 'status' => 'not_started', 'seconds' => 0.0 ],
+						],
+					] );
+				}
+
+				return '';
+			} );
+
+		$tester = $this->create_command_tester( $env_info, $docker );
+		$status = $tester->execute( [ 'env_id' => $env_id, '--json' => true ], [ 'interactive' => false ] );
+		$result = json_decode( $tester->getDisplay(), true );
+
+		$this->assertSame( Command::SUCCESS, $status );
+		$this->assertSame( 'success', $result['status'] );
+		$this->assertSame( 'copy_per_reset', $result['strategy'] );
+		foreach ( $result['phases'] as $phase ) {
+			$this->assertSame( 'completed', $phase['status'] );
+		}
+	}
+
+	public function test_missing_staged_snapshot_fails_when_host_backup_checksum_does_not_match(): void {
+		$env_id   = 'qitenv-reset-json-staged-missing-host-mismatch';
+		$metadata = $this->staged_metadata();
+		$env_info = $this->create_environment( $env_id, $metadata );
+		$docker   = $this->createMock( Docker::class );
+		$docker->expects( $this->never() )
+			->method( 'copy_into_docker' );
+		$docker->expects( $this->once() )
+			->method( 'run_inside_docker' )
+			->willReturn( json_encode( [
+				'status'       => 'failed',
+				'failed_phase' => 'database_import',
+				'failure_code'  => 'snapshot_unavailable',
+				'message'      => 'The staged database snapshot is missing or unreadable.',
+				'phases'       => [
+					'database_import'    => [ 'status' => 'failed', 'seconds' => 0.01 ],
+					'object_cache_flush' => [ 'status' => 'not_started', 'seconds' => 0.0 ],
+				],
+			] ) );
+
+		$tester = $this->create_command_tester( $env_info, $docker );
+		$status = $tester->execute( [ 'env_id' => $env_id, '--json' => true ], [ 'interactive' => false ] );
+		$result = json_decode( $tester->getDisplay(), true );
+
+		$this->assertSame( Command::FAILURE, $status );
+		$this->assertSame( 'failed', $result['status'] );
+		$this->assertSame( 'copy_per_reset', $result['strategy'] );
+		$this->assertSame( 'snapshot_copy', $result['failed_phase'] );
+		$this->assertSame( 'failed', $result['phases']['snapshot_copy']['status'] );
+		$this->assertStringContainsString( 'host backup failed checksum verification', $result['message'] );
+	}
+
 	public function test_staged_checksum_failure_is_structured_and_does_not_fall_back(): void {
 		$env_id   = 'qitenv-reset-json-checksum-failure';
 		$metadata = $this->staged_metadata();
@@ -156,7 +230,8 @@ class ResetEnvironmentCommandTest extends \QIT_CLI_Tests\QITTestCase {
 			->willReturn( json_encode( [
 				'status'       => 'failed',
 				'failed_phase' => 'database_import',
-				'message'      => 'The staged database snapshot is missing or failed checksum verification.',
+				'failure_code'  => 'snapshot_checksum_mismatch',
+				'message'      => 'The staged database snapshot failed checksum verification.',
 				'phases'       => [
 					'database_import'    => [ 'status' => 'failed', 'seconds' => 0.01 ],
 					'object_cache_flush' => [ 'status' => 'not_started', 'seconds' => 0.0 ],

--- a/src/tests/unit/ResetEnvironmentCommandTest.php
+++ b/src/tests/unit/ResetEnvironmentCommandTest.php
@@ -146,6 +146,60 @@ class ResetEnvironmentCommandTest extends \QIT_CLI_Tests\QITTestCase {
 		$this->assertSame( 0.25, $result['phases']['object_cache_flush']['seconds'] );
 	}
 
+	public function test_staged_helper_success_without_cache_phase_returns_structured_failure(): void {
+		$env_id   = 'qitenv-reset-json-staged-incomplete-cache';
+		$metadata = $this->staged_metadata();
+		$env_info = $this->create_environment( $env_id, $metadata );
+		$docker   = $this->createMock( Docker::class );
+		$docker->expects( $this->never() )
+			->method( 'copy_into_docker' );
+		$docker->expects( $this->once() )
+			->method( 'run_inside_docker' )
+			->willReturn( json_encode( [
+				'status'       => 'success',
+				'failed_phase' => null,
+				'phases'       => [
+					'database_import' => [ 'status' => 'completed', 'seconds' => 0.75 ],
+				],
+			] ) );
+
+		$tester = $this->create_command_tester( $env_info, $docker );
+		$status = $tester->execute( [ 'env_id' => $env_id, '--json' => true ], [ 'interactive' => false ] );
+		$result = json_decode( $tester->getDisplay(), true );
+
+		$this->assertSame( Command::FAILURE, $status );
+		$this->assertSame( 'failed', $result['status'] );
+		$this->assertSame( 'object_cache_flush', $result['failed_phase'] );
+		$this->assertSame( 'failed', $result['phases']['object_cache_flush']['status'] );
+		$this->assertStringContainsString( 'without completing object cache flush', $result['message'] );
+	}
+
+	public function test_human_output_does_not_claim_incomplete_cache_flush_succeeded(): void {
+		$env_id   = 'qitenv-reset-human-staged-incomplete-cache';
+		$metadata = $this->staged_metadata();
+		$env_info = $this->create_environment( $env_id, $metadata );
+		$docker   = $this->createMock( Docker::class );
+		$docker->expects( $this->never() )
+			->method( 'copy_into_docker' );
+		$docker->expects( $this->once() )
+			->method( 'run_inside_docker' )
+			->willReturn( json_encode( [
+				'status'       => 'success',
+				'failed_phase' => null,
+				'phases'       => [
+					'database_import'    => [ 'status' => 'completed', 'seconds' => 0.75 ],
+					'object_cache_flush' => [ 'status' => 'not_started', 'seconds' => 0.0 ],
+				],
+			] ) );
+
+		$tester = $this->create_command_tester( $env_info, $docker );
+		$status = $tester->execute( [ 'env_id' => $env_id ], [ 'interactive' => false ] );
+
+		$this->assertSame( Command::FAILURE, $status );
+		$this->assertStringContainsString( 'without completing object cache flush', $tester->getDisplay() );
+		$this->assertStringNotContainsString( 'WordPress object cache flushed.', $tester->getDisplay() );
+	}
+
 	public function test_missing_staged_snapshot_uses_checksum_verified_legacy_fallback(): void {
 		$env_id                      = 'qitenv-reset-json-staged-missing';
 		$metadata                    = $this->staged_metadata();

--- a/src/tests/unit/ResetEnvironmentCommandTest.php
+++ b/src/tests/unit/ResetEnvironmentCommandTest.php
@@ -13,8 +13,10 @@ class ResetEnvironmentCommandTest extends \QIT_CLI_Tests\QITTestCase {
 
 	public function tearDown(): void {
 		foreach ( $this->backup_dirs as $backup_dir ) {
-			if ( file_exists( $backup_dir . '/setup-complete.sql' ) ) {
-				unlink( $backup_dir . '/setup-complete.sql' );
+			foreach ( [ 'setup-complete.sql', 'metadata.json' ] as $file ) {
+				if ( file_exists( $backup_dir . '/' . $file ) ) {
+					unlink( $backup_dir . '/' . $file );
+				}
 			}
 			if ( is_dir( $backup_dir ) ) {
 				rmdir( $backup_dir );
@@ -72,13 +74,184 @@ class ResetEnvironmentCommandTest extends \QIT_CLI_Tests\QITTestCase {
 		$this->assertStringNotContainsString( 'WordPress object cache flushed.', $tester->getDisplay() );
 	}
 
-	private function create_environment( string $env_id ): E2EEnvInfo {
+	public function test_legacy_json_result_contains_all_timed_phases(): void {
+		$env_id   = 'qitenv-reset-json-legacy';
+		$env_info = $this->create_environment( $env_id );
+		$docker   = $this->createMock( Docker::class );
+		$docker->expects( $this->once() )
+			->method( 'copy_into_docker' );
+		$docker->expects( $this->exactly( 3 ) )
+			->method( 'run_inside_docker' )
+			->willReturn( '' );
+
+		$tester = $this->create_command_tester( $env_info, $docker );
+		$status = $tester->execute( [ 'env_id' => $env_id, '--json' => true ], [ 'interactive' => false ] );
+		$result = json_decode( $tester->getDisplay(), true );
+
+		$this->assertSame( Command::SUCCESS, $status );
+		$this->assertSame( 'success', $result['status'] );
+		$this->assertSame( 'copy_per_reset', $result['strategy'] );
+		$this->assertNull( $result['failed_phase'] );
+		$this->assertSame(
+			[ 'environment_lookup', 'snapshot_copy', 'database_import', 'temporary_file_cleanup', 'object_cache_flush' ],
+			array_keys( $result['phases'] )
+		);
+		foreach ( $result['phases'] as $phase ) {
+			$this->assertSame( 'completed', $phase['status'] );
+			$this->assertGreaterThanOrEqual( 0, $phase['seconds'] );
+		}
+		$this->assertGreaterThanOrEqual( 0, $result['total_seconds'] );
+	}
+
+	public function test_staged_reset_uses_one_container_execution_and_skips_copy_and_cleanup(): void {
+		$env_id   = 'qitenv-reset-json-staged';
+		$metadata = $this->staged_metadata();
+		$env_info = $this->create_environment( $env_id, $metadata );
+		$docker   = $this->createMock( Docker::class );
+		$docker->expects( $this->never() )
+			->method( 'copy_into_docker' );
+		$docker->expects( $this->once() )
+			->method( 'run_inside_docker' )
+			->with( $env_info, [ 'php', $metadata['reset_helper'], $metadata['container_snapshot'], $metadata['snapshot_sha256'] ] )
+			->willReturn( json_encode( [
+				'status'       => 'success',
+				'failed_phase' => null,
+				'phases'       => [
+					'database_import'    => [ 'status' => 'completed', 'seconds' => 0.75 ],
+					'object_cache_flush' => [ 'status' => 'completed', 'seconds' => 0.25 ],
+				],
+			] ) );
+
+		$tester = $this->create_command_tester( $env_info, $docker );
+		$status = $tester->execute( [ 'env_id' => $env_id, '--json' => true ], [ 'interactive' => false ] );
+		$result = json_decode( $tester->getDisplay(), true );
+
+		$this->assertSame( Command::SUCCESS, $status );
+		$this->assertSame( 'container_staged', $result['strategy'] );
+		$this->assertEquals( [ 'status' => 'skipped', 'seconds' => 0.0 ], $result['phases']['snapshot_copy'] );
+		$this->assertEquals( [ 'status' => 'skipped', 'seconds' => 0.0 ], $result['phases']['temporary_file_cleanup'] );
+		$this->assertSame( 0.75, $result['phases']['database_import']['seconds'] );
+		$this->assertSame( 0.25, $result['phases']['object_cache_flush']['seconds'] );
+	}
+
+	public function test_staged_checksum_failure_is_structured_and_does_not_fall_back(): void {
+		$env_id   = 'qitenv-reset-json-checksum-failure';
+		$metadata = $this->staged_metadata();
+		$env_info = $this->create_environment( $env_id, $metadata );
+		$docker   = $this->createMock( Docker::class );
+		$docker->expects( $this->never() )
+			->method( 'copy_into_docker' );
+		$docker->expects( $this->once() )
+			->method( 'run_inside_docker' )
+			->willReturn( json_encode( [
+				'status'       => 'failed',
+				'failed_phase' => 'database_import',
+				'message'      => 'The staged database snapshot is missing or failed checksum verification.',
+				'phases'       => [
+					'database_import'    => [ 'status' => 'failed', 'seconds' => 0.01 ],
+					'object_cache_flush' => [ 'status' => 'not_started', 'seconds' => 0.0 ],
+				],
+			] ) );
+
+		$tester = $this->create_command_tester( $env_info, $docker );
+		$status = $tester->execute( [ 'env_id' => $env_id, '--json' => true ], [ 'interactive' => false ] );
+		$result = json_decode( $tester->getDisplay(), true );
+
+		$this->assertSame( Command::FAILURE, $status );
+		$this->assertSame( 'failed', $result['status'] );
+		$this->assertSame( 'container_staged', $result['strategy'] );
+		$this->assertSame( 'database_import', $result['failed_phase'] );
+		$this->assertStringContainsString( 'checksum verification', $result['message'] );
+		$this->assertSame( 'not_started', $result['phases']['object_cache_flush']['status'] );
+	}
+
+	public function test_legacy_cleanup_failure_is_fail_closed_and_skips_cache_flush(): void {
+		$env_id   = 'qitenv-reset-json-cleanup-failure';
+		$env_info = $this->create_environment( $env_id );
+		$docker   = $this->createMock( Docker::class );
+		$docker->expects( $this->once() )
+			->method( 'copy_into_docker' );
+		$docker->expects( $this->exactly( 2 ) )
+			->method( 'run_inside_docker' )
+			->willReturnCallback( static function ( E2EEnvInfo $actual_env, array $command ): string {
+				if ( $command[0] === 'rm' ) {
+					throw new \RuntimeException( 'Unable to remove temporary snapshot.' );
+				}
+				return '';
+			} );
+
+		$tester = $this->create_command_tester( $env_info, $docker );
+		$status = $tester->execute( [ 'env_id' => $env_id, '--json' => true ], [ 'interactive' => false ] );
+		$result = json_decode( $tester->getDisplay(), true );
+
+		$this->assertSame( Command::FAILURE, $status );
+		$this->assertSame( 'temporary_file_cleanup', $result['failed_phase'] );
+		$this->assertSame( 'failed', $result['phases']['temporary_file_cleanup']['status'] );
+		$this->assertSame( 'not_started', $result['phases']['object_cache_flush']['status'] );
+	}
+
+	public function test_legacy_import_failure_is_structured_and_still_cleans_up(): void {
+		$env_id   = 'qitenv-reset-json-import-failure';
+		$env_info = $this->create_environment( $env_id );
+		$docker   = $this->createMock( Docker::class );
+		$docker->expects( $this->once() )
+			->method( 'copy_into_docker' );
+		$docker->expects( $this->exactly( 2 ) )
+			->method( 'run_inside_docker' )
+			->willReturnCallback( static function ( E2EEnvInfo $actual_env, array $command ): string {
+				if ( $command[0] === 'sh' ) {
+					throw new \RuntimeException( 'Import rejected.' );
+				}
+				return '';
+			} );
+
+		$tester = $this->create_command_tester( $env_info, $docker );
+		$status = $tester->execute( [ 'env_id' => $env_id, '--json' => true ], [ 'interactive' => false ] );
+		$result = json_decode( $tester->getDisplay(), true );
+
+		$this->assertSame( Command::FAILURE, $status );
+		$this->assertSame( 'database_import', $result['failed_phase'] );
+		$this->assertSame( 'failed', $result['phases']['database_import']['status'] );
+		$this->assertSame( 'completed', $result['phases']['temporary_file_cleanup']['status'] );
+		$this->assertSame( 'not_started', $result['phases']['object_cache_flush']['status'] );
+	}
+
+	public function test_legacy_cache_failure_is_structured(): void {
+		$env_id   = 'qitenv-reset-json-cache-failure';
+		$env_info = $this->create_environment( $env_id );
+		$docker   = $this->createMock( Docker::class );
+		$docker->expects( $this->once() )
+			->method( 'copy_into_docker' );
+		$docker->expects( $this->exactly( 3 ) )
+			->method( 'run_inside_docker' )
+			->willReturnCallback( static function ( E2EEnvInfo $actual_env, array $command ): string {
+				if ( $command === [ 'sh', '-c', 'cd /var/www/html && wp cache flush --quiet' ] ) {
+					throw new \RuntimeException( 'Cache flush rejected.' );
+				}
+				return '';
+			} );
+
+		$tester = $this->create_command_tester( $env_info, $docker );
+		$status = $tester->execute( [ 'env_id' => $env_id, '--json' => true ], [ 'interactive' => false ] );
+		$result = json_decode( $tester->getDisplay(), true );
+
+		$this->assertSame( Command::FAILURE, $status );
+		$this->assertSame( 'object_cache_flush', $result['failed_phase'] );
+		$this->assertSame( 'failed', $result['phases']['object_cache_flush']['status'] );
+		$this->assertStringContainsString( 'Cache flush rejected', $result['message'] );
+	}
+
+	/** @param array<string,mixed> $metadata */
+	private function create_environment( string $env_id, array $metadata = [] ): E2EEnvInfo {
 		$backup_dir         = sys_get_temp_dir() . '/qit-env-backups/' . $env_id;
 		$this->backup_dirs[] = $backup_dir;
 		if ( ! is_dir( $backup_dir ) ) {
 			mkdir( $backup_dir, 0777, true );
 		}
 		file_put_contents( $backup_dir . '/setup-complete.sql', '-- test backup' );
+		if ( ! empty( $metadata ) ) {
+			file_put_contents( $backup_dir . '/metadata.json', json_encode( $metadata ) );
+		}
 
 		$env_info                        = new E2EEnvInfo();
 		$env_info->env_id                = $env_id;
@@ -86,6 +259,16 @@ class ResetEnvironmentCommandTest extends \QIT_CLI_Tests\QITTestCase {
 		$env_info->temporary_env          = sys_get_temp_dir() . '/' . $env_id;
 
 		return $env_info;
+	}
+
+	/** @return array<string,string> */
+	private function staged_metadata(): array {
+		return [
+			'snapshot_strategy'  => 'container_staged',
+			'container_snapshot' => '/tmp/qit-env-reset/setup-complete.sql',
+			'snapshot_sha256'    => str_repeat( 'a', 64 ),
+			'reset_helper'       => '/qit/bin/qit-env-reset.php',
+		];
 	}
 
 	private function create_command_tester( E2EEnvInfo $env_info, Docker $docker ): CommandTester {

--- a/src/tests/unit/ResetEnvironmentCommandTest.php
+++ b/src/tests/unit/ResetEnvironmentCommandTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use QIT_CLI\Commands\Environment\ResetEnvironmentCommand;
+use QIT_CLI\Commands\Environment\ResetEnvironmentHelper;
 use QIT_CLI\Environment\Docker;
 use QIT_CLI\Environment\EnvironmentMonitor;
 use QIT_CLI\Environment\Environments\E2E\E2EEnvInfo;
@@ -24,6 +25,15 @@ class ResetEnvironmentCommandTest extends \QIT_CLI_Tests\QITTestCase {
 		}
 
 		parent::tearDown();
+	}
+
+	public function test_staged_helper_uses_php_72_compatible_timing(): void {
+		$script = ResetEnvironmentHelper::script();
+
+		$this->assertStringNotContainsString( 'hrtime(', $script );
+		$this->assertStringContainsString( '$started = microtime( true );', $script );
+		$this->assertStringContainsString( 'function qit_reset_elapsed( float $phase_started ): float', $script );
+		$this->assertStringContainsString( 'return round( microtime( true ) - $phase_started, 6 );', $script );
 	}
 
 	public function test_flushes_object_cache_from_wordpress_directory(): void {

--- a/src/tests/unit/ResetEnvironmentCommandTest.php
+++ b/src/tests/unit/ResetEnvironmentCommandTest.php
@@ -113,7 +113,7 @@ class ResetEnvironmentCommandTest extends \QIT_CLI_Tests\QITTestCase {
 		$this->assertGreaterThanOrEqual( 0, $result['total_seconds'] );
 	}
 
-	public function test_staged_reset_uses_one_container_execution_and_skips_copy_and_cleanup(): void {
+	public function test_staged_reset_parses_last_json_line_and_uses_one_container_execution(): void {
 		$env_id   = 'qitenv-reset-json-staged';
 		$metadata = $this->staged_metadata();
 		$env_info = $this->create_environment( $env_id, $metadata );
@@ -123,14 +123,14 @@ class ResetEnvironmentCommandTest extends \QIT_CLI_Tests\QITTestCase {
 		$docker->expects( $this->once() )
 			->method( 'run_inside_docker' )
 			->with( $env_info, [ 'php', $metadata['reset_helper'], $metadata['container_snapshot'], $metadata['snapshot_sha256'] ] )
-			->willReturn( json_encode( [
+			->willReturn( "PHP Deprecated: noisy extension warning\n" . json_encode( [
 				'status'       => 'success',
 				'failed_phase' => null,
 				'phases'       => [
 					'database_import'    => [ 'status' => 'completed', 'seconds' => 0.75 ],
 					'object_cache_flush' => [ 'status' => 'completed', 'seconds' => 0.25 ],
 				],
-			] ) );
+			] ) . "\nDocker warning: noisy stderr output" );
 
 		$tester = $this->create_command_tester( $env_info, $docker );
 		$status = $tester->execute( [ 'env_id' => $env_id, '--json' => true ], [ 'interactive' => false ] );

--- a/src/tests/unit/ResetEnvironmentCommandTest.php
+++ b/src/tests/unit/ResetEnvironmentCommandTest.php
@@ -6,6 +6,8 @@ use QIT_CLI\Environment\Docker;
 use QIT_CLI\Environment\EnvironmentMonitor;
 use QIT_CLI\Environment\Environments\E2E\E2EEnvInfo;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class ResetEnvironmentCommandTest extends \QIT_CLI_Tests\QITTestCase {
@@ -34,6 +36,9 @@ class ResetEnvironmentCommandTest extends \QIT_CLI_Tests\QITTestCase {
 		$this->assertStringContainsString( '$started = microtime( true );', $script );
 		$this->assertStringContainsString( 'function qit_reset_elapsed( float $phase_started ): float', $script );
 		$this->assertStringContainsString( 'return round( microtime( true ) - $phase_started, 6 );', $script );
+		$this->assertStringContainsString( 'stream_select( $read, $write, $except, 1 );', $script );
+		$this->assertStringContainsString( 'stream_set_blocking( $stream, false );', $script );
+		$this->assertStringNotContainsString( '$stdout = stream_get_contents( $pipes[1] );', $script );
 		$this->assertStringContainsString( "'snapshot_unavailable'", $script );
 		$this->assertStringContainsString( "'snapshot_checksum_mismatch'", $script );
 	}
@@ -113,6 +118,64 @@ class ResetEnvironmentCommandTest extends \QIT_CLI_Tests\QITTestCase {
 			$this->assertGreaterThanOrEqual( 0, $phase['seconds'] );
 		}
 		$this->assertGreaterThanOrEqual( 0, $result['total_seconds'] );
+	}
+
+	public function test_json_mode_does_not_emit_automatic_environment_selection_message(): void {
+		$older_env = $this->create_environment( 'qitenv-reset-json-selection-20260719' );
+		$newer_env = $this->create_environment( 'qitenv-reset-json-selection-20260720' );
+		$monitor   = $this->createMock( EnvironmentMonitor::class );
+		$monitor->expects( $this->once() )
+			->method( 'get' )
+			->willReturn( [ $older_env, $newer_env ] );
+		$docker = $this->createMock( Docker::class );
+		$docker->expects( $this->once() )
+			->method( 'copy_into_docker' );
+		$docker->expects( $this->exactly( 3 ) )
+			->method( 'run_inside_docker' )
+			->willReturn( '' );
+
+		$tester = new CommandTester( new ResetEnvironmentCommand( $monitor, $docker ) );
+		$status = $tester->execute( [ '--json' => true ], [ 'interactive' => false ] );
+		$result = json_decode( $tester->getDisplay(), true );
+
+		$this->assertSame( Command::SUCCESS, $status, $tester->getDisplay() );
+		$this->assertSame( $newer_env->env_id, $result['env_id'] );
+		$this->assertStringNotContainsString( 'Using most recent', $tester->getDisplay() );
+	}
+
+	public function test_environment_lookup_excludes_interactive_prompt_wait(): void {
+		$older_env = $this->create_environment( 'qitenv-reset-json-prompt-20260719' );
+		$newer_env = $this->create_environment( 'qitenv-reset-json-prompt-20260720' );
+		$monitor   = $this->createMock( EnvironmentMonitor::class );
+		$monitor->expects( $this->once() )
+			->method( 'get' )
+			->willReturn( [ $older_env, $newer_env ] );
+		$docker = $this->createMock( Docker::class );
+		$docker->expects( $this->once() )
+			->method( 'copy_into_docker' );
+		$docker->expects( $this->exactly( 3 ) )
+			->method( 'run_inside_docker' )
+			->willReturn( '' );
+		$question_helper = $this->createMock( QuestionHelper::class );
+		$question_helper->expects( $this->once() )
+			->method( 'ask' )
+			->willReturnCallback( static function (): string {
+				usleep( 500000 );
+				return 'qitenv-reset-json-prompt-20260720 (PHP , WP )';
+			} );
+
+		$command = new ResetEnvironmentCommand( $monitor, $docker );
+		$command->setHelperSet( new HelperSet( [ 'question' => $question_helper ] ) );
+		$tester = new CommandTester( $command );
+		$status = $tester->execute( [ '--json' => true ], [ 'interactive' => true ] );
+		$result = json_decode( $tester->getDisplay(), true );
+
+		$this->assertSame( Command::SUCCESS, $status, $tester->getDisplay() );
+		$this->assertSame( $newer_env->env_id, $result['env_id'] );
+		$this->assertGreaterThanOrEqual(
+			0.4,
+			$result['total_seconds'] - $result['phases']['environment_lookup']['seconds']
+		);
 	}
 
 	public function test_staged_reset_parses_last_json_line_and_uses_one_container_execution(): void {
@@ -339,7 +402,7 @@ class ResetEnvironmentCommandTest extends \QIT_CLI_Tests\QITTestCase {
 			->method( 'run_inside_docker' )
 			->willReturnCallback( static function ( E2EEnvInfo $actual_env, array $command ): string {
 				if ( $command[0] === 'sh' ) {
-					throw new \RuntimeException( 'Import rejected.' );
+					throw new \RuntimeException( 'Import <error>rejected</error>.' );
 				}
 				return '';
 			} );
@@ -353,6 +416,7 @@ class ResetEnvironmentCommandTest extends \QIT_CLI_Tests\QITTestCase {
 		$this->assertSame( 'failed', $result['phases']['database_import']['status'] );
 		$this->assertSame( 'completed', $result['phases']['temporary_file_cleanup']['status'] );
 		$this->assertSame( 'not_started', $result['phases']['object_cache_flush']['status'] );
+		$this->assertSame( 'Database restore failed: Import <error>rejected</error>.', $result['message'] );
 	}
 
 	public function test_legacy_cache_failure_is_structured(): void {


### PR DESCRIPTION
## Summary
- add structured env:reset JSON phase timings and fail-closed phase errors
- stage an immutable checksummed post-setup snapshot for one-exec resets
- preserve the fully instrumented copy-per-reset path for older environments
- use a checksum-verified copy-per-reset fallback only when the staged snapshot is unavailable
- reject helper success unless database import and object-cache flush both completed
- verify repeated database and Redis cache isolation in integration coverage

## Validation
- make phpunit (289 tests)
- make phpstan
- make phpcs
- make phan
- focused Docker integration reset contract (2 resets with persistent object cache)
- generated reset helper executed directly on automattic/qit-runner-php-7.2-fpm-alpine

Companion: Automattic/compatibility-dashboard#1767
