### PR TITLE
Implement subpackage option for local e2e test runs

### DIFF
--- a/src/src/Commands/Environment/UpEnvironmentCommand.php
+++ b/src/src/Commands/Environment/UpEnvironmentCommand.php
@@ -163,38 +163,7 @@ class UpEnvironmentCommand extends QITCommand {
 					continue;
 				}
 
-				// Skip absolute paths (already absolute)
-				if ( substr( $package, 0, 1 ) === '/' ) {
-					continue;
-				}
-
-				// Check if it's a relative path starting with . (includes ./, ., ../, etc.)
-				if ( substr( $package, 0, 1 ) === '.' ) {
-					// Try realpath first, fall back to manual construction if it fails
-					$resolved = @realpath( $package );
-					if ( $resolved === false ) {
-						// realpath failed (possibly due to permissions or non-existent path)
-						// For simple . and ./, use getcwd
-						if ( $package === '.' || $package === './' ) {
-							$package = getcwd();
-						} else {
-							// For other relative paths, construct manually
-							// This preserves the relative path structure even if intermediate dirs don't exist
-							$package = getcwd() . '/' . $package;
-						}
-					} else {
-						$package = $resolved;
-					}
-				} else {
-					// For other paths (not starting with . or /), try to resolve as local path
-					// If it exists locally, expand it; otherwise assume it's a package reference
-					$resolved = @realpath( $package );
-					if ( $resolved !== false ) {
-						// Path exists locally, use the resolved absolute path
-						$package = $resolved;
-					}
-					// If realpath fails, leave it unchanged (likely a package reference like vendor/package:1.0.0)
-				}
+				$package = PackageReferenceUtils::expand_local_path( $package );
 			}
 			unset( $package ); // Break the reference
 		}

--- a/src/src/Commands/RunE2ECommand.php
+++ b/src/src/Commands/RunE2ECommand.php
@@ -129,9 +129,6 @@ class RunE2ECommand extends QITCommand {
 			->addOption( 'passthrough_target', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
 			'Test packages that should receive passthrough arguments (multiple allowed)', [] )
 
-			/*
-			─────────────── Shared Options (reused from env:up) ───────────────
-			*/
 			/* ─────────────── E2E-specific options ─────────────── */
 			->addOption(
 				'test-package',
@@ -143,10 +140,14 @@ class RunE2ECommand extends QITCommand {
 			->addOption(
 				'subpackage',
 				null,
-				InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+				InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
 				'Run only the given subpackage(s) of a single local test package; the value(s) must match the subpackage ID(s) in the test package manifest',
 				[]
 			)
+
+			/*
+			─────────────── Shared Options (reused from env:up) ───────────────
+			*/
 			->reuseOption( 'env:up', 'environment' )
 			->reuseOption( 'env:up', 'php_version' )
 			->reuseOption( 'env:up', 'wordpress_version' )

--- a/src/src/Commands/RunE2ECommand.php
+++ b/src/src/Commands/RunE2ECommand.php
@@ -401,7 +401,9 @@ class RunE2ECommand extends QITCommand {
 					if ( ! empty( $requested_subpackages )
 						&& $subpackage_parent_dir !== null
 						&& $pkg_info['source'] === 'local'
-						&& realpath( $pkg_info['path'] ) === realpath( $subpackage_parent_dir ) ) {
+						&& realpath( $pkg_info['path'] ) === realpath( $subpackage_parent_dir )
+						&& false !== realpath( $pkg_info['path'] )
+					) {
 						try {
 							$expanded = $this->expand_subpackages( $pkg_info, $requested_subpackages );
 						} catch ( \InvalidArgumentException $e ) {

--- a/src/src/Commands/RunE2ECommand.php
+++ b/src/src/Commands/RunE2ECommand.php
@@ -220,16 +220,7 @@ class RunE2ECommand extends QITCommand {
 			try {
 				$subpackage_parent_dir = \QIT_CLI\Utils\SubpackageSelector::validate_selection( $requested_subpackages, $candidate_refs );
 			} catch ( \RuntimeException $e ) {
-				if ( $input->getOption( 'json' ) ) {
-					$output->write( json_encode( [
-						'error'   => 'invalid_subpackage',
-						'message' => $e->getMessage(),
-					] ) );
-				} else {
-					$output->writeln( sprintf( '<error>%s</error>', $e->getMessage() ) );
-				}
-
-				return Command::FAILURE;
+				return $this->fail_subpackage_selection( $input, $output, $e->getMessage() );
 			}
 		}
 
@@ -411,25 +402,16 @@ class RunE2ECommand extends QITCommand {
 						&& $subpackage_parent_dir !== null
 						&& $pkg_info['source'] === 'local'
 						&& realpath( $pkg_info['path'] ) === realpath( $subpackage_parent_dir ) ) {
-						$parent_manifest = new \QIT_CLI\PreCommand\Objects\TestPackageManifest( $pkg_info['manifest'] );
-						foreach ( $requested_subpackages as $subpackage_id ) {
-							try {
-								$subpackage_manifest = $parent_manifest->create_subpackage_manifest( $subpackage_id );
-							} catch ( \InvalidArgumentException $e ) {
-								// Defensive: the selection was validated before env:up ran.
-								throw new \RuntimeException( $e->getMessage() );
-							}
+						try {
+							$expanded = $this->expand_subpackages( $pkg_info, $requested_subpackages );
+						} catch ( \InvalidArgumentException $e ) {
+							// This should not happen, as we validate subpackages early on, but this
+							// serves as an additional defensive measure.
+							return $this->fail_subpackage_selection( $input, $output, $e->getMessage() );
+						}
 
-							$test_packages[ $subpackage_id ] = [
-								'manifest'       => $subpackage_manifest,
-								'path'           => $pkg_info['path'],           // Parent host dir (shared).
-								'container_path' => $pkg_info['container_path'], // Parent container path (shared mount).
-								'metadata'       => [
-									'downloaded_path' => $pkg_info['path'],
-									'version'         => 'local',
-									'remote'          => false,
-								],
-							];
+						foreach ( $expanded as $subpackage_id => $entry ) {
+							$test_packages[ $subpackage_id ] = $entry;
 						}
 						continue;
 					}
@@ -452,6 +434,23 @@ class RunE2ECommand extends QITCommand {
 						],
 					];
 				}
+			}
+		}
+
+		// Ensure that when --subpackage is used, every requested subpackage
+		// has an entry in $test_packages. This ensures we only run requested 
+		// subpackages and not the full parent package.
+		if ( ! empty( $requested_subpackages ) ) {
+			$missing_subpackages = array_diff( $requested_subpackages, array_keys( $test_packages ) );
+			if ( ! empty( $missing_subpackages ) ) {
+				return $this->fail_subpackage_selection(
+					$input,
+					$output,
+					sprintf(
+						"Failed to apply the --subpackage selection. The following subpackage(s) were not expanded from the local parent package:\n  - %s\n\nThe full parent package was NOT run, to avoid executing unintended tests.",
+						implode( "\n  - ", $missing_subpackages )
+					)
+				);
 			}
 		}
 
@@ -1194,6 +1193,60 @@ class RunE2ECommand extends QITCommand {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Expand a local parent test package into one entry per selected subpackage.
+	 *
+	 * All entries share the parent's host directory and container mount; only the
+	 * 'run' phase differs per subpackage.
+	 *
+	 * @param array<string,mixed> $pkg_info              Reconstructed parent package info from env_info (needs 'manifest', 'path', 'container_path').
+	 * @param array<string>       $requested_subpackages Subpackage IDs to expand.
+	 *
+	 * @return array<string,array<string,mixed>> Map of subpackage ID => reconstructed test package entry.
+	 * @throws \InvalidArgumentException If a subpackage manifest cannot be synthesized.
+	 */
+	private function expand_subpackages( array $pkg_info, array $requested_subpackages ): array {
+		$parent_manifest = new \QIT_CLI\PreCommand\Objects\TestPackageManifest( $pkg_info['manifest'] );
+		$entries         = [];
+
+		foreach ( $requested_subpackages as $subpackage_id ) {
+			$entries[ $subpackage_id ] = [
+				'manifest'       => $parent_manifest->create_subpackage_manifest( $subpackage_id ),
+				'path'           => $pkg_info['path'],           // Parent host dir (shared).
+				'container_path' => $pkg_info['container_path'], // Parent container path (shared mount).
+				'metadata'       => [
+					'downloaded_path' => $pkg_info['path'],
+					'version'         => 'local',
+					'remote'          => false,
+				],
+			];
+		}
+
+		return $entries;
+	}
+
+	/**
+	 * Emit a --subpackage selection failure using the command's output mode.
+	 *
+	 * @param QITInput        $input The input interface.
+	 * @param OutputInterface $output The output interface.
+	 * @param string          $message The error message.
+	 *
+	 * @return int The exit status.
+	 */
+	private function fail_subpackage_selection( QITInput $input, OutputInterface $output, string $message ): int {
+		if ( $input->getOption( 'json' ) ) {
+			$output->write( json_encode( [
+				'error'   => 'invalid_subpackage',
+				'message' => $message,
+			] ) );
+		} else {
+			$output->writeln( sprintf( '<error>%s</error>', $message ) );
+		}
+
+		return Command::FAILURE;
 	}
 
 

--- a/src/src/Commands/RunE2ECommand.php
+++ b/src/src/Commands/RunE2ECommand.php
@@ -140,6 +140,13 @@ class RunE2ECommand extends QITCommand {
 				'Test packages to include (multiple values allowed)',
 				[]
 			)
+			->addOption(
+				'subpackage',
+				null,
+				InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+				'Run only the given subpackage(s) of a single local test package (full ID, e.g. namespace/name; multiple allowed)',
+				[]
+			)
 			->reuseOption( 'env:up', 'environment' )
 			->reuseOption( 'env:up', 'php_version' )
 			->reuseOption( 'env:up', 'wordpress_version' )
@@ -183,6 +190,46 @@ class RunE2ECommand extends QITCommand {
 			$output->writeln( '<comment>To run E2E tests on Windows, please use WSL.</comment>' );
 
 			return self::FAILURE;
+		}
+
+		/* ─ Validate --subpackage selection (fail fast, before any expensive work) ─ */
+		$requested_subpackages = array_values( array_unique( array_filter( (array) $input->getOption( 'subpackage' ) ) ) );
+		$subpackage_parent_dir = null;
+		if ( ! empty( $requested_subpackages ) ) {
+			// Validate against user-supplied test packages only (profile + CLI).
+			// Env-config utilities are merged later and are exempt by construction.
+			$candidate_refs = array_map(
+				[ \QIT_CLI\Utils\PackageReferenceUtils::class, 'expand_local_path' ],
+				$input->get_test_packages()
+			);
+
+			// Mirror env:up's auto-detection: the current directory counts as a
+			// local test package when it contains a qit-test.json.
+			$cwd = getcwd();
+			if ( $cwd !== false && file_exists( $cwd . '/qit-test.json' ) ) {
+				$cwd_real     = realpath( $cwd );
+				$already_seen = array_filter( $candidate_refs, static function ( $ref ) use ( $cwd_real ) {
+					return is_dir( $ref ) && realpath( $ref ) === $cwd_real;
+				} );
+				if ( empty( $already_seen ) ) {
+					$candidate_refs[] = $cwd;
+				}
+			}
+
+			try {
+				$subpackage_parent_dir = \QIT_CLI\Utils\SubpackageSelector::validate_selection( $requested_subpackages, $candidate_refs );
+			} catch ( \RuntimeException $e ) {
+				if ( $input->getOption( 'json' ) ) {
+					$output->write( json_encode( [
+						'error'   => 'invalid_subpackage',
+						'message' => $e->getMessage(),
+					] ) );
+				} else {
+					$output->writeln( sprintf( '<error>%s</error>', $e->getMessage() ) );
+				}
+
+				return Command::FAILURE;
+			}
 		}
 
 		/* ─ Warn about unimplemented --async flag ─ */
@@ -355,6 +402,37 @@ class RunE2ECommand extends QITCommand {
 				// The package_id might be different (e.g., for local packages)
 				// Check if this package has manifest data (added by env:up)
 				if ( ! empty( $pkg_info['manifest'] ) ) {
+					// When --subpackage is used, expand the single local parent package
+					// into one entry per selected subpackage. All entries share the
+					// parent's host directory and container mount; only the 'run'
+					// phase differs per subpackage (pure subset contract).
+					if ( ! empty( $requested_subpackages )
+						&& $subpackage_parent_dir !== null
+						&& $pkg_info['source'] === 'local'
+						&& realpath( $pkg_info['path'] ) === realpath( $subpackage_parent_dir ) ) {
+						$parent_manifest = new \QIT_CLI\PreCommand\Objects\TestPackageManifest( $pkg_info['manifest'] );
+						foreach ( $requested_subpackages as $subpackage_id ) {
+							try {
+								$subpackage_manifest = $parent_manifest->create_subpackage_manifest( $subpackage_id );
+							} catch ( \InvalidArgumentException $e ) {
+								// Defensive: the selection was validated before env:up ran.
+								throw new \RuntimeException( $e->getMessage() );
+							}
+
+							$test_packages[ $subpackage_id ] = [
+								'manifest'       => $subpackage_manifest,
+								'path'           => $pkg_info['path'],           // Parent host dir (shared).
+								'container_path' => $pkg_info['container_path'], // Parent container path (shared mount).
+								'metadata'       => [
+									'downloaded_path' => $pkg_info['path'],
+									'version'         => 'local',
+									'remote'          => false,
+								],
+							];
+						}
+						continue;
+					}
+
 					// Determine version based on source
 					$version = 'local'; // Default for local packages
 					if ( $pkg_info['source'] === 'registry' && str_contains( $original_ref, ':' ) ) {
@@ -422,7 +500,9 @@ class RunE2ECommand extends QITCommand {
 		if ( ! empty( $test_packages ) ) {
 			foreach ( $test_packages as $pkg_id => $meta ) {
 				if ( ! empty( $meta['path'] ) ) {
-					$is_local                     = file_exists( $pkg_id ) && is_dir( $pkg_id );
+					// Keys are not always paths (e.g. subpackage IDs), so rely on
+					// the metadata built during reconstruction instead.
+					$is_local                     = $meta['metadata']['remote'] === false;
 					$package_local_map[ $pkg_id ] = $is_local;
 				}
 			}
@@ -459,9 +539,12 @@ class RunE2ECommand extends QITCommand {
 		$test_packages_metadata = [];
 		if ( ! empty( $test_packages ) ) {
 			foreach ( $test_packages as $pkg_id => $meta ) {
+				// Subpackage entries are keyed by subpackage ID and absent from
+				// test_packages_for_setup - they carry the parent's container path.
 				$test_packages_metadata[ $pkg_id ] = [
 					'path'           => $meta['path'],
-					'container_path' => $env_info->test_packages_for_setup[ $pkg_id ]['container_path'] ?? '',
+					'container_path' => $env_info->test_packages_for_setup[ $pkg_id ]['container_path']
+						?? ( $meta['container_path'] ?? '' ),
 				];
 			}
 		}

--- a/src/src/Commands/RunE2ECommand.php
+++ b/src/src/Commands/RunE2ECommand.php
@@ -438,7 +438,7 @@ class RunE2ECommand extends QITCommand {
 		}
 
 		// Ensure that when --subpackage is used, every requested subpackage
-		// has an entry in $test_packages. This ensures we only run requested 
+		// has an entry in $test_packages. This ensures we only run requested
 		// subpackages and not the full parent package.
 		if ( ! empty( $requested_subpackages ) ) {
 			$missing_subpackages = array_diff( $requested_subpackages, array_keys( $test_packages ) );

--- a/src/src/Commands/RunE2ECommand.php
+++ b/src/src/Commands/RunE2ECommand.php
@@ -143,8 +143,8 @@ class RunE2ECommand extends QITCommand {
 			->addOption(
 				'subpackage',
 				null,
-				InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
-				'Run only the given subpackage(s) of a single local test package (full ID, e.g. namespace/name; multiple allowed)',
+				InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+				'Run only the given subpackage(s) of a single local test package; the value(s) must match the subpackage ID(s) in the test package manifest',
 				[]
 			)
 			->reuseOption( 'env:up', 'environment' )

--- a/src/src/PreCommand/Download/TestPackageDownloader.php
+++ b/src/src/PreCommand/Download/TestPackageDownloader.php
@@ -961,7 +961,6 @@ class TestPackageDownloader {
 		}
 
 		try {
-			// Synthesis logic lives on the manifest so it can be reused outside the download flow.
 			return $parent_manifest->create_subpackage_manifest( $subpackage_id );
 		} catch ( \InvalidArgumentException $e ) {
 			// Preserve historical behavior: a subpackage without a 'run' phase is a runtime error here.

--- a/src/src/PreCommand/Download/TestPackageDownloader.php
+++ b/src/src/PreCommand/Download/TestPackageDownloader.php
@@ -948,8 +948,7 @@ class TestPackageDownloader {
 	 */
 	protected function extract_subpackage_manifest( TestPackageManifest $parent_manifest, string $subpackage_id ): ?TestPackageManifest {
 		// Check if parent has this subpackage
-		$subpackage_config = $parent_manifest->get_subpackage( $subpackage_id );
-		if ( ! $subpackage_config ) {
+		if ( ! $parent_manifest->get_subpackage( $subpackage_id ) ) {
 			if ( $this->output->isVeryVerbose() ) {
 				$this->output->writeln( "Subpackage $subpackage_id not found in parent manifest" );
 			}
@@ -958,69 +957,16 @@ class TestPackageDownloader {
 
 		if ( $this->output->isVeryVerbose() ) {
 			$this->output->writeln( "Found subpackage $subpackage_id in parent manifest" );
+			$this->output->writeln( 'Creating subpackage manifest with package ID: ' . $subpackage_id );
 		}
 
-		// Start with parent's complete configuration (subpackages inherit everything)
-		$parent_phases   = $parent_manifest->get_phases();
-		$subpackage_data = [
-			'package'        => $subpackage_id,
-			'parent_package' => $parent_manifest->get_package_id(),
-			'test_type'      => $parent_manifest->get_test_type(),
-			'test_dir'       => $parent_manifest->get_test_dir(),
-			'test'           => [
-				'phases'  => [
-					// Inherit ALL phases from parent
-					'globalSetup'    => $parent_phases['globalSetup'] ?? [],
-					'globalTeardown' => $parent_phases['globalTeardown'] ?? [],
-					'setup'          => $parent_phases['setup'] ?? [],
-					'run'            => [], // Will be overridden below
-					'teardown'       => $parent_phases['teardown'] ?? [],
-				],
-				// Results paths inherited from parent
-				'results' => $parent_manifest->get_test_results(),
-			],
-			// Inherit all other configurations from parent
-			'requires'       => $parent_manifest->get_requires(),
-			'mu_plugins'     => $parent_manifest->get_mu_plugins(),
-			'envs'           => $parent_manifest->get_env(),
-			'timeout'        => $parent_manifest->get_timeout(),
-			'retry'          => $parent_manifest->get_retry(),
-		];
-
-		// Apply subpackage-specific overrides (only metadata fields)
-		if ( isset( $subpackage_config['description'] ) ) {
-			$subpackage_data['description'] = $subpackage_config['description'];
+		try {
+			// Synthesis logic lives on the manifest so it can be reused outside the download flow.
+			return $parent_manifest->create_subpackage_manifest( $subpackage_id );
+		} catch ( \InvalidArgumentException $e ) {
+			// Preserve historical behavior: a subpackage without a 'run' phase is a runtime error here.
+			throw new \RuntimeException( $e->getMessage() );
 		}
-		if ( isset( $subpackage_config['tags'] ) ) {
-			$subpackage_data['tags'] = $subpackage_config['tags'];
-		}
-
-		// Subpackages can still override requires if needed (for metadata purposes)
-		if ( isset( $subpackage_config['requires'] ) ) {
-			$subpackage_data['requires'] = array_merge(
-				$parent_manifest->get_requires(),
-				$subpackage_config['requires']
-			);
-		}
-
-		// Override ONLY the run phase - this is the key difference for subpackages
-		if ( isset( $subpackage_config['test']['phases']['run'] ) ) {
-			$subpackage_data['test']['phases']['run'] = $subpackage_config['test']['phases']['run'];
-		} else {
-			// Subpackage must specify run phase
-			throw new \RuntimeException(
-				"Subpackage '{$subpackage_id}' must specify a 'run' phase. " .
-				'Subpackages exist to run a subset of tests from the parent package.'
-			);
-		}
-
-		// Debug the package field before creating manifest
-		if ( $this->output->isVeryVerbose() ) {
-			$this->output->writeln( 'Creating subpackage manifest with package ID: ' . $subpackage_data['package'] );
-		}
-
-		// Create and return the subpackage manifest
-		return new TestPackageManifest( $subpackage_data );
 	}
 
 	/**

--- a/src/src/PreCommand/Objects/TestPackageManifest.php
+++ b/src/src/PreCommand/Objects/TestPackageManifest.php
@@ -458,25 +458,21 @@ final class TestPackageManifest {
 			);
 		}
 
-		// Start with parent's complete configuration (subpackages inherit everything)
+		// Start with parent's complete configuration -- subpackages inherit everything _except_ the run phase.
 		$subpackage_data = [
 			'package'        => $subpackage_id,
 			'parent_package' => $this->package_id,
 			'test_type'      => $this->test_type,
 			'test_dir'       => $this->test_dir,
 			'test'           => [
-				'phases'  => [
-					// Inherit ALL phases from parent
-					'globalSetup'    => $this->phases['globalSetup'] ?? [],
-					'globalTeardown' => $this->phases['globalTeardown'] ?? [],
-					'setup'          => $this->phases['setup'] ?? [],
-					'run'            => [], // Will be overridden below
-					'teardown'       => $this->phases['teardown'] ?? [],
-				],
-				// Results paths inherited from parent
+				'phases'  => array_merge(
+					$this->phases,
+					[
+						'run' => []
+					]
+				),
 				'results' => $this->test_results,
 			],
-			// Inherit all other configurations from parent
 			'requires'       => $this->requires,
 			'mu_plugins'     => $this->mu_plugins,
 			'envs'           => $this->env_vars,
@@ -484,7 +480,7 @@ final class TestPackageManifest {
 			'retry'          => $this->retry,
 		];
 
-		// Apply subpackage-specific overrides (only metadata fields)
+		// Apply subpackage-specific overrides
 		if ( isset( $subpackage_config['description'] ) ) {
 			$subpackage_data['description'] = $subpackage_config['description'];
 		}
@@ -492,7 +488,6 @@ final class TestPackageManifest {
 			$subpackage_data['tags'] = $subpackage_config['tags'];
 		}
 
-		// Subpackages can still override requires if needed (for metadata purposes)
 		if ( isset( $subpackage_config['requires'] ) ) {
 			$subpackage_data['requires'] = array_merge(
 				$this->requires,
@@ -500,16 +495,15 @@ final class TestPackageManifest {
 			);
 		}
 
-		// Override ONLY the run phase - this is the key difference for subpackages
-		if ( isset( $subpackage_config['test']['phases']['run'] ) ) {
-			$subpackage_data['test']['phases']['run'] = $subpackage_config['test']['phases']['run'];
-		} else {
-			// Subpackage must specify run phase
+		if ( ! isset( $subpackage_config['test']['phases']['run'] ) ) {
 			throw new InvalidArgumentException(
 				"Subpackage '{$subpackage_id}' must specify a 'run' phase. " .
 				'Subpackages exist to run a subset of tests from the parent package.'
 			);
 		}
+
+		// Now override the run phase with the value from the subpackage.
+		$subpackage_data['test']['phases']['run'] = $subpackage_config['test']['phases']['run'];
 
 		return new TestPackageManifest( $subpackage_data );
 	}

--- a/src/src/PreCommand/Objects/TestPackageManifest.php
+++ b/src/src/PreCommand/Objects/TestPackageManifest.php
@@ -705,6 +705,7 @@ final class TestPackageManifest {
 			'retry'          => $this->retry,
 			'subpackages'    => $this->subpackages,
 			'parent_package' => $this->parent_package,
+			'actions'        => $this->actions,
 		];
 	}
 }

--- a/src/src/PreCommand/Objects/TestPackageManifest.php
+++ b/src/src/PreCommand/Objects/TestPackageManifest.php
@@ -72,8 +72,8 @@ final class TestPackageManifest {
 		// Package identification - handle v1 vs v2 format
 		if ( isset( $data['package'] ) && str_contains( $data['package'], '/' ) ) {
 			// v2 format: "package": "woocommerce/checkout"
-			$this->package_id                         = $data['package'];
-			[ $this->namespace, $this->package_name ] = explode( '/', $this->package_id, 2 );
+			$this->package_id = $data['package'];
+			$this->populate_namespace_and_package_name_from_package_id();
 		} elseif ( isset( $data['namespace'] ) && isset( $data['package'] ) ) {
 			// v1 format: separate namespace and package fields
 			$this->namespace    = $data['namespace'];
@@ -211,6 +211,17 @@ final class TestPackageManifest {
 			}
 		} else {
 			$this->requires_tunnel = false;
+		}
+	}
+
+	/**
+	 * Populate {@see $namespace} and {@see $package_name} from {@see $package_id}
+	 * when package_id is using the v2 package format, e.g. "woocommerce/checkout".
+	 */
+	protected function populate_namespace_and_package_name_from_package_id(): void {
+		if ( str_contains( $this->package_id, '/' ) ) {
+			// v2 format: "package": "woocommerce/checkout"
+			[ $this->namespace, $this->package_name ] = explode( '/', $this->package_id, 2 );
 		}
 	}
 
@@ -491,7 +502,11 @@ final class TestPackageManifest {
 
 		$package_data['phases']['run'] = $subpackage_config['test']['phases']['run'];
 
-		return new TestPackageManifest( $package_data );
+		$subpackage_manifest = new TestPackageManifest( $package_data );
+
+		$subpackage_manifest->populate_namespace_and_package_name_from_package_id();
+
+		return $subpackage_manifest;
 	}
 
 	public function requires_plugin( string $slug ): bool {

--- a/src/src/PreCommand/Objects/TestPackageManifest.php
+++ b/src/src/PreCommand/Objects/TestPackageManifest.php
@@ -467,8 +467,6 @@ final class TestPackageManifest {
 		$package_data['parent_package'] = $this->package_id;
 		$package_data['subpackages']    = [];
 
-		$package_data['phases']['run'] = [];
-
 		// Apply subpackage-specific overrides
 		if ( isset( $subpackage_config['description'] ) ) {
 			$package_data['description'] = $subpackage_config['description'];
@@ -483,7 +481,7 @@ final class TestPackageManifest {
 				$subpackage_config['requires']
 			);
 		}
- 
+
 		if ( ! isset( $subpackage_config['test']['phases']['run'] ) ) {
 			throw new InvalidArgumentException(
 				"Subpackage '{$subpackage_id}' must specify a 'run' phase. " .

--- a/src/src/PreCommand/Objects/TestPackageManifest.php
+++ b/src/src/PreCommand/Objects/TestPackageManifest.php
@@ -186,6 +186,7 @@ final class TestPackageManifest {
 		$this->retry          = $data['retry'];
 		$this->subpackages    = $data['subpackages'];
 		$this->parent_package = $data['parent_package'];
+		$this->actions        = $data['actions'] ?? [];
 		// For normalized data, only support new format (requires.network)
 		if ( isset( $data['requires']['network'] ) ) {
 			if ( is_string( $data['requires']['network'] ) ) {
@@ -258,6 +259,7 @@ final class TestPackageManifest {
 			'parent_package'   => $this->parent_package,
 			'requires_network' => $this->requires_network,
 			'requires_tunnel'  => $this->requires_tunnel,
+			'actions'          => $this->actions,
 		];
 	}
 

--- a/src/src/PreCommand/Objects/TestPackageManifest.php
+++ b/src/src/PreCommand/Objects/TestPackageManifest.php
@@ -437,6 +437,83 @@ final class TestPackageManifest {
 		return $this->subpackages[ $identifier ] ?? null;
 	}
 
+	/**
+	 * Synthesize a full manifest for one of this package's subpackages.
+	 *
+	 * Subpackages are pure subsets that inherit all configuration from the
+	 * parent except the 'run' phase, which they must override to select which
+	 * tests to execute. Note: subpackage-level 'requires' overrides are merged
+	 * for metadata purposes only — environment provisioning always uses the
+	 * parent manifest's requirements.
+	 *
+	 * @param string $subpackage_id The subpackage ID to synthesize (full ID, e.g. "namespace/name").
+	 * @return TestPackageManifest The synthesized subpackage manifest.
+	 * @throws InvalidArgumentException If the subpackage does not exist or lacks a 'run' phase.
+	 */
+	public function create_subpackage_manifest( string $subpackage_id ): TestPackageManifest {
+		$subpackage_config = $this->get_subpackage( $subpackage_id );
+		if ( ! $subpackage_config ) {
+			throw new InvalidArgumentException(
+				"Subpackage '{$subpackage_id}' not found in package '{$this->package_id}'."
+			);
+		}
+
+		// Start with parent's complete configuration (subpackages inherit everything)
+		$subpackage_data = [
+			'package'        => $subpackage_id,
+			'parent_package' => $this->package_id,
+			'test_type'      => $this->test_type,
+			'test_dir'       => $this->test_dir,
+			'test'           => [
+				'phases'  => [
+					// Inherit ALL phases from parent
+					'globalSetup'    => $this->phases['globalSetup'] ?? [],
+					'globalTeardown' => $this->phases['globalTeardown'] ?? [],
+					'setup'          => $this->phases['setup'] ?? [],
+					'run'            => [], // Will be overridden below
+					'teardown'       => $this->phases['teardown'] ?? [],
+				],
+				// Results paths inherited from parent
+				'results' => $this->test_results,
+			],
+			// Inherit all other configurations from parent
+			'requires'       => $this->requires,
+			'mu_plugins'     => $this->mu_plugins,
+			'envs'           => $this->env_vars,
+			'timeout'        => $this->timeout,
+			'retry'          => $this->retry,
+		];
+
+		// Apply subpackage-specific overrides (only metadata fields)
+		if ( isset( $subpackage_config['description'] ) ) {
+			$subpackage_data['description'] = $subpackage_config['description'];
+		}
+		if ( isset( $subpackage_config['tags'] ) ) {
+			$subpackage_data['tags'] = $subpackage_config['tags'];
+		}
+
+		// Subpackages can still override requires if needed (for metadata purposes)
+		if ( isset( $subpackage_config['requires'] ) ) {
+			$subpackage_data['requires'] = array_merge(
+				$this->requires,
+				$subpackage_config['requires']
+			);
+		}
+
+		// Override ONLY the run phase - this is the key difference for subpackages
+		if ( isset( $subpackage_config['test']['phases']['run'] ) ) {
+			$subpackage_data['test']['phases']['run'] = $subpackage_config['test']['phases']['run'];
+		} else {
+			// Subpackage must specify run phase
+			throw new InvalidArgumentException(
+				"Subpackage '{$subpackage_id}' must specify a 'run' phase. " .
+				'Subpackages exist to run a subset of tests from the parent package.'
+			);
+		}
+
+		return new TestPackageManifest( $subpackage_data );
+	}
+
 	public function requires_plugin( string $slug ): bool {
 		// Now plugins is an array, check if slug is in the array
 		return isset( $this->requires['plugins'] ) &&

--- a/src/src/PreCommand/Objects/TestPackageManifest.php
+++ b/src/src/PreCommand/Objects/TestPackageManifest.php
@@ -468,7 +468,7 @@ final class TestPackageManifest {
 				'phases'  => array_merge(
 					$this->phases,
 					[
-						'run' => []
+						'run' => [],
 					]
 				),
 				'results' => $this->test_results,

--- a/src/src/PreCommand/Objects/TestPackageManifest.php
+++ b/src/src/PreCommand/Objects/TestPackageManifest.php
@@ -458,43 +458,30 @@ final class TestPackageManifest {
 			);
 		}
 
-		// Start with parent's complete configuration -- subpackages inherit everything _except_ the run phase.
-		$subpackage_data = [
-			'package'        => $subpackage_id,
-			'parent_package' => $this->package_id,
-			'test_type'      => $this->test_type,
-			'test_dir'       => $this->test_dir,
-			'test'           => [
-				'phases'  => array_merge(
-					$this->phases,
-					[
-						'run' => [],
-					]
-				),
-				'results' => $this->test_results,
-			],
-			'requires'       => $this->requires,
-			'mu_plugins'     => $this->mu_plugins,
-			'envs'           => $this->env_vars,
-			'timeout'        => $this->timeout,
-			'retry'          => $this->retry,
-		];
+		// Start with parent's complete configuration.
+		$package_data = $this->to_array();
+
+		$package_data['package_id']     = $subpackage_id;
+		$package_data['parent_package'] = $this->package_id;
+		$package_data['subpackages']    = [];
+
+		$package_data['phases']['run'] = [];
 
 		// Apply subpackage-specific overrides
 		if ( isset( $subpackage_config['description'] ) ) {
-			$subpackage_data['description'] = $subpackage_config['description'];
+			$package_data['description'] = $subpackage_config['description'];
 		}
 		if ( isset( $subpackage_config['tags'] ) ) {
-			$subpackage_data['tags'] = $subpackage_config['tags'];
+			$package_data['tags'] = $subpackage_config['tags'];
 		}
 
 		if ( isset( $subpackage_config['requires'] ) ) {
-			$subpackage_data['requires'] = array_merge(
+			$package_data['requires'] = array_merge(
 				$this->requires,
 				$subpackage_config['requires']
 			);
 		}
-
+ 
 		if ( ! isset( $subpackage_config['test']['phases']['run'] ) ) {
 			throw new InvalidArgumentException(
 				"Subpackage '{$subpackage_id}' must specify a 'run' phase. " .
@@ -502,10 +489,9 @@ final class TestPackageManifest {
 			);
 		}
 
-		// Now override the run phase with the value from the subpackage.
-		$subpackage_data['test']['phases']['run'] = $subpackage_config['test']['phases']['run'];
+		$package_data['phases']['run'] = $subpackage_config['test']['phases']['run'];
 
-		return new TestPackageManifest( $subpackage_data );
+		return new TestPackageManifest( $package_data );
 	}
 
 	public function requires_plugin( string $slug ): bool {

--- a/src/src/Utils/PackageReferenceUtils.php
+++ b/src/src/Utils/PackageReferenceUtils.php
@@ -180,6 +180,59 @@ class PackageReferenceUtils {
 	}
 
 	/**
+	 * Expand a possibly-relative local path reference to an absolute path.
+	 *
+	 * - Absolute paths are returned unchanged.
+	 * - Relative paths starting with '.' ('.', './x', '../x') are resolved via
+	 *   realpath(), falling back to manual construction from getcwd() when
+	 *   realpath() fails (e.g. permissions or non-existent intermediate dirs).
+	 * - Other references are resolved via realpath() when they exist locally;
+	 *   otherwise they are returned unchanged (likely remote references such
+	 *   as "vendor/package:1.0.0").
+	 *
+	 * @param string $reference The package reference.
+	 * @return string The expanded reference.
+	 */
+	public static function expand_local_path( string $reference ): string {
+		// Skip absolute paths (already absolute).
+		if ( substr( $reference, 0, 1 ) === '/' ) {
+			return $reference;
+		}
+
+		// Check if it's a relative path starting with . (includes ./, ., ../, etc.)
+		if ( substr( $reference, 0, 1 ) === '.' ) {
+			// Try realpath first, fall back to manual construction if it fails
+			$resolved = @realpath( $reference );
+			if ( $resolved === false ) {
+				// realpath failed (possibly due to permissions or non-existent path)
+				$cwd = getcwd();
+				if ( $cwd === false ) {
+					return $reference;
+				}
+				// For simple . and ./, use getcwd
+				if ( $reference === '.' || $reference === './' ) {
+					return $cwd;
+				}
+				// For other relative paths, construct manually
+				// This preserves the relative path structure even if intermediate dirs don't exist
+				return $cwd . '/' . $reference;
+			}
+			return $resolved;
+		}
+
+		// For other paths (not starting with . or /), try to resolve as local path
+		// If it exists locally, expand it; otherwise assume it's a package reference
+		$resolved = @realpath( $reference );
+		if ( $resolved !== false ) {
+			// Path exists locally, use the resolved absolute path
+			return $resolved;
+		}
+
+		// If realpath fails, leave it unchanged (likely a package reference like vendor/package:1.0.0)
+		return $reference;
+	}
+
+	/**
 	 * Read package ID from a local package's qit-test.json manifest.
 	 *
 	 * @param string $path Path to the package directory.

--- a/src/src/Utils/SubpackageSelector.php
+++ b/src/src/Utils/SubpackageSelector.php
@@ -3,7 +3,6 @@
 namespace QIT_CLI\Utils;
 
 use QIT_CLI\PreCommand\Configuration\Parser\TestPackageManifestParser;
-use QIT_CLI\Utils\PackageReferenceUtils;
 
 /**
  * Validates --subpackage selections against the supplied test packages.

--- a/src/src/Utils/SubpackageSelector.php
+++ b/src/src/Utils/SubpackageSelector.php
@@ -33,12 +33,20 @@ class SubpackageSelector {
 		foreach ( $package_refs as $ref ) {
 			if ( PackageReferenceUtils::is_local_reference( $ref ) ) {
 				$local_dir = PackageReferenceUtils::expand_local_path( $ref );
+
+				if ( ! is_dir( $local_dir ) ) {
+					throw new \RuntimeException(
+						"The local test package directory {$local_dir} does not exist for package {$ref}."
+					);
+				}
+
 				if ( ! file_exists( rtrim( $local_dir, '/' ) . '/qit-test.json' ) ) {
 					throw new \RuntimeException(
 						"The local test package directory {$local_dir} does not contain a qit-test.json file.\n" .
 						'Unable to validate the specified subpackages.'
 					);
 				}
+
 				$local_dirs[] = $local_dir;
 			} else {
 				$remote_refs[] = $ref;

--- a/src/src/Utils/SubpackageSelector.php
+++ b/src/src/Utils/SubpackageSelector.php
@@ -17,15 +17,13 @@ class SubpackageSelector {
 	/**
 	 * Validate a --subpackage selection against the candidate test packages.
 	 *
-	 * @param array<string> $subpackage_ids Requested subpackage IDs (full IDs, e.g. "namespace/name").
+	 * @param array<string> $subpackage_ids Requested subpackage IDs (full IDs, e.g. "namespace/name"). These values are expected to be normalized and unique.
 	 * @param array<string> $package_refs   Candidate test package references, with local paths already expanded to absolute paths.
 	 *
 	 * @return string Absolute path of the single local parent package directory.
 	 * @throws \RuntimeException On any violation.
 	 */
 	public static function validate_selection( array $subpackage_ids, array $package_refs ): string {
-		$subpackage_ids = array_values( array_unique( array_filter( $subpackage_ids ) ) );
-
 		// Classify each reference as a local package directory or a remote reference.
 		$local_dirs  = [];
 		$remote_refs = [];

--- a/src/src/Utils/SubpackageSelector.php
+++ b/src/src/Utils/SubpackageSelector.php
@@ -57,7 +57,7 @@ class SubpackageSelector {
 				'  - ' . implode( "\n  - ", $remote_refs ) . "\n" .
 				"\n" .
 				"To run a remote subpackage, reference it directly, e.g.:\n" .
-				'  --test-package namespace/subpackage:version'
+				'  --test-package namespace/package/subpackage:version'
 			);
 		}
 

--- a/src/src/Utils/SubpackageSelector.php
+++ b/src/src/Utils/SubpackageSelector.php
@@ -71,16 +71,17 @@ class SubpackageSelector {
 			);
 		}
 
-		if ( count( $local_dirs ) > 1 ) {
+		$normalized_local_dirs = array_values( array_unique( $local_dirs ) );
+		if ( count( $normalized_local_dirs ) > 1 ) {
 			throw new \RuntimeException(
-				'The --subpackage option requires exactly ONE local test package, but ' . count( $local_dirs ) . " were found:\n" .
-				'  - ' . implode( "\n  - ", $local_dirs ) . "\n" .
+				'The --subpackage option requires exactly ONE local test package, but ' . count( $normalized_local_dirs ) . " were found:\n" .
+				'  - ' . implode( "\n  - ", $normalized_local_dirs ) . "\n" .
 				"\n" .
 				'Remove the extra packages or run each selection separately.'
 			);
 		}
 
-		$parent_dir = $local_dirs[0];
+		$parent_dir = reset( $normalized_local_dirs );
 
 		// Ensure we have a valid test package manifest.
 		try {

--- a/src/src/Utils/SubpackageSelector.php
+++ b/src/src/Utils/SubpackageSelector.php
@@ -2,7 +2,7 @@
 
 namespace QIT_CLI\Utils;
 
-use QIT_CLI\PreCommand\Objects\TestPackageManifest;
+use QIT_CLI\PreCommand\Configuration\Parser\TestPackageManifestParser;
 use QIT_CLI\Utils\PackageReferenceUtils;
 
 /**
@@ -72,21 +72,13 @@ class SubpackageSelector {
 			);
 		}
 
-		$parent_dir    = $local_dirs[0];
-		$manifest_path = rtrim( $parent_dir, '/' ) . '/qit-test.json';
-		$manifest_data = json_decode( (string) file_get_contents( $manifest_path ), true );
+		$parent_dir = $local_dirs[0];
 
-		if ( json_last_error() !== JSON_ERROR_NONE ) {
-			throw new \RuntimeException( "Invalid JSON in {$manifest_path}: " . json_last_error_msg() );
-		}
-
-		if ( ! is_array( $manifest_data ) ) {
-			throw new \RuntimeException( "Invalid JSON in {$manifest_path}: expected an object." );
-		}
-
+		// Ensure we have a valid test package manifest.
 		try {
-			$manifest = new TestPackageManifest( $manifest_data );
+			$manifest = ( new TestPackageManifestParser() )->parse( $parent_dir );
 		} catch ( \InvalidArgumentException $e ) {
+			$manifest_path = rtrim( $parent_dir, '/' ) . '/qit-test.json';
 			throw new \RuntimeException( "Invalid test package manifest at {$manifest_path}: " . $e->getMessage() );
 		}
 
@@ -112,7 +104,7 @@ class SubpackageSelector {
 				);
 			}
 
-			// Fail fast if the subpackage is not runnable (e.g. missing a run phase).
+			// Validate that we can create a valid subpackage manifest.
 			try {
 				$manifest->create_subpackage_manifest( $subpackage_id );
 			} catch ( \InvalidArgumentException $e ) {

--- a/src/src/Utils/SubpackageSelector.php
+++ b/src/src/Utils/SubpackageSelector.php
@@ -110,6 +110,8 @@ class SubpackageSelector {
 				);
 			}
 
+			self::validate_subpackage_id( $subpackage_id );
+
 			// Validate that we can create a valid subpackage manifest.
 			try {
 				$manifest->create_subpackage_manifest( $subpackage_id );
@@ -119,5 +121,26 @@ class SubpackageSelector {
 		}
 
 		return $parent_dir;
+	}
+
+	/**
+	 * Validate a subpackage ID.
+	 *
+	 * @param string $subpackage_id The subpackage ID to validate.
+	 *
+	 * @return void
+	 * @throws \RuntimeException If the subpackage ID is invalid.
+	 */
+	private static function validate_subpackage_id( string $subpackage_id ): void {
+		if ( str_contains( $subpackage_id, '/' ) && ! str_starts_with( $subpackage_id, '/' ) && ! str_ends_with( $subpackage_id, '/' ) ) {
+			return;
+		}
+
+		throw new \RuntimeException(
+			sprintf(
+				"Invalid subpackage ID: '%s'. Subpackage IDs must be in the format 'namespace/subpackage'.",
+				$subpackage_id
+			)
+		);
 	}
 }

--- a/src/src/Utils/SubpackageSelector.php
+++ b/src/src/Utils/SubpackageSelector.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace QIT_CLI\Utils;
+
+use QIT_CLI\PreCommand\Objects\TestPackageManifest;
+
+/**
+ * Validates --subpackage selections against the supplied test packages.
+ *
+ * The --subpackage option only applies when exactly ONE local test package
+ * directory is supplied and no remote package references are present.
+ * Any violation is a hard error so the command fails fast, before any
+ * expensive work such as environment setup.
+ */
+class SubpackageSelector {
+
+	/**
+	 * Validate a --subpackage selection against the candidate test packages.
+	 *
+	 * @param array<string> $subpackage_ids Requested subpackage IDs (full IDs, e.g. "namespace/name").
+	 * @param array<string> $package_refs   Candidate test package references, with local paths already expanded to absolute paths.
+	 *
+	 * @return string Absolute path of the single local parent package directory.
+	 * @throws \RuntimeException On any violation.
+	 */
+	public static function validate_selection( array $subpackage_ids, array $package_refs ): string {
+		$subpackage_ids = array_values( array_unique( array_filter( $subpackage_ids ) ) );
+
+		// Classify each reference as a local package directory or a remote reference.
+		$local_dirs  = [];
+		$remote_refs = [];
+		foreach ( $package_refs as $ref ) {
+			if ( is_dir( $ref ) && file_exists( rtrim( $ref, '/' ) . '/qit-test.json' ) ) {
+				$local_dirs[] = $ref;
+			} else {
+				$remote_refs[] = $ref;
+			}
+		}
+
+		if ( ! empty( $remote_refs ) ) {
+			throw new \RuntimeException(
+				"The --subpackage option can only be used with a single local test package.\n" .
+				"Remote test package references are not allowed when using --subpackage:\n" .
+				'  - ' . implode( "\n  - ", $remote_refs ) . "\n" .
+				"\n" .
+				"To run a remote subpackage, reference it directly, e.g.:\n" .
+				'  --test-package namespace/subpackage:version'
+			);
+		}
+
+		if ( empty( $local_dirs ) ) {
+			throw new \RuntimeException(
+				"The --subpackage option requires a local test package.\n" .
+				'Provide one with --test-package <dir>, via qit.json, or run from a directory containing qit-test.json.'
+			);
+		}
+
+		if ( count( $local_dirs ) > 1 ) {
+			throw new \RuntimeException(
+				'The --subpackage option requires exactly ONE local test package, but ' . count( $local_dirs ) . " were found:\n" .
+				'  - ' . implode( "\n  - ", $local_dirs ) . "\n" .
+				"\n" .
+				'Remove the extra packages or run each selection separately.'
+			);
+		}
+
+		$parent_dir    = $local_dirs[0];
+		$manifest_path = rtrim( $parent_dir, '/' ) . '/qit-test.json';
+		$manifest_data = json_decode( (string) file_get_contents( $manifest_path ), true );
+
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			throw new \RuntimeException( "Invalid JSON in {$manifest_path}: " . json_last_error_msg() );
+		}
+
+		try {
+			$manifest = new TestPackageManifest( $manifest_data );
+		} catch ( \InvalidArgumentException $e ) {
+			throw new \RuntimeException( "Invalid test package manifest at {$manifest_path}: " . $e->getMessage() );
+		}
+
+		if ( ! $manifest->has_subpackages() ) {
+			throw new \RuntimeException(
+				sprintf(
+					"Test package '%s' (%s) does not define any subpackages in qit-test.json.",
+					$manifest->get_package_id(),
+					$parent_dir
+				)
+			);
+		}
+
+		foreach ( $subpackage_ids as $subpackage_id ) {
+			if ( $manifest->get_subpackage( $subpackage_id ) === null ) {
+				throw new \RuntimeException(
+					sprintf(
+						"Subpackage '%s' not found in test package '%s'.\nAvailable subpackages:\n  - %s",
+						$subpackage_id,
+						$manifest->get_package_id(),
+						implode( "\n  - ", array_keys( $manifest->get_subpackages() ) )
+					)
+				);
+			}
+		}
+
+		return $parent_dir;
+	}
+}

--- a/src/src/Utils/SubpackageSelector.php
+++ b/src/src/Utils/SubpackageSelector.php
@@ -72,6 +72,10 @@ class SubpackageSelector {
 			throw new \RuntimeException( "Invalid JSON in {$manifest_path}: " . json_last_error_msg() );
 		}
 
+		if ( ! is_array( $manifest_data ) ) {
+			throw new \RuntimeException( "Invalid JSON in {$manifest_path}: expected an object." );
+		}
+
 		try {
 			$manifest = new TestPackageManifest( $manifest_data );
 		} catch ( \InvalidArgumentException $e ) {

--- a/src/src/Utils/SubpackageSelector.php
+++ b/src/src/Utils/SubpackageSelector.php
@@ -36,7 +36,7 @@ class SubpackageSelector {
 				if ( ! file_exists( rtrim( $local_dir, '/' ) . '/qit-test.json' ) ) {
 					throw new \RuntimeException(
 						"The local test package directory {$local_dir} does not contain a qit-test.json file.\n" .
-						"Unable to validate the specified subpackages."
+						'Unable to validate the specified subpackages.'
 					);
 				}
 				$local_dirs[] = $local_dir;

--- a/src/src/Utils/SubpackageSelector.php
+++ b/src/src/Utils/SubpackageSelector.php
@@ -3,6 +3,7 @@
 namespace QIT_CLI\Utils;
 
 use QIT_CLI\PreCommand\Objects\TestPackageManifest;
+use QIT_CLI\Utils\PackageReferenceUtils;
 
 /**
  * Validates --subpackage selections against the supplied test packages.
@@ -30,8 +31,15 @@ class SubpackageSelector {
 		$local_dirs  = [];
 		$remote_refs = [];
 		foreach ( $package_refs as $ref ) {
-			if ( is_dir( $ref ) && file_exists( rtrim( $ref, '/' ) . '/qit-test.json' ) ) {
-				$local_dirs[] = $ref;
+			if ( PackageReferenceUtils::is_local_reference( $ref ) ) {
+				$local_dir = PackageReferenceUtils::expand_local_path( $ref );
+				if ( ! file_exists( rtrim( $local_dir, '/' ) . '/qit-test.json' ) ) {
+					throw new \RuntimeException(
+						"The local test package directory {$local_dir} does not contain a qit-test.json file.\n" .
+						"Unable to validate the specified subpackages."
+					);
+				}
+				$local_dirs[] = $local_dir;
 			} else {
 				$remote_refs[] = $ref;
 			}

--- a/src/src/Utils/SubpackageSelector.php
+++ b/src/src/Utils/SubpackageSelector.php
@@ -99,6 +99,13 @@ class SubpackageSelector {
 					)
 				);
 			}
+
+			// Fail fast if the subpackage is not runnable (e.g. missing a run phase).
+			try {
+				$manifest->create_subpackage_manifest( $subpackage_id );
+			} catch ( \InvalidArgumentException $e ) {
+				throw new \RuntimeException( $e->getMessage() );
+			}
 		}
 
 		return $parent_dir;

--- a/src/tests/integration/tests/Commands/RunE2ECommandTest.php
+++ b/src/tests/integration/tests/Commands/RunE2ECommandTest.php
@@ -238,6 +238,7 @@ class RunE2ECommandTest extends TestCase {
 		$tempDir = null;
 		$packageDir = null;
 		$pluginDir = null;
+		$subpackageId = null;
 
 		try {
 			$tempDir = sys_get_temp_dir() . '/qit-test-' . uniqid();
@@ -297,42 +298,33 @@ test('site loads', async ({ page }) => {
 			file_put_contents( $configPath, json_encode( $qit_json, JSON_PRETTY_PRINT ) );
 
 			if ( $subpackage ) {
-				$subpackageDir = $packageDir . '/test-subpackage';
-				mkdir( $subpackageDir, 0755, true );
+				// Modify the existing manifest to add a subpackage.
+				$manifestPath = $packageDir . '/qit-test.json';
+				$manifest     = json_decode( (string) file_get_contents( $manifestPath ), true );
 
-				$qit_test_json = [
-					'package'      => 'woocommerce/plugin-test-package',
-					'package_type' => 'test',
-					'description'  => 'Test package for testing the plugin',
-					'test_type'    => 'e2e',
-					'test'         => [
-						'phases' => [
-							'setup' => [
-								"echo 'Setting up test package'",
-							],
-							'run'   => [
-								"npx playwright test $testFile",
-							],
-						],
-					],
-					'subpackages'  => [
-						'woocommerce/plugin-test-package-subpackage' => [
-							'description' => 'Test subpackage for testing the plugin',
-							'test' => [
-								'phases' => [
-									'setup' => [
-										"echo 'Setting up SUBPACKAGE'",
-									],
-									'run'   => [
-										"npx playwright test $testFile",
-									],
+				// Add output to the parent package's setup phase.
+				$manifest['test']['phases']['setup']   = $manifest['test']['phases']['setup'] ?? [];
+				$manifest['test']['phases']['setup'][] = "echo 'INHERITED_PARENT_SETUP'";
+
+				$parentPackage = $manifest['package'];
+				$subpackageId  = $parentPackage . '-subpackage';
+
+				$manifest['subpackages'] = [
+					$subpackageId => [
+						'description' => 'Subpackage that runs only the example spec',
+						'test' => [
+							'phases' => [
+								// Add custom output to the subpackage's run phase for later verification.
+								'run' => [
+									"echo 'RUNNING_SUBPACKAGE'",
+									"npx playwright test $testFile",
 								],
 							],
 						],
 					],
 				];
 
-				file_put_contents( $packageDir . '/qit-test.json', json_encode( $qit_test_json, JSON_PRETTY_PRINT ) );
+				file_put_contents( $manifestPath, json_encode( $manifest, JSON_PRETTY_PRINT ) );
 			}
 
 			// Run the test
@@ -344,7 +336,7 @@ test('site loads', async ({ page }) => {
 			}
 			if ( $subpackage ) {
 				$qit_args[] = '--subpackage';
-				$qit_args[] = 'woocommerce/plugin-test-package-subpackage';
+				$qit_args[] = $subpackageId;
 			}
 
 			$proc = qit( $qit_args, return_process: true );
@@ -357,7 +349,10 @@ test('site loads', async ({ page }) => {
 			$this->assertStringContainsString( 'Running Test Packages', $output );
 
 			if ( $subpackage ) {
-				$this->assertStringContainsString( 'Setting up SUBPACKAGE', $output );
+				// Confirm the subpackage 'run' phase output is present.
+				$this->assertStringContainsString( 'RUNNING_SUBPACKAGE', $output );
+				// Confirm the parent package's 'setup' phase output is present.
+				$this->assertStringContainsString( 'INHERITED_PARENT_SETUP', $output );
 			}
 
 			// The test should complete - we're testing the workflow, not the actual plugin functionality

--- a/src/tests/integration/tests/Commands/RunE2ECommandTest.php
+++ b/src/tests/integration/tests/Commands/RunE2ECommandTest.php
@@ -210,22 +210,45 @@ class RunE2ECommandTest extends TestCase {
 	}
 
 	/**
-	 * Test running e2e with local test package and custom plugin.
+	 * Provide test cases for {@see test_run_e2e_with_local_package()}.
 	 */
-	public function test_run_e2e_with_local_package_and_custom_plugin(): void {
+	public function provide_test_run_e2e_with_local_package_test_cases(): array {
+		return [
+			'custom plugin' => [
+				'custom_plugin' => true,
+				'subpackage'    => false,
+			],
+			'subpackage specified' => [
+				'custom_plugin' => false,
+				'subpackage'    => true,
+			],
+			'custom plugin and subpackage specified' => [
+				'custom_plugin' => true,
+				'subpackage'    => true,
+			],
+		];
+	}
+
+	/**
+	 * Test running e2e with local test package and custom plugin.
+	 *
+	 * @dataProvider provide_test_run_e2e_with_local_package_test_cases
+	 */
+	public function test_run_e2e_with_local_package( bool $custom_plugin, bool $subpackage ): void {
 		$tempDir = null;
 		$packageDir = null;
 		$pluginDir = null;
-		
+
 		try {
 			$tempDir = sys_get_temp_dir() . '/qit-test-' . uniqid();
 			mkdir( $tempDir, 0755, true );
 			$packageDir = $tempDir . '/test-package';
 			$pluginDir = $tempDir . '/test-plugin';
-			
-			// Create a simple test plugin
-			mkdir( $pluginDir, 0755, true );
-			file_put_contents( $pluginDir . '/test-plugin.php', '<?php
+
+			if ( $custom_plugin ) {
+				// Create a simple test plugin
+				mkdir( $pluginDir, 0755, true );
+				file_put_contents( $pluginDir . '/test-plugin.php', '<?php
 /**
  * Plugin Name: Test Plugin
  * Version: 1.0.0
@@ -235,8 +258,9 @@ add_action( "wp_body_open", function() {
 	echo "<div style=\"display:none\" id=\"test-plugin-marker\">Test plugin is active!</div>";
 } );
 ' );
-			
-			// Scaffold a test package that tests for the plugin
+			}
+
+			// Scaffold a test package
 			qit( [
 				'package:scaffold',
 				$packageDir,
@@ -245,11 +269,11 @@ add_action( "wp_body_open", function() {
 				'--framework=playwright',
 			] );
 			
-			// Modify the test to just check if the site loads with the plugin
+			// Modify the test to just check if the site loads
 			$testFile = $packageDir . '/tests/example.spec.js';
 			file_put_contents( $testFile, "import { test, expect } from '@playwright/test';
 
-test('site loads with custom plugin', async ({ page }) => {
+test('site loads', async ({ page }) => {
   const response = await page.goto('/');
   expect(response?.status()).toBe(200);
   
@@ -271,14 +295,59 @@ test('site loads with custom plugin', async ({ page }) => {
 			
 			$configPath = $tempDir . '/qit.json';
 			file_put_contents( $configPath, json_encode( $qit_json, JSON_PRETTY_PRINT ) );
-			
-			// Run the test with our custom plugin
-			$proc = qit( [
-				'run:e2e',
-				'woocommerce',
-				'--plugin', realpath( $pluginDir ),
-				'--config', $configPath,
-			], return_process: true );
+
+			if ( $subpackage ) {
+				$subpackageDir = $packageDir . '/test-subpackage';
+				mkdir( $subpackageDir, 0755, true );
+
+				$qit_test_json = [
+					'package'      => 'woocommerce/plugin-test-package',
+					'package_type' => 'test',
+					'description'  => 'Test package for testing the plugin',
+					'test_type'    => 'e2e',
+					'test'         => [
+						'phases' => [
+							'setup' => [
+								"echo 'Setting up test package'",
+							],
+							'run'   => [
+								"npx playwright test $testFile",
+							],
+						],
+					],
+					'subpackages'  => [
+						'woocommerce/plugin-test-package-subpackage' => [
+							'description' => 'Test subpackage for testing the plugin',
+							'test' => [
+								'phases' => [
+									'setup' => [
+										"echo 'Setting up SUBPACKAGE'",
+									],
+									'run'   => [
+										"npx playwright test $testFile",
+									],
+								],
+							],
+						],
+					],
+				];
+
+				file_put_contents( $packageDir . '/qit-test.json', json_encode( $qit_test_json, JSON_PRETTY_PRINT ) );
+			}
+
+			// Run the test
+			$qit_args = [ 'run:e2e', 'woocommerce', '--config', $configPath ];
+
+			if ( $custom_plugin ) {
+				$qit_args[] = '--plugin';
+				$qit_args[] = realpath( $pluginDir );
+			}
+			if ( $subpackage ) {
+				$qit_args[] = '--subpackage';
+				$qit_args[] = 'woocommerce/plugin-test-package-subpackage';
+			}
+
+			$proc = qit( $qit_args, return_process: true );
 			
 			$output = $proc->getOutput();
 			$exitCode = $proc->getExitCode();
@@ -286,7 +355,11 @@ test('site loads with custom plugin', async ({ page }) => {
 			// Verify the test ran
 			$this->assertStringContainsString( 'Using local package: ' . $packageDir, $output );
 			$this->assertStringContainsString( 'Running Test Packages', $output );
-			
+
+			if ( $subpackage ) {
+				$this->assertStringContainsString( 'Setting up SUBPACKAGE', $output );
+			}
+
 			// The test should complete - we're testing the workflow, not the actual plugin functionality
 			// The plugin might not be activated by default in the test environment
 			$this->assertContains( $exitCode, [0, 1], 'Test should complete. Output: ' . $output );

--- a/src/tests/integration/tests/Commands/RunE2ECommandTest.php
+++ b/src/tests/integration/tests/Commands/RunE2ECommandTest.php
@@ -271,7 +271,8 @@ add_action( "wp_body_open", function() {
 			] );
 			
 			// Modify the test to just check if the site loads
-			$testFile = $packageDir . '/tests/example.spec.js';
+			$testFileRelativePath = 'tests/example.spec.js';
+			$testFile = $packageDir . '/' . $testFileRelativePath;
 			file_put_contents( $testFile, "import { test, expect } from '@playwright/test';
 
 test('site loads', async ({ page }) => {
@@ -317,7 +318,7 @@ test('site loads', async ({ page }) => {
 								// Add custom output to the subpackage's run phase for later verification.
 								'run' => [
 									"echo 'RUNNING_SUBPACKAGE'",
-									"npx playwright test $testFile",
+									"npx playwright test $testFileRelativePath",
 								],
 							],
 						],

--- a/src/tests/integration/tests/TestPackages/Packages/Subpackages/LocalSubpackageExecutionTest.php
+++ b/src/tests/integration/tests/TestPackages/Packages/Subpackages/LocalSubpackageExecutionTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace QIT\IntegrationTests\TestPackages\Packages\Subpackages;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use QIT\IntegrationTests\TestCleanupHelper;
+use function qit;
+
+/**
+ * Test execution of local subpackages selected via the --subpackage option.
+ *
+ * Fixtures:
+ * - subpackages-parent: Main package with 3 subpackages (checkout, cart, account)
+ */
+#[Group( 'docker' )]
+class LocalSubpackageExecutionTest extends TestCase {
+
+	private string $fixturesDir;
+	private array $tempDirs = [];
+	private string $originalCwd;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->fixturesDir = QIT_INTEGRATION_TESTS_ROOT . '/fixtures/test-packages';
+		$this->originalCwd = getcwd();
+
+		// Clean up any leftover test packages before running
+		TestCleanupHelper::cleanup_all_test_packages();
+	}
+
+	protected function tearDown(): void {
+		chdir( $this->originalCwd );
+
+		// Clean up any test packages created during the test
+		TestCleanupHelper::cleanup_all_test_packages();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test running a single subpackage of a local test package.
+	 */
+	public function test_single_local_subpackage_runs_only_its_tests(): void {
+		$config = $this->createConfig( [
+			$this->fixturesDir . '/subpackages-parent',
+		] );
+
+		$proc = qit( [
+			'run:e2e',
+			'woocommerce',
+			'--config=' . $config,
+			'--subpackage=woocommerce/qit-integration-test-checkout',
+		], return_process: true );
+
+		$output   = $proc->getOutput();
+		$exitCode = $proc->getExitCode();
+
+		$this->assertEquals( 0, $exitCode,
+			'Subpackage selection should run successfully. Output: ' . $output );
+
+		// Only the selected subpackage's run phase should execute.
+		$this->assertStringContainsString( 'checkout.spec.js', $output,
+			'Checkout subpackage test should execute' );
+		$this->assertStringNotContainsString( 'all.spec.js', $output,
+			'Parent run phase should NOT execute' );
+		$this->assertStringNotContainsString( 'cart.spec.js', $output,
+			'Cart subpackage should NOT execute' );
+		$this->assertStringNotContainsString( 'account.spec.js', $output,
+			'Account subpackage should NOT execute' );
+
+		// Inherited phases from the parent should execute.
+		$this->assertStringContainsString( '[GLOBAL_SETUP]', $output,
+			'Inherited globalSetup should execute' );
+		$this->assertStringContainsString( '[SETUP] Package-specific', $output,
+			'Inherited setup should execute' );
+
+		// Global setup should run exactly once.
+		$this->assertEquals( 1, substr_count( $output, '[GLOBAL_SETUP]' ),
+			'Global setup should run exactly once' );
+
+		// Only one package should execute.
+		$this->assertStringContainsString( 'PACKAGE [1/1]', $output,
+			'Should show only 1 package executing' );
+
+		// The subpackage runs as a local package.
+		$this->assertStringContainsString( 'woocommerce/qit-integration-test-checkout:local', $output,
+			'Subpackage should be identified as a local package' );
+	}
+
+	/**
+	 * Test running multiple subpackages of the same local parent.
+	 */
+	public function test_multiple_local_subpackages_run_with_dedup(): void {
+		$config = $this->createConfig( [
+			$this->fixturesDir . '/subpackages-parent',
+		] );
+
+		$proc = qit( [
+			'run:e2e',
+			'woocommerce',
+			'--config=' . $config,
+			'--subpackage=woocommerce/qit-integration-test-checkout',
+			'--subpackage=woocommerce/qit-integration-test-cart',
+		], return_process: true );
+
+		$output = $proc->getOutput();
+
+		$this->assertEquals( 0, $proc->getExitCode(),
+			'Multiple subpackage selections should run successfully. Output: ' . $output );
+
+		// Both selected subpackages should run.
+		$this->assertStringContainsString( 'checkout.spec.js', $output,
+			'Checkout subpackage test should execute' );
+		$this->assertStringContainsString( 'cart.spec.js', $output,
+			'Cart subpackage test should execute' );
+
+		// Parent and unselected subpackage should not run.
+		$this->assertStringNotContainsString( 'all.spec.js', $output,
+			'Parent run phase should NOT execute' );
+		$this->assertStringNotContainsString( 'account.spec.js', $output,
+			'Account subpackage should NOT execute' );
+
+		// Two packages should execute.
+		$this->assertStringContainsString( 'PACKAGE [1/2]', $output,
+			'Should show package 1 of 2' );
+		$this->assertStringContainsString( 'PACKAGE [2/2]', $output,
+			'Should show package 2 of 2' );
+
+		// Shared inherited globalSetup should be deduplicated (runs once).
+		$this->assertEquals( 1, substr_count( $output, '[GLOBAL_SETUP]' ),
+			'Inherited globalSetup should run exactly once (deduplicated)' );
+	}
+
+	/**
+	 * Test running a subpackage with the parent auto-detected from cwd.
+	 */
+	public function test_subpackage_with_cwd_auto_detected_parent(): void {
+		// Run from inside the fixture - no --test-package or config needed.
+		chdir( $this->fixturesDir . '/subpackages-parent' );
+
+		$proc = qit( [
+			'run:e2e',
+			'woocommerce',
+			'--subpackage=woocommerce/qit-integration-test-checkout',
+		], return_process: true );
+
+		$output = $proc->getOutput();
+
+		$this->assertEquals( 0, $proc->getExitCode(),
+			'Auto-detected parent with --subpackage should run successfully. Output: ' . $output );
+
+		$this->assertStringContainsString( 'checkout.spec.js', $output,
+			'Checkout subpackage test should execute' );
+		$this->assertStringNotContainsString( 'all.spec.js', $output,
+			'Parent run phase should NOT execute' );
+	}
+
+	/**
+	 * Helper: Create a temporary config file
+	 */
+	private function createConfig( array $packagePaths ): string {
+		$tempDir = sys_get_temp_dir() . '/qit_local_subpkg_test_' . uniqid();
+		$this->tempDirs[] = $tempDir;
+		mkdir( $tempDir, 0755, true );
+
+		$config = [
+			'$schema'      => 'https://raw.githubusercontent.com/woocommerce/qit-cli/trunk/src/src/PreCommand/Schemas/qit-schema.json',
+			'sut'          => [
+				'type'   => 'plugin',
+				'slug'   => 'woocommerce',
+				'source' => [ 'type' => 'wporg' ],
+			],
+			'test_types'   => [
+				'e2e' => [
+					'default' => [
+						'test_packages' => $packagePaths,
+					],
+				],
+			],
+			'environments' => [
+				'default' => [
+					'php' => '8.2',
+					'wp'  => 'stable',
+				],
+			],
+		];
+
+		$configPath = $tempDir . '/qit.json';
+		file_put_contents( $configPath, json_encode( $config, JSON_PRETTY_PRINT ) );
+
+		return $configPath;
+	}
+}

--- a/src/tests/integration/tests/TestPackages/Packages/Subpackages/LocalSubpackageExecutionTest.php
+++ b/src/tests/integration/tests/TestPackages/Packages/Subpackages/LocalSubpackageExecutionTest.php
@@ -32,6 +32,17 @@ class LocalSubpackageExecutionTest extends TestCase {
 	protected function tearDown(): void {
 		chdir( $this->originalCwd );
 
+		foreach ( $this->tempDirs as $dir ) {
+			$config_path = $dir . '/qit.json';
+			if ( file_exists( $config_path ) ) {
+				unlink( $config_path );
+			}
+			if ( is_dir( $dir ) ) {
+				rmdir( $dir );
+			}
+		}
+		$this->tempDirs = [];
+
 		// Clean up any test packages created during the test
 		TestCleanupHelper::cleanup_all_test_packages();
 

--- a/src/tests/integration/tests/TestPackages/Packages/Subpackages/LocalSubpackageSelectionTest.php
+++ b/src/tests/integration/tests/TestPackages/Packages/Subpackages/LocalSubpackageSelectionTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace QIT\IntegrationTests\TestPackages\Packages\Subpackages;
+
+use PHPUnit\Framework\TestCase;
+use function qit;
+
+/**
+ * Test validation of the --subpackage option for run:e2e.
+ *
+ * The --subpackage option selects subpackages of a single LOCAL test package.
+ * These tests cover the fail-fast validation, which happens before any
+ * environment setup - so they don't need Docker.
+ */
+class LocalSubpackageSelectionTest extends TestCase {
+
+	private string $fixturesDir;
+	private string $originalCwd;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->fixturesDir = QIT_INTEGRATION_TESTS_ROOT . '/fixtures/test-packages';
+		$this->originalCwd = getcwd();
+	}
+
+	protected function tearDown(): void {
+		chdir( $this->originalCwd );
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that an unknown subpackage ID fails fast, listing the available IDs.
+	 */
+	public function test_unknown_subpackage_id_fails_with_available_list(): void {
+		$proc = qit( [
+			'run:e2e',
+			'woocommerce',
+			'--test-package=' . $this->fixturesDir . '/subpackages-parent',
+			'--subpackage=woocommerce/qit-integration-test-nonexistent',
+		], expected_exit_code: 1, return_process: true );
+
+		$output = $proc->getOutput() . "\n" . $proc->getErrorOutput();
+
+		$this->assertStringContainsString(
+			"Subpackage 'woocommerce/qit-integration-test-nonexistent' not found in test package 'woocommerce/qit-integration-test-e2e-suite'",
+			$output
+		);
+		// Available subpackages should be listed.
+		$this->assertStringContainsString( 'woocommerce/qit-integration-test-checkout', $output );
+		$this->assertStringContainsString( 'woocommerce/qit-integration-test-cart', $output );
+		$this->assertStringContainsString( 'woocommerce/qit-integration-test-account', $output );
+
+		// Validation must fail before any environment work starts.
+		$this->assertStringNotContainsString( 'Creating environment', $output );
+	}
+
+	/**
+	 * Test that short subpackage names are rejected - full IDs only.
+	 */
+	public function test_short_subpackage_name_is_rejected(): void {
+		$proc = qit( [
+			'run:e2e',
+			'woocommerce',
+			'--test-package=' . $this->fixturesDir . '/subpackages-parent',
+			'--subpackage=qit-integration-test-checkout',
+		], expected_exit_code: 1, return_process: true );
+
+		$output = $proc->getOutput() . "\n" . $proc->getErrorOutput();
+
+		$this->assertStringContainsString(
+			"Subpackage 'qit-integration-test-checkout' not found",
+			$output
+		);
+	}
+
+	/**
+	 * Test that combining --subpackage with a remote package reference fails.
+	 */
+	public function test_subpackage_with_remote_reference_fails(): void {
+		$proc = qit( [
+			'run:e2e',
+			'woocommerce',
+			'--test-package=' . $this->fixturesDir . '/subpackages-parent',
+			'--test-package=woocommerce/some-remote-package:latest',
+			'--subpackage=woocommerce/qit-integration-test-checkout',
+		], expected_exit_code: 1, return_process: true );
+
+		$output = $proc->getOutput() . "\n" . $proc->getErrorOutput();
+
+		$this->assertStringContainsString(
+			'Remote test package references are not allowed when using --subpackage',
+			$output
+		);
+		$this->assertStringContainsString( 'woocommerce/some-remote-package:latest', $output );
+	}
+
+	/**
+	 * Test that --subpackage with no local test package fails.
+	 */
+	public function test_subpackage_without_local_package_fails(): void {
+		// Run from a directory WITHOUT a qit-test.json and pass no --test-package.
+		chdir( sys_get_temp_dir() );
+
+		$proc = qit( [
+			'run:e2e',
+			'woocommerce',
+			'--subpackage=woocommerce/qit-integration-test-checkout',
+		], expected_exit_code: 1, return_process: true );
+
+		$output = $proc->getOutput() . "\n" . $proc->getErrorOutput();
+
+		$this->assertStringContainsString(
+			'The --subpackage option requires a local test package',
+			$output
+		);
+	}
+
+	/**
+	 * Test that --subpackage with multiple local test packages fails.
+	 */
+	public function test_subpackage_with_multiple_local_packages_fails(): void {
+		$proc = qit( [
+			'run:e2e',
+			'woocommerce',
+			'--test-package=' . $this->fixturesDir . '/subpackages-parent',
+			'--test-package=' . $this->fixturesDir . '/regular-test-package-one',
+			'--subpackage=woocommerce/qit-integration-test-checkout',
+		], expected_exit_code: 1, return_process: true );
+
+		$output = $proc->getOutput() . "\n" . $proc->getErrorOutput();
+
+		$this->assertStringContainsString(
+			'requires exactly ONE local test package, but 2 were found',
+			$output
+		);
+	}
+
+	/**
+	 * Test that --subpackage against a package with no subpackages fails.
+	 */
+	public function test_subpackage_against_package_without_subpackages_fails(): void {
+		$proc = qit( [
+			'run:e2e',
+			'woocommerce',
+			'--test-package=' . $this->fixturesDir . '/regular-test-package-one',
+			'--subpackage=woocommerce/qit-integration-test-checkout',
+		], expected_exit_code: 1, return_process: true );
+
+		$output = $proc->getOutput() . "\n" . $proc->getErrorOutput();
+
+		$this->assertStringContainsString( 'does not define any subpackages in qit-test.json', $output );
+	}
+
+	/**
+	 * Test that the current directory counts as the local package (auto-detect).
+	 */
+	public function test_cwd_auto_detection_counts_as_local_package(): void {
+		// Run from inside the fixture - no --test-package needed.
+		chdir( $this->fixturesDir . '/subpackages-parent' );
+
+		$proc = qit( [
+			'run:e2e',
+			'woocommerce',
+			'--subpackage=woocommerce/qit-integration-test-nonexistent',
+		], expected_exit_code: 1, return_process: true );
+
+		$output = $proc->getOutput() . "\n" . $proc->getErrorOutput();
+
+		// The 'not found' error (rather than 'requires a local test package')
+		// proves the cwd was auto-detected as the local parent package.
+		$this->assertStringContainsString(
+			"Subpackage 'woocommerce/qit-integration-test-nonexistent' not found in test package 'woocommerce/qit-integration-test-e2e-suite'",
+			$output
+		);
+	}
+
+	/**
+	 * Test that validation errors are emitted as JSON in --json mode.
+	 */
+	public function test_subpackage_validation_error_in_json_mode(): void {
+		$proc = qit( [
+			'run:e2e',
+			'woocommerce',
+			'--test-package=' . $this->fixturesDir . '/subpackages-parent',
+			'--subpackage=woocommerce/qit-integration-test-nonexistent',
+			'--json',
+		], expected_exit_code: 1, return_process: true );
+
+		$output = trim( $proc->getOutput() );
+
+		// The error payload is a JSON object on stdout; tolerate any preamble lines.
+		$json_start = strpos( $output, '{"error"' );
+		$this->assertNotFalse( $json_start, 'Output should contain a JSON error payload. Output: ' . $output );
+
+		$data = json_decode( substr( $output, $json_start ), true );
+		$this->assertNotNull( $data, 'Error payload should be valid JSON. Output: ' . $output );
+		$this->assertEquals( 'invalid_subpackage', $data['error'] ?? null );
+		$this->assertStringContainsString( 'not found in test package', $data['message'] ?? '' );
+	}
+}

--- a/src/tests/unit/PackageReferenceUtilsTest.php
+++ b/src/tests/unit/PackageReferenceUtilsTest.php
@@ -155,6 +155,38 @@ class PackageReferenceUtilsTest extends TestCase {
 	}
 
 	/**
+	 * Test expanding local path references to absolute paths.
+	 */
+	public function test_expand_local_path(): void {
+		// Absolute paths are returned unchanged.
+		$this->assertEquals( __DIR__, PackageReferenceUtils::expand_local_path( __DIR__ ) );
+		$this->assertEquals( '/this/path/does/not/exist', PackageReferenceUtils::expand_local_path( '/this/path/does/not/exist' ) );
+
+		// '.' resolves to the current working directory.
+		$this->assertEquals( realpath( getcwd() ), PackageReferenceUtils::expand_local_path( '.' ) );
+
+		// Non-existent relative paths fall back to manual construction from cwd.
+		$this->assertEquals(
+			getcwd() . '/./relative/does-not-exist',
+			PackageReferenceUtils::expand_local_path( './relative/does-not-exist' )
+		);
+		$this->assertEquals(
+			getcwd() . '/../does-not-exist',
+			PackageReferenceUtils::expand_local_path( '../does-not-exist' )
+		);
+
+		// Remote-looking references that don't resolve locally are unchanged.
+		$this->assertEquals(
+			'woocommerce/e2e:latest',
+			PackageReferenceUtils::expand_local_path( 'woocommerce/e2e:latest' )
+		);
+		$this->assertEquals(
+			'woocommerce/e2e/checkout:1.0.0',
+			PackageReferenceUtils::expand_local_path( 'woocommerce/e2e/checkout:1.0.0' )
+		);
+	}
+
+	/**
 	 * Test validating multiple references.
 	 */
 	public function test_validate_references(): void {

--- a/src/tests/unit/RunE2ESubpackageOptionTest.php
+++ b/src/tests/unit/RunE2ESubpackageOptionTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace QIT_CLI_Tests;
+
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\StringInput;
+
+/**
+ * Unit tests for the `--subpackage` option of the `run:e2e` QIT command.
+ */
+class RunE2ESubpackageOptionTest extends QITTestCase {
+
+	/**
+	 * Generate a {@see \Symfony\Component\Console\Input\StringInput} using the 
+	 * `run:e2e` command definition.
+	 *
+	 * @param string $cli The command line values, without the command name.
+	 *
+	 * @return StringInput The bound input.
+	 */
+	private function get_parsed_run_e2e_command_input( string $cli ): StringInput {
+		$command = $GLOBALS['qit_application']->find( 'run:e2e' );
+
+		$input = new StringInput( $cli );
+		$input->bind( $command->getDefinition() );
+
+		return $input;
+	}
+
+	/**
+	 * Provide test cases for {@see test_subpackage_option_handling()}.
+	 *
+	 * @return array<string,array{cli:string,expected:array<string>|null}>
+	 */
+	public function subpackage_option_provider(): array {
+		return [
+			'single value is returned'                   => [
+				'cli'      => '--subpackage woocommerce/my-subpackage',
+				'expected' => [ 'woocommerce/my-subpackage' ],
+			],
+			'multiple values are returned'               => [
+				'cli'      => '--subpackage woocommerce/sub-a --subpackage woocommerce/sub-b',
+				'expected' => [ 'woocommerce/sub-a', 'woocommerce/sub-b' ],
+			],
+			'no value when option is not specified'      => [
+				'cli'      => 'woocommerce',
+				'expected' => [],
+			],
+			'option without value is rejected'           => [
+				'cli'      => '--subpackage',
+				'expected' => null,
+			],
+			'option without value before another option' => [
+				'cli'      => '--subpackage --json',
+				'expected' => null,
+			],
+		];
+	}
+
+	/**
+	 * Test that the `--subpackage` option is handled correctly.
+	 *
+	 * @dataProvider subpackage_option_provider
+	 *
+	 * @param string             $cli      The command line input value, without the `run:e2e` command.
+	 * @param array<string>|null $expected Expected option value, or null when the input should be rejected.
+	 */
+	public function test_subpackage_option_handling( string $cli, ?array $expected ): void {
+		if ( null === $expected ) {
+			$this->expectException( RuntimeException::class );
+			$this->expectExceptionMessage( 'The "--subpackage" option requires a value.' );
+		}
+
+		$input = $this->get_parsed_run_e2e_command_input( $cli );
+
+		$this->assertSame( $expected, $input->getOption( 'subpackage' ) );
+	}
+}

--- a/src/tests/unit/RunE2ESubpackageOptionTest.php
+++ b/src/tests/unit/RunE2ESubpackageOptionTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\StringInput;
 class RunE2ESubpackageOptionTest extends QITTestCase {
 
 	/**
-	 * Generate a {@see \Symfony\Component\Console\Input\StringInput} using the 
+	 * Generate a {@see \Symfony\Component\Console\Input\StringInput} using the
 	 * `run:e2e` command definition.
 	 *
 	 * @param string $cli The command line values, without the command name.

--- a/src/tests/unit/SubpackageSelectorTest.php
+++ b/src/tests/unit/SubpackageSelectorTest.php
@@ -44,20 +44,33 @@ class SubpackageSelectorTest extends TestCase {
 	}
 
 	/**
-	 * @return array<string,mixed> A parent manifest with two subpackages.
+	 * A schema-valid e2e results block (ctrf-json + blob-dir are required for e2e).
+	 *
+	 * @return array<string,string>
+	 */
+	private function get_e2e_results_config(): array {
+		return [
+			'ctrf-json' => './results/ctrf.json',
+			'blob-dir'  => './blob-report',
+		];
+	}
+
+	/**
+	 * @return array<string,mixed> A schema-valid parent manifest with two subpackages.
 	 */
 	private function get_parent_manifest_data(): array {
 		return [
-			'package' => 'woocommerce/e2e-suite',
-			'test' => [
-				'phases' => [ 'run' => [ 'npx playwright test' ] ],
-				'results' => [],
+			'package'     => 'woocommerce/e2e-suite',
+			'test_type'   => 'e2e',
+			'test'        => [
+				'phases'  => [ 'run' => [ 'npx playwright test' ] ],
+				'results' => $this->get_e2e_results_config(),
 			],
 			'subpackages' => [
 				'woocommerce/checkout' => [
 					'test' => [ 'phases' => [ 'run' => [ 'npx playwright test tests/checkout.spec.js' ] ] ],
 				],
-				'woocommerce/cart' => [
+				'woocommerce/cart'     => [
 					'test' => [ 'phases' => [ 'run' => [ 'npx playwright test tests/cart.spec.js' ] ] ],
 				],
 			],
@@ -98,14 +111,16 @@ class SubpackageSelectorTest extends TestCase {
 	public function test_remote_reference_is_rejected(): void {
 		$dir = $this->create_package_dir( $this->get_parent_manifest_data() );
 
-		$this->expectException( \RuntimeException::class );
-		$this->expectExceptionMessage( 'Remote test package references are not allowed when using --subpackage' );
-		$this->expectExceptionMessage( 'woocommerce/e2e:latest' );
-
-		SubpackageSelector::validate_selection(
-			[ 'woocommerce/checkout' ],
-			[ $dir, 'woocommerce/e2e:latest' ]
-		);
+		try {
+			SubpackageSelector::validate_selection(
+				[ 'woocommerce/checkout' ],
+				[ $dir, 'woocommerce/e2e:latest' ]
+			);
+			$this->fail( 'Expected a RuntimeException for the remote reference, but none was thrown.' );
+		} catch ( \RuntimeException $e ) {
+			$this->assertStringContainsString( 'Remote test package references are not allowed when using --subpackage', $e->getMessage() );
+			$this->assertStringContainsString( 'woocommerce/e2e:latest', $e->getMessage() );
+		}
 	}
 
 	/**
@@ -124,10 +139,11 @@ class SubpackageSelectorTest extends TestCase {
 	public function test_multiple_local_packages_are_rejected(): void {
 		$dir_one = $this->create_package_dir( $this->get_parent_manifest_data() );
 		$dir_two = $this->create_package_dir( [
-			'package' => 'woocommerce/other-suite',
-			'test' => [
-				'phases' => [ 'run' => [ 'npx playwright test' ] ],
-				'results' => [],
+			'package'   => 'woocommerce/other-suite',
+			'test_type' => 'e2e',
+			'test'      => [
+				'phases'  => [ 'run' => [ 'npx playwright test' ] ],
+				'results' => $this->get_e2e_results_config(),
 			],
 		] );
 
@@ -142,10 +158,11 @@ class SubpackageSelectorTest extends TestCase {
 	 */
 	public function test_package_without_subpackages_is_rejected(): void {
 		$dir = $this->create_package_dir( [
-			'package' => 'woocommerce/plain-suite',
-			'test' => [
-				'phases' => [ 'run' => [ 'npx playwright test' ] ],
-				'results' => [],
+			'package'   => 'woocommerce/plain-suite',
+			'test_type' => 'e2e',
+			'test'      => [
+				'phases'  => [ 'run' => [ 'npx playwright test' ] ],
+				'results' => $this->get_e2e_results_config(),
 			],
 		] );
 
@@ -162,13 +179,15 @@ class SubpackageSelectorTest extends TestCase {
 	public function test_unknown_subpackage_id_is_rejected_with_available_list(): void {
 		$dir = $this->create_package_dir( $this->get_parent_manifest_data() );
 
-		$this->expectException( \RuntimeException::class );
-		$this->expectExceptionMessage( "Subpackage 'checkout' not found in test package 'woocommerce/e2e-suite'" );
-		$this->expectExceptionMessage( 'woocommerce/checkout' );
-		$this->expectExceptionMessage( 'woocommerce/cart' );
-
 		// 'checkout' is a short name - only the full ID 'woocommerce/checkout' is valid.
-		SubpackageSelector::validate_selection( [ 'checkout' ], [ $dir ] );
+		try {
+			SubpackageSelector::validate_selection( [ 'checkout' ], [ $dir ] );
+			$this->fail( 'Expected a RuntimeException for the unknown subpackage ID, but none was thrown.' );
+		} catch ( \RuntimeException $e ) {
+			$this->assertStringContainsString( "Subpackage 'checkout' not found in test package 'woocommerce/e2e-suite'", $e->getMessage() );
+			$this->assertStringContainsString( 'woocommerce/checkout', $e->getMessage() );
+			$this->assertStringContainsString( 'woocommerce/cart', $e->getMessage() );
+		}
 	}
 
 	/**
@@ -179,6 +198,31 @@ class SubpackageSelectorTest extends TestCase {
 
 		$this->expectException( \RuntimeException::class );
 		$this->expectExceptionMessage( "Invalid JSON in {$dir}/qit-test.json" );
+
+		SubpackageSelector::validate_selection( [ 'woocommerce/checkout' ], [ $dir ] );
+	}
+
+	/**
+	 * Test that a schema-invalid manifest (valid JSON, but violates the test
+	 * package schema) is rejected early.
+	 */
+	public function test_schema_invalid_manifest_is_rejected(): void {
+		$dir = $this->create_package_dir( [
+			'package'     => 'woocommerce/e2e-suite',
+			'test_type'   => 'e2e',
+			'test'        => [
+				'phases'  => [ 'run' => [ 'npx playwright test' ] ],
+				'results' => [], // Missing required ctrf-json / blob-dir for e2e.
+			],
+			'subpackages' => [
+				'woocommerce/checkout' => [
+					'test' => [ 'phases' => [ 'run' => [ 'npx playwright test tests/checkout.spec.js' ] ] ],
+				],
+			],
+		] );
+
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessage( 'Schema validation failed' );
 
 		SubpackageSelector::validate_selection( [ 'woocommerce/checkout' ], [ $dir ] );
 	}

--- a/src/tests/unit/SubpackageSelectorTest.php
+++ b/src/tests/unit/SubpackageSelectorTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace QIT_CLI_Tests;
+
+use PHPUnit\Framework\TestCase;
+use QIT_CLI\Utils\SubpackageSelector;
+
+/**
+ * Test for SubpackageSelector - validates --subpackage selections
+ * against the supplied test packages.
+ */
+class SubpackageSelectorTest extends TestCase {
+
+	/** @var array<string> Temp directories created during the test. */
+	private array $temp_dirs = [];
+
+	protected function tearDown(): void {
+		foreach ( $this->temp_dirs as $dir ) {
+			if ( file_exists( $dir . '/qit-test.json' ) ) {
+				unlink( $dir . '/qit-test.json' );
+			}
+			if ( is_dir( $dir ) ) {
+				rmdir( $dir );
+			}
+		}
+		$this->temp_dirs = [];
+		parent::tearDown();
+	}
+
+	/**
+	 * Create a temp package directory containing the given qit-test.json contents.
+	 *
+	 * @param array<string,mixed>|string $manifest Manifest data (or raw string for invalid JSON).
+	 */
+	private function create_package_dir( $manifest ): string {
+		$dir = sys_get_temp_dir() . '/qit-subpackage-selector-test-' . uniqid();
+		mkdir( $dir, 0777, true );
+		$this->temp_dirs[] = $dir;
+
+		$contents = is_string( $manifest ) ? $manifest : json_encode( $manifest );
+		file_put_contents( $dir . '/qit-test.json', $contents );
+
+		return $dir;
+	}
+
+	/**
+	 * @return array<string,mixed> A parent manifest with two subpackages.
+	 */
+	private function get_parent_manifest_data(): array {
+		return [
+			'package' => 'woocommerce/e2e-suite',
+			'test' => [
+				'phases' => [ 'run' => [ 'npx playwright test' ] ],
+				'results' => [],
+			],
+			'subpackages' => [
+				'woocommerce/checkout' => [
+					'test' => [ 'phases' => [ 'run' => [ 'npx playwright test tests/checkout.spec.js' ] ] ],
+				],
+				'woocommerce/cart' => [
+					'test' => [ 'phases' => [ 'run' => [ 'npx playwright test tests/cart.spec.js' ] ] ],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Test happy path: one local package, valid subpackage IDs.
+	 */
+	public function test_valid_selection_returns_parent_dir(): void {
+		$dir = $this->create_package_dir( $this->get_parent_manifest_data() );
+
+		$result = SubpackageSelector::validate_selection(
+			[ 'woocommerce/checkout', 'woocommerce/cart' ],
+			[ $dir ]
+		);
+
+		$this->assertEquals( $dir, $result );
+	}
+
+	/**
+	 * Test duplicate subpackage IDs are deduplicated (not an error).
+	 */
+	public function test_duplicate_subpackage_ids_are_deduped(): void {
+		$dir = $this->create_package_dir( $this->get_parent_manifest_data() );
+
+		$result = SubpackageSelector::validate_selection(
+			[ 'woocommerce/checkout', 'woocommerce/checkout' ],
+			[ $dir ]
+		);
+
+		$this->assertEquals( $dir, $result );
+	}
+
+	/**
+	 * Test that a remote package reference is rejected, even alongside a local package.
+	 */
+	public function test_remote_reference_is_rejected(): void {
+		$dir = $this->create_package_dir( $this->get_parent_manifest_data() );
+
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessage( 'Remote test package references are not allowed when using --subpackage' );
+		$this->expectExceptionMessage( 'woocommerce/e2e:latest' );
+
+		SubpackageSelector::validate_selection(
+			[ 'woocommerce/checkout' ],
+			[ $dir, 'woocommerce/e2e:latest' ]
+		);
+	}
+
+	/**
+	 * Test that zero local packages is rejected.
+	 */
+	public function test_no_local_package_is_rejected(): void {
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessage( 'The --subpackage option requires a local test package' );
+
+		SubpackageSelector::validate_selection( [ 'woocommerce/checkout' ], [] );
+	}
+
+	/**
+	 * Test that multiple local packages are rejected.
+	 */
+	public function test_multiple_local_packages_are_rejected(): void {
+		$dir_one = $this->create_package_dir( $this->get_parent_manifest_data() );
+		$dir_two = $this->create_package_dir( [
+			'package' => 'woocommerce/other-suite',
+			'test' => [
+				'phases' => [ 'run' => [ 'npx playwright test' ] ],
+				'results' => [],
+			],
+		] );
+
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessage( 'requires exactly ONE local test package, but 2 were found' );
+
+		SubpackageSelector::validate_selection( [ 'woocommerce/checkout' ], [ $dir_one, $dir_two ] );
+	}
+
+	/**
+	 * Test that a package without subpackages is rejected.
+	 */
+	public function test_package_without_subpackages_is_rejected(): void {
+		$dir = $this->create_package_dir( [
+			'package' => 'woocommerce/plain-suite',
+			'test' => [
+				'phases' => [ 'run' => [ 'npx playwright test' ] ],
+				'results' => [],
+			],
+		] );
+
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessage( "Test package 'woocommerce/plain-suite' ({$dir}) does not define any subpackages" );
+
+		SubpackageSelector::validate_selection( [ 'woocommerce/checkout' ], [ $dir ] );
+	}
+
+	/**
+	 * Test that an unknown subpackage ID is rejected, listing available IDs.
+	 * Short names (without the namespace) must not match - full IDs only.
+	 */
+	public function test_unknown_subpackage_id_is_rejected_with_available_list(): void {
+		$dir = $this->create_package_dir( $this->get_parent_manifest_data() );
+
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessage( "Subpackage 'checkout' not found in test package 'woocommerce/e2e-suite'" );
+		$this->expectExceptionMessage( 'woocommerce/checkout' );
+		$this->expectExceptionMessage( 'woocommerce/cart' );
+
+		// 'checkout' is a short name - only the full ID 'woocommerce/checkout' is valid.
+		SubpackageSelector::validate_selection( [ 'checkout' ], [ $dir ] );
+	}
+
+	/**
+	 * Test that invalid JSON in the local manifest is rejected.
+	 */
+	public function test_invalid_manifest_json_is_rejected(): void {
+		$dir = $this->create_package_dir( '{ this is not valid json' );
+
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessage( "Invalid JSON in {$dir}/qit-test.json" );
+
+		SubpackageSelector::validate_selection( [ 'woocommerce/checkout' ], [ $dir ] );
+	}
+}

--- a/src/tests/unit/TestPackageManifestTest.php
+++ b/src/tests/unit/TestPackageManifestTest.php
@@ -157,6 +157,120 @@ class TestPackageManifestTest extends TestCase {
 	}
 	
 	/**
+	 * Build a parent manifest with subpackages for create_subpackage_manifest tests.
+	 */
+	private function get_parent_manifest_with_subpackages(): TestPackageManifest {
+		return new TestPackageManifest( [
+			'package' => 'woocommerce/e2e-suite',
+			'description' => 'Parent test suite',
+			'test_dir' => './tests',
+			'test_type' => 'e2e',
+			'test' => [
+				'phases' => [
+					'globalSetup' => ['./bootstrap/global-setup.sh'],
+					'setup' => ['npm ci'],
+					'run' => ['npx playwright test'],
+					'teardown' => ['./cleanup.sh'],
+					'globalTeardown' => ['./global-teardown.sh'],
+				],
+				'results' => ['ctrf-json' => './results/ctrf.json'],
+			],
+			'requires' => ['plugins' => ['woocommerce']],
+			'mu_plugins' => ['./mu/helper.php'],
+			'envs' => ['FOO' => 'bar'],
+			'timeout' => 900,
+			'retry' => ['times' => 1, 'delay' => 5],
+			'subpackages' => [
+				'woocommerce/checkout' => [
+					'description' => 'Checkout tests only',
+					'tags' => ['checkout'],
+					'test' => ['phases' => ['run' => ['npx playwright test tests/checkout.spec.js']]],
+				],
+				'woocommerce/cart' => [
+					'requires' => ['plugins' => ['woocommerce', 'woocommerce-gateway-stripe']],
+					'test' => ['phases' => ['run' => ['npx playwright test tests/cart.spec.js']]],
+				],
+				'woocommerce/no-run-phase' => [
+					'description' => 'Missing test.phases entirely',
+				],
+			],
+		] );
+	}
+
+	/**
+	 * Test create_subpackage_manifest inherits everything except the run phase.
+	 */
+	public function test_create_subpackage_manifest_inherits_parent_config(): void {
+		$parent = $this->get_parent_manifest_with_subpackages();
+
+		$subpackage = $parent->create_subpackage_manifest( 'woocommerce/checkout' );
+
+		$this->assertEquals( 'woocommerce/checkout', $subpackage->get_package_id() );
+		$this->assertEquals( 'woocommerce/e2e-suite', $subpackage->get_parent_package() );
+		$this->assertTrue( $subpackage->is_subpackage() );
+
+		// Only the run phase is overridden.
+		$phases = $subpackage->get_phases();
+		$this->assertEquals( ['npx playwright test tests/checkout.spec.js'], $phases['run'] );
+		$this->assertEquals( ['./bootstrap/global-setup.sh'], $phases['globalSetup'] );
+		$this->assertEquals( ['npm ci'], $phases['setup'] );
+		$this->assertEquals( ['./cleanup.sh'], $phases['teardown'] );
+		$this->assertEquals( ['./global-teardown.sh'], $phases['globalTeardown'] );
+
+		// Everything else is inherited from the parent.
+		$this->assertEquals( ['ctrf-json' => './results/ctrf.json'], $subpackage->get_test_results() );
+		$this->assertEquals( ['plugins' => ['woocommerce']], $subpackage->get_requires() );
+		$this->assertEquals( ['./mu/helper.php'], $subpackage->get_mu_plugins() );
+		$this->assertEquals( ['FOO' => 'bar'], $subpackage->get_env() );
+		$this->assertEquals( 900, $subpackage->get_timeout() );
+		$this->assertEquals( ['times' => 1, 'delay' => 5], $subpackage->get_retry() );
+		$this->assertEquals( './tests', $subpackage->get_test_dir() );
+		$this->assertEquals( 'e2e', $subpackage->get_test_type() );
+
+		// Metadata overrides from the subpackage config are applied.
+		$this->assertEquals( 'Checkout tests only', $subpackage->get_description() );
+		$this->assertEquals( ['checkout'], $subpackage->get_tags() );
+	}
+
+	/**
+	 * Test create_subpackage_manifest merges subpackage requires overrides.
+	 */
+	public function test_create_subpackage_manifest_merges_requires_override(): void {
+		$parent = $this->get_parent_manifest_with_subpackages();
+
+		$subpackage = $parent->create_subpackage_manifest( 'woocommerce/cart' );
+
+		$this->assertEquals(
+			['plugins' => ['woocommerce', 'woocommerce-gateway-stripe']],
+			$subpackage->get_requires()
+		);
+	}
+
+	/**
+	 * Test create_subpackage_manifest throws for an unknown subpackage ID.
+	 */
+	public function test_create_subpackage_manifest_throws_for_unknown_id(): void {
+		$parent = $this->get_parent_manifest_with_subpackages();
+
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( "Subpackage 'woocommerce/nonexistent' not found in package 'woocommerce/e2e-suite'" );
+
+		$parent->create_subpackage_manifest( 'woocommerce/nonexistent' );
+	}
+
+	/**
+	 * Test create_subpackage_manifest throws when the subpackage lacks a run phase.
+	 */
+	public function test_create_subpackage_manifest_throws_for_missing_run_phase(): void {
+		$parent = $this->get_parent_manifest_with_subpackages();
+
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( "Subpackage 'woocommerce/no-run-phase' must specify a 'run' phase" );
+
+		$parent->create_subpackage_manifest( 'woocommerce/no-run-phase' );
+	}
+
+	/**
 	 * Test utility package detection (no run phase).
 	 */
 	public function test_utility_package(): void {

--- a/src/tests/unit/TestPackageManifestTest.php
+++ b/src/tests/unit/TestPackageManifestTest.php
@@ -3,6 +3,7 @@
 namespace QIT_CLI_Tests;
 
 use PHPUnit\Framework\TestCase;
+use QIT_CLI\PreCommand\Objects\PackageType;
 use QIT_CLI\PreCommand\Objects\TestPackageManifest;
 
 /**
@@ -400,5 +401,435 @@ class TestPackageManifestTest extends TestCase {
 		$manifest = new TestPackageManifest( $data );
 
 		$this->assertEquals( [], $manifest->get_actions() );
+	}
+
+	/**
+	 * External manifest data exercising every supported field.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_full_manifest_data(): array {
+		return [
+			'package' => 'woocommerce/e2e-suite',
+			'tags' => ['e2e', 'critical'],
+			'package_type' => 'test',
+			'test_type' => 'e2e',
+			'test_dir' => './tests',
+			'description' => 'Full manifest',
+			'requires' => [
+				'plugins' => ['woocommerce'],
+				'themes' => ['storefront'],
+				'secrets' => ['API_KEY'],
+				'network' => true,
+				'tunnel' => true,
+			],
+			'test' => [
+				'phases' => [
+					'globalSetup' => ['./bootstrap/global-setup.sh'],
+					'setup' => ['npm ci'],
+					'run' => ['npx playwright test'],
+					'teardown' => ['./cleanup.sh'],
+					'globalTeardown' => ['./global-teardown.sh'],
+				],
+				'results' => ['ctrf-json' => './results/ctrf.json'],
+			],
+			'mu_plugins' => ['./mu/helper.php'],
+			'envs' => [
+				'FOO' => 'bar',
+				'DEBUG' => true,
+				'RETRIES' => 3,
+			],
+			'timeout' => 900,
+			'retry' => ['times' => 2, 'delay' => 5],
+			'subpackages' => [
+				'woocommerce/checkout' => [
+					'description' => 'Checkout tests only',
+					'tags' => ['checkout'],
+					'test' => ['phases' => ['run' => ['npx playwright test tests/checkout.spec.js']]],
+				],
+			],
+			'actions' => [
+				'makePurchase' => './flows/pay.ts',
+				'refundOrder' => './flows/refund.ts',
+			],
+		];
+	}
+
+	/**
+	 * The phases as stored internally, including the defaults applied for missing phases.
+	 *
+	 * @return array<string, array<string>>
+	 */
+	private function get_full_manifest_phases(): array {
+		return [
+			'globalSetup' => ['./bootstrap/global-setup.sh'],
+			'setup' => ['npm ci'],
+			'run' => ['npx playwright test'],
+			'teardown' => ['./cleanup.sh'],
+			'globalTeardown' => ['./global-teardown.sh'],
+		];
+	}
+
+	/**
+	 * Test to_array() exports every field of the normalized (cache) representation.
+	 */
+	public function test_to_array_exports_all_fields(): void {
+		$manifest = new TestPackageManifest( $this->get_full_manifest_data() );
+
+		$expected = [
+			'_normalized' => true,
+			'package_id' => 'woocommerce/e2e-suite',
+			'namespace' => 'woocommerce',
+			'package_name' => 'e2e-suite',
+			'package_type' => 'test',
+			'tags' => ['e2e', 'critical'],
+			'test_type' => 'e2e',
+			'test_dir' => './tests',
+			'description' => 'Full manifest',
+			'requires' => [
+				'plugins' => ['woocommerce'],
+				'themes' => ['storefront'],
+				'secrets' => ['API_KEY'],
+				'network' => true,
+				'tunnel' => true,
+			],
+			'phases' => $this->get_full_manifest_phases(),
+			'test_results' => ['ctrf-json' => './results/ctrf.json'],
+			'mu_plugins' => ['./mu/helper.php'],
+			// Env values are stringified.
+			'env_vars' => [
+				'FOO' => 'bar',
+				'DEBUG' => 'true',
+				'RETRIES' => '3',
+			],
+			'timeout' => 900,
+			'retry' => ['times' => 2, 'delay' => 5],
+			'subpackages' => [
+				'woocommerce/checkout' => [
+					'description' => 'Checkout tests only',
+					'tags' => ['checkout'],
+					'test' => ['phases' => ['run' => ['npx playwright test tests/checkout.spec.js']]],
+				],
+			],
+			'parent_package' => null,
+			'requires_network' => true,
+			'requires_tunnel' => true,
+			'actions' => [
+				'makePurchase' => './flows/pay.ts',
+				'refundOrder' => './flows/refund.ts',
+			],
+		];
+
+		$this->assertEquals( $expected, $manifest->to_array() );
+	}
+
+	/**
+	 * Test jsonSerialize() exports every field in the external manifest format.
+	 */
+	public function test_json_serialize_exports_all_fields(): void {
+		$manifest = new TestPackageManifest( $this->get_full_manifest_data() );
+
+		$expected = [
+			'package' => 'woocommerce/e2e-suite',
+			'tags' => ['e2e', 'critical'],
+			'package_type' => 'test',
+			'test_type' => 'e2e',
+			'test_dir' => './tests',
+			'description' => 'Full manifest',
+			'requires' => [
+				'plugins' => ['woocommerce'],
+				'themes' => ['storefront'],
+				'secrets' => ['API_KEY'],
+				'network' => true,
+				'tunnel' => true,
+			],
+			'test' => [
+				'phases' => $this->get_full_manifest_phases(),
+				'results' => ['ctrf-json' => './results/ctrf.json'],
+			],
+			'mu_plugins' => ['./mu/helper.php'],
+			// Env values are stringified.
+			'envs' => [
+				'FOO' => 'bar',
+				'DEBUG' => 'true',
+				'RETRIES' => '3',
+			],
+			'timeout' => 900,
+			'retry' => ['times' => 2, 'delay' => 5],
+			'subpackages' => [
+				'woocommerce/checkout' => [
+					'description' => 'Checkout tests only',
+					'tags' => ['checkout'],
+					'test' => ['phases' => ['run' => ['npx playwright test tests/checkout.spec.js']]],
+				],
+			],
+			'parent_package' => null,
+			'actions' => [
+				'makePurchase' => './flows/pay.ts',
+				'refundOrder' => './flows/refund.ts',
+			],
+		];
+
+		$this->assertEquals( $expected, $manifest->jsonSerialize() );
+	}
+
+	/**
+	 * Test to_array() -> constructor round trip is lossless (cache write/read).
+	 */
+	public function test_to_array_round_trip_preserves_all_fields(): void {
+		$original = new TestPackageManifest( $this->get_full_manifest_data() );
+
+		$reloaded = new TestPackageManifest( $original->to_array() );
+
+		$this->assertEquals( $original->to_array(), $reloaded->to_array() );
+		$this->assertEquals( $original->jsonSerialize(), $reloaded->jsonSerialize() );
+	}
+
+	/**
+	 * Test jsonSerialize() -> constructor round trip is lossless.
+	 *
+	 * Comparing the normalized state of both manifests catches any field that
+	 * jsonSerialize() forgets to emit, since a dropped field would fall back to
+	 * its default when the serialized output is re-adapted.
+	 */
+	public function test_json_serialize_round_trip_preserves_all_fields(): void {
+		$original = new TestPackageManifest( $this->get_full_manifest_data() );
+
+		$reloaded = new TestPackageManifest( $original->jsonSerialize() );
+
+		$this->assertEquals( $original->jsonSerialize(), $reloaded->jsonSerialize() );
+		$this->assertEquals( $original->to_array(), $reloaded->to_array() );
+	}
+
+	/**
+	 * Test a round trip through an actual JSON string is lossless.
+	 */
+	public function test_json_encoded_round_trip_preserves_all_fields(): void {
+		$original = new TestPackageManifest( $this->get_full_manifest_data() );
+
+		$json = json_encode( $original->jsonSerialize() );
+		$this->assertIsString( $json );
+
+		$reloaded = new TestPackageManifest( json_decode( $json, true ) );
+
+		$this->assertEquals( $original->to_array(), $reloaded->to_array() );
+	}
+
+	/**
+	 * Test both serializations always emit every key, using defaults for fields
+	 * that the external manifest did not declare.
+	 */
+	public function test_serialization_of_minimal_manifest_uses_defaults(): void {
+		$manifest = new TestPackageManifest( [
+			'package' => 'test/package',
+			'test' => [
+				'phases' => ['run' => ['npx playwright test']],
+			],
+		] );
+
+		$expected_phases = [
+			'globalSetup' => [],
+			'globalTeardown' => [],
+			'setup' => [],
+			'run' => ['npx playwright test'],
+			'teardown' => [],
+		];
+
+		$this->assertEquals( [
+			'_normalized' => true,
+			'package_id' => 'test/package',
+			'namespace' => 'test',
+			'package_name' => 'package',
+			// Derived: has a run phase, so it is a test package.
+			'package_type' => PackageType::TEST,
+			'tags' => [],
+			'test_type' => 'e2e',
+			'test_dir' => './',
+			'description' => '',
+			'requires' => [],
+			'phases' => $expected_phases,
+			'test_results' => [],
+			'mu_plugins' => [],
+			'env_vars' => [],
+			'timeout' => 1800,
+			'retry' => ['times' => 0, 'delay' => 0],
+			'subpackages' => [],
+			'parent_package' => null,
+			'requires_network' => false,
+			'requires_tunnel' => false,
+			'actions' => [],
+		], $manifest->to_array() );
+
+		$this->assertEquals( [
+			'package' => 'test/package',
+			'tags' => [],
+			'package_type' => PackageType::TEST,
+			'test_type' => 'e2e',
+			'test_dir' => './',
+			'description' => '',
+			'requires' => [],
+			'test' => [
+				'phases' => $expected_phases,
+				'results' => [],
+			],
+			'mu_plugins' => [],
+			'envs' => [],
+			'timeout' => 1800,
+			'retry' => ['times' => 0, 'delay' => 0],
+			'subpackages' => [],
+			'parent_package' => null,
+			'actions' => [],
+		], $manifest->jsonSerialize() );
+	}
+
+	/**
+	 * Test normalized data written before actions existed still loads (backwards compatibility).
+	 */
+	public function test_normalized_data_without_actions_defaults_to_empty(): void {
+		$normalized = [
+			'_normalized' => true,
+			'package_id' => 'woocommerce/checkout',
+			'namespace' => 'woocommerce',
+			'package_name' => 'checkout',
+			'tags' => [],
+			'test_type' => 'e2e',
+			'test_dir' => './',
+			'description' => 'Test package',
+			'requires' => [],
+			'phases' => ['run' => ['test']],
+			'test_results' => [],
+			'mu_plugins' => [],
+			'env_vars' => [],
+			'timeout' => 1800,
+			'retry' => ['times' => 0, 'delay' => 0],
+			'subpackages' => [],
+			'parent_package' => null,
+			// No 'actions' key - cached before actions were supported.
+		];
+
+		$manifest = new TestPackageManifest( $normalized );
+
+		$this->assertSame( [], $manifest->get_actions() );
+		$this->assertSame( [], $manifest->to_array()['actions'] );
+		$this->assertSame( [], $manifest->jsonSerialize()['actions'] );
+	}
+
+	/**
+	 * Test a utility package (no run phase) serializes its derived package type.
+	 */
+	public function test_serialization_of_utility_package_type(): void {
+		$manifest = new TestPackageManifest( [
+			'package' => 'woocommerce/setup-utils',
+			'test' => [
+				'phases' => ['globalSetup' => ['composer install']],
+			],
+		] );
+
+		$this->assertSame( PackageType::UTILITY, $manifest->to_array()['package_type'] );
+		$this->assertSame( PackageType::UTILITY, $manifest->jsonSerialize()['package_type'] );
+
+		// The derived type survives a round trip rather than being re-derived differently.
+		$reloaded = new TestPackageManifest( $manifest->jsonSerialize() );
+		$this->assertSame( PackageType::UTILITY, $reloaded->get_package_type() );
+	}
+
+	/**
+	 * Test string network/tunnel requirements are normalized to booleans on export.
+	 */
+	public function test_serialization_normalizes_string_network_and_tunnel_flags(): void {
+		$manifest = new TestPackageManifest( [
+			'package' => 'test/package',
+			'requires' => [
+				'network' => 'true',
+				'tunnel' => 'false',
+			],
+			'test' => [
+				'phases' => ['run' => ['test']],
+			],
+		] );
+
+		$normalized = $manifest->to_array();
+		$this->assertTrue( $normalized['requires_network'] );
+		$this->assertFalse( $normalized['requires_tunnel'] );
+
+		// The raw requires values are exported untouched, and re-adapted on reload.
+		$this->assertSame( 'true', $manifest->jsonSerialize()['requires']['network'] );
+		$this->assertSame( 'false', $manifest->jsonSerialize()['requires']['tunnel'] );
+
+		$reloaded = new TestPackageManifest( $manifest->jsonSerialize() );
+		$this->assertTrue( $reloaded->requires_network() );
+		$this->assertFalse( $reloaded->requires_tunnel() );
+	}
+
+	/**
+	 * Test a synthesized subpackage serializes all of its inherited and overridden fields.
+	 */
+	public function test_serialization_of_synthesized_subpackage(): void {
+		$parent = new TestPackageManifest( $this->get_full_manifest_data() );
+
+		$subpackage = $parent->create_subpackage_manifest( 'woocommerce/checkout' );
+		$serialized = $subpackage->jsonSerialize();
+
+		// Subpackage identity, including the namespace/package name derived from the subpackage ID
+		// rather than inherited from the parent.
+		$this->assertSame( 'woocommerce/checkout', $serialized['package'] );
+		$this->assertSame( 'woocommerce/e2e-suite', $serialized['parent_package'] );
+		$this->assertSame( [], $serialized['subpackages'] );
+		$this->assertSame( 'woocommerce', $subpackage->get_namespace() );
+		$this->assertSame( 'checkout', $subpackage->get_package_name() );
+		$this->assertSame( 'woocommerce-checkout', $subpackage->get_container_directory_name() );
+
+		// Overridden fields.
+		$this->assertEquals( ['npx playwright test tests/checkout.spec.js'], $serialized['test']['phases']['run'] );
+		$this->assertSame( 'Checkout tests only', $serialized['description'] );
+		$this->assertEquals( ['checkout'], $serialized['tags'] );
+
+		// Everything else is inherited from the parent.
+		$parent_serialized = $parent->jsonSerialize();
+		foreach ( ['package_type', 'test_type', 'test_dir', 'requires', 'mu_plugins', 'envs', 'timeout', 'retry', 'actions'] as $inherited ) {
+			$this->assertEquals( $parent_serialized[ $inherited ], $serialized[ $inherited ], "Field '{$inherited}' was not inherited." );
+		}
+		$this->assertEquals( $parent_serialized['test']['results'], $serialized['test']['results'] );
+		foreach ( ['globalSetup', 'setup', 'teardown', 'globalTeardown'] as $phase ) {
+			$this->assertEquals( $parent_serialized['test']['phases'][ $phase ], $serialized['test']['phases'][ $phase ], "Phase '{$phase}' was not inherited." );
+		}
+
+		// The serialized subpackage reloads into an equivalent manifest. Since jsonSerialize() only
+		// emits the combined 'package' field, this also pins that a synthesized subpackage's
+		// namespace/package name match what re-deriving them from the package ID produces.
+		$reloaded = new TestPackageManifest( $serialized );
+		$this->assertEquals( $subpackage->to_array(), $reloaded->to_array() );
+	}
+
+	/**
+	 * Test a subpackage in a different namespace to its parent derives its own identity.
+	 */
+	public function test_synthesized_subpackage_in_other_namespace_derives_own_identity(): void {
+		$parent = new TestPackageManifest( [
+			'package' => 'woocommerce/e2e-suite',
+			'test' => [
+				'phases' => ['run' => ['npx playwright test']],
+				'results' => []
+			],
+			'subpackages' => [
+				'partner/checkout' => [
+					'test' => ['phases' => ['run' => ['npx playwright test tests/checkout.spec.js']]],
+				],
+			],
+		] );
+
+		$subpackage = $parent->create_subpackage_manifest( 'partner/checkout' );
+
+		$this->assertSame( 'partner/checkout', $subpackage->get_package_id() );
+		$this->assertSame( 'partner', $subpackage->get_namespace() );
+		$this->assertSame( 'checkout', $subpackage->get_package_name() );
+
+		$normalized = $subpackage->to_array();
+		$this->assertSame( 'partner', $normalized['namespace'] );
+		$this->assertSame( 'checkout', $normalized['package_name'] );
+
+		// The identity survives both round trips.
+		$this->assertEquals( $normalized, ( new TestPackageManifest( $normalized ) )->to_array() );
+		$this->assertEquals( $normalized, ( new TestPackageManifest( $subpackage->jsonSerialize() ) )->to_array() );
 	}
 }


### PR DESCRIPTION
This PR explores the addition of a `subpackage` option to the `qit run:e2e` command that can be used for local e2e test runs to limit execution to one or more subpackages defined for the current local directory. The option can only be used when exactly one local test package is specified, and will error in all other cases.

The gap/use case for this was flagged in [this comment](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5208#issuecomment-5039321745) on https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5208 by @zhongruige -- this PR tries to add support in QIT itself.

I am not actually sure how to test this in my environment, and I put this together using Claude, so we may want to drop the feature.