### PR TITLE
Ignore WC-core activation-table DB errors in PrepareDebugLog

### DIFF
--- a/src/src/Utils/PrepareDebugLog.php
+++ b/src/src/Utils/PrepareDebugLog.php
@@ -82,6 +82,41 @@ class PrepareDebugLog {
 					continue;
 				}
 
+				/*
+				 * Ignore "table doesn't exist" DB errors for WooCommerce core tables that WooCommerce
+				 * queries during its own activation, before WC_Install creates the tables. These are
+				 * WooCommerce-core false positives (the query is Woo's own, about Woo's own table), not
+				 * SUT bugs. wpdb::print_error() lines ("WordPress database error ... made by ...") carry
+				 * no "in <file>" clause, so the generic Woo-core filter above never matches them.
+				 *   - wc_tax_rate_classes: queried via tax settings during boot.
+				 *   - woocommerce_attribute_taxonomies: queried by VisualAttributeTermAdmin (@since WC 10.9.0)
+				 *     during init_hooks, hit under plugin_sandbox_scrape before install runs.
+				 * Matched prefix-agnostically (via the core table suffix) so a non-default DB prefix is still covered.
+				 */
+				$woo_core_activation_tables = [
+					'wc_tax_rate_classes',
+					'woocommerce_attribute_taxonomies',
+				];
+
+				if (
+					! $is_testing_woocommerce_core
+					&& ! $has_sut_slug_in_error
+					&& stripos( $line, 'WordPress database error' ) !== false
+					&& stripos( $line, 'exist for query' ) !== false
+				) {
+					$is_woo_core_activation_table_error = false;
+					foreach ( $woo_core_activation_tables as $woo_core_table ) {
+						if ( stripos( $line, $woo_core_table ) !== false ) {
+							$is_woo_core_activation_table_error = true;
+							break;
+						}
+					}
+
+					if ( $is_woo_core_activation_table_error ) {
+						continue;
+					}
+				}
+
 				// Ignore errors coming from wp-mail-logging, if it's not the SUT. This is a plugin we install on all E2E tests.
 				$error_from_wp_mail_logging = stripos( $line, 'in /var/www/html/wp-content/plugins/wp-mail-logging/' ) !== false;
 				$is_testing_wp_mail_logging = $sut_slug === 'wp-mail-logging';

--- a/src/tests/unit/PrepareDebugLogTest.php
+++ b/src/tests/unit/PrepareDebugLogTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace QIT_CLI_Tests;
+
+use PHPUnit\Framework\TestCase;
+use QIT_CLI\Environment\Environments\E2E\E2EEnvInfo;
+use QIT_CLI\Utils\PrepareDebugLog;
+
+class PrepareDebugLogTest extends TestCase {
+	/** @var string */
+	protected $debug_log_file;
+
+	/** @var string */
+	protected $prepared_file;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->debug_log_file = tempnam( sys_get_temp_dir(), 'qit-debug-log' );
+		$this->prepared_file  = tempnam( sys_get_temp_dir(), 'qit-debug-log-prepared' );
+	}
+
+	public function tearDown(): void {
+		@unlink( $this->debug_log_file );
+		@unlink( $this->prepared_file );
+		parent::tearDown();
+	}
+
+	protected function prepare( string $debug_log_contents, string $sut_slug ): array {
+		file_put_contents( $this->debug_log_file, $debug_log_contents );
+
+		$env_info      = new E2EEnvInfo();
+		$env_info->sut = [ 'slug' => $sut_slug ];
+
+		$prepare_debug_log = new PrepareDebugLog();
+		$prepare_debug_log->set_sut_slug( $sut_slug );
+		$prepare_debug_log->prepare_debug_log( $this->debug_log_file, $this->prepared_file, $env_info );
+
+		return json_decode( (string) file_get_contents( $this->prepared_file ), true );
+	}
+
+	protected function messages( array $log_entries ): array {
+		return array_column( $log_entries, 'message' );
+	}
+
+	public function test_woo_core_activation_table_db_errors_are_ignored_for_non_woo_sut() {
+		$debug_log = <<<LOG
+[28-Jul-2026 08:21:41 UTC] WordPress database error Table 'wordpress.wp_woocommerce_attribute_taxonomies' doesn't exist for query SELECT * FROM wp_woocommerce_attribute_taxonomies WHERE attribute_name != '' ORDER BY attribute_name ASC; made by activate_plugin, plugin_sandbox_scrape, include_once('/plugins/woocommerce/woocommerce.php'), WC, WooCommerce::instance, WooCommerce->__construct, WooCommerce->init_hooks, Automattic\WooCommerce\Internal\ProductAttributes\VisualAttributeTermAdmin->register, wc_get_attribute_taxonomies, QM_DB->query
+[28-Jul-2026 08:21:42 UTC] WordPress database error Table 'wordpress.wp_wc_tax_rate_classes' doesn't exist for query SELECT * FROM wp_wc_tax_rate_classes; made by activate_plugin, plugin_sandbox_scrape, include_once('/plugins/woocommerce/woocommerce.php'), QM_DB->query
+[28-Jul-2026 08:21:43 UTC] PHP Warning: Undefined variable \$foo in /var/www/html/wp-content/plugins/registration-form-fields/includes/form.php on line 10
+LOG;
+
+		$messages = $this->messages( $this->prepare( $debug_log, 'registration-form-fields' ) );
+
+		$this->assertCount( 1, $messages );
+		$this->assertStringContainsString( 'registration-form-fields', $messages[0] );
+	}
+
+	public function test_woo_core_activation_table_db_errors_are_kept_when_testing_woocommerce_core() {
+		$debug_log = <<<LOG
+[28-Jul-2026 08:21:41 UTC] WordPress database error Table 'wordpress.wp_woocommerce_attribute_taxonomies' doesn't exist for query SELECT * FROM wp_woocommerce_attribute_taxonomies; made by activate_plugin, plugin_sandbox_scrape, QM_DB->query
+LOG;
+
+		$messages = $this->messages( $this->prepare( $debug_log, 'woocommerce' ) );
+
+		$this->assertCount( 1, $messages );
+		$this->assertStringContainsString( 'wp_woocommerce_attribute_taxonomies', $messages[0] );
+	}
+
+	public function test_db_errors_on_other_tables_are_kept() {
+		$debug_log = <<<LOG
+[28-Jul-2026 08:21:41 UTC] WordPress database error Table 'wordpress.wp_my_plugin_table' doesn't exist for query SELECT * FROM wp_my_plugin_table; made by activate_plugin, plugin_sandbox_scrape, QM_DB->query
+LOG;
+
+		$messages = $this->messages( $this->prepare( $debug_log, 'registration-form-fields' ) );
+
+		$this->assertCount( 1, $messages );
+		$this->assertStringContainsString( 'wp_my_plugin_table', $messages[0] );
+	}
+
+	public function test_woo_core_activation_table_db_errors_use_prefix_agnostic_match() {
+		$debug_log = <<<LOG
+[28-Jul-2026 08:21:41 UTC] WordPress database error Table 'wordpress.custom_woocommerce_attribute_taxonomies' doesn't exist for query SELECT * FROM custom_woocommerce_attribute_taxonomies; made by activate_plugin, plugin_sandbox_scrape, QM_DB->query
+LOG;
+
+		$log_entries = $this->prepare( $debug_log, 'registration-form-fields' );
+
+		$this->assertSame( [], $log_entries );
+	}
+}


### PR DESCRIPTION
Fixes [QIT-1026](https://linear.app/a8c/issue/QIT-1026).

## What

Adds a table allowlist to `PrepareDebugLog` so "table doesn't exist" DB errors for WooCommerce core tables that WooCommerce queries **during its own activation** (before `WC_Install` creates them) are no longer surfaced in vendor test reports:

- `wc_tax_rate_classes` — queried via tax settings during boot
- `woocommerce_attribute_taxonomies` — queried by `VisualAttributeTermAdmin` (@since WC 10.9.0) during `init_hooks`, hit under `plugin_sandbox_scrape` before install runs

The skip only applies when the SUT is not WooCommerce core and the SUT slug does not appear in the log line, and the table is matched prefix-agnostically so non-default DB prefixes are covered.

## Why

Vendor report for test run 5123919 ("Registration Form Fields", WC 10.9.4) showed:

```
WordPress database error Table 'wordpress.wp_woocommerce_attribute_taxonomies' doesn't exist for query SELECT * FROM wp_woocommerce_attribute_taxonomies ... made by activate_plugin, plugin_sandbox_scrape, include_once('/plugins/woocommerce/woocommerce.php'), ..., VisualAttributeTermAdmin->register, wc_get_attribute_taxonomies, QM_DB->query
```

This is WooCommerce querying its own table during its own activation — not a SUT bug. `wpdb::print_error()` lines carry no `in <file>` clause, so the existing generic Woo-core filter (`in /var/www/html/wp-content/plugins/woocommerce/`) never matches them.

This ports the allowlist from compatibility-dashboard's `ci/bin/results/prepare-debug-log.php` (commit `304f8e475`), which is now orphaned — activation runs go through the bundled qit PHAR, whose debug.log filtering is this class.

## Testing

- New `PrepareDebugLogTest.php`: filtered for a normal SUT; kept when WooCommerce is the SUT; kept for non-allowlisted tables; prefix-agnostic matching
- Full unit suite: 310 tests OK; phpcs and phpstan clean

## Follow-up (tracked in QIT-1026)

- Rebuild the PHAR and bump the bundled copies in compatibility-dashboard (`ci/tests/activation*/qit`)
- Decide whether to delete the orphaned manager-side `ci/bin/results/prepare-debug-log.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)