### PR TITLE
Add remote execution for package-backed managed tests

### DIFF
--- a/src/src/Commands/ExtensionSetTrait.php
+++ b/src/src/Commands/ExtensionSetTrait.php
@@ -20,8 +20,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * For local commands, the set name is expanded into the extensions it contains
  * and merged into `--plugin`, which env:up then resolves like any other plugin
- * slug. Woo API/E2E commands use this trait to switch extension-set runs back
- * to the Manager-hosted flow instead.
+ * slug. Managed package commands also use this trait to opt into the
+ * Manager-hosted flow explicitly or when an extension set requires it.
  *
  * This trait is meant to be used in the context of Command classes.
  *
@@ -48,6 +48,18 @@ trait ExtensionSetTrait {
 			null,
 			InputOption::VALUE_OPTIONAL,
 			$set_description
+		);
+	}
+
+	/**
+	 * Register the explicit Manager-hosted execution option.
+	 */
+	protected function configure_remote_option(): void {
+		$this->addOption(
+			'remote',
+			null,
+			InputOption::VALUE_NONE,
+			'Run the managed test on QIT servers instead of locally'
 		);
 	}
 
@@ -86,26 +98,34 @@ trait ExtensionSetTrait {
 		return null;
 	}
 
-	protected function run_remote_extension_set_if_provided(
+	protected function run_remote_if_requested(
 		QITInput $input,
 		OutputInterface $output,
 		string $remote_test_type,
 		?string $profile_test_type = null
 	): ?int {
 		$extension_set_name = $input->getOption( 'extension_set' );
-		if ( empty( $extension_set_name ) ) {
+		if ( ! $input->getOption( 'remote' ) && empty( $extension_set_name ) ) {
 			return null;
 		}
 
-		$extension_set_error = $this->validate_extension_set_exists( (string) $extension_set_name, $output );
-		if ( $extension_set_error !== null ) {
-			return $extension_set_error;
+		if ( getenv( 'QIT_TEST_RUN_ID' ) !== false ) {
+			$output->writeln( '<error>Cannot start a remote test while QIT_TEST_RUN_ID is set.</error>' );
+
+			return Command::INVALID;
+		}
+
+		if ( ! empty( $extension_set_name ) ) {
+			$extension_set_error = $this->validate_extension_set_exists( (string) $extension_set_name, $output );
+			if ( $extension_set_error !== null ) {
+				return $extension_set_error;
+			}
 		}
 
 		$runner          = App::make( RemoteTestRunner::class );
 		$options_to_send = $runner->get_options_to_send_for_schema( $remote_test_type );
 
-		$unsupported_options_error = $this->validate_only_remote_options_for_remote_extension_set( $input, $output, array_keys( $options_to_send ) );
+		$unsupported_options_error = $this->validate_only_remote_options( $input, $output, array_keys( $options_to_send ) );
 		if ( $unsupported_options_error !== null ) {
 			return $unsupported_options_error;
 		}
@@ -147,7 +167,7 @@ trait ExtensionSetTrait {
 	 * @param OutputInterface $output         The command output.
 	 * @param array<string>   $schema_options Options the Manager schema accepts.
 	 */
-	private function validate_only_remote_options_for_remote_extension_set( QITInput $input, OutputInterface $output, array $schema_options ): ?int {
+	private function validate_only_remote_options( QITInput $input, OutputInterface $output, array $schema_options ): ?int {
 		$allowed_options = array_unique( array_merge(
 			$schema_options,
 			[
@@ -164,6 +184,7 @@ trait ExtensionSetTrait {
 				'print-report-url',
 				'profile',
 				'quiet',
+				'remote',
 				'timeout',
 				'verbose',
 				'version',
@@ -193,7 +214,7 @@ trait ExtensionSetTrait {
 		}
 
 		$output->writeln( sprintf(
-			'<error>--extension_set runs managed compatibility-set tests on QIT servers and cannot be combined with local-only option(s): %s.</error>',
+			'<error>Remote managed tests cannot be combined with local-only option(s): %s.</error>',
 			implode( ', ', array_unique( $provided ) )
 		) );
 

--- a/src/src/Commands/RunActivationTestCommand.php
+++ b/src/src/Commands/RunActivationTestCommand.php
@@ -29,6 +29,7 @@ class RunActivationTestCommand extends RunE2ECommand {
 		parent::configure();
 		$this->setDescription( 'Run activation tests' );
 		$this->configure_extension_set_option();
+		$this->configure_remote_option();
 	}
 
 	/******************************************************************
@@ -37,7 +38,7 @@ class RunActivationTestCommand extends RunE2ECommand {
 	protected function doExecute( QITInput $input, OutputInterface $output ): int {
 		/** @var \QIT_CLI\QITInput $input */
 
-		$remote_result = $this->run_remote_extension_set_if_provided( $input, $output, 'activation' );
+		$remote_result = $this->run_remote_if_requested( $input, $output, 'activation' );
 		if ( $remote_result !== null ) {
 			return $remote_result;
 		}

--- a/src/src/Commands/RunE2ECommand.php
+++ b/src/src/Commands/RunE2ECommand.php
@@ -164,7 +164,7 @@ class RunE2ECommand extends QITCommand {
 			->addOption( 'notify', null, InputOption::VALUE_NONE, 'Notify on failures' )
 			->addOption( 'group', 'g', InputOption::VALUE_NEGATABLE, 'Register into a group', false )
 			->addOption( 'print-report-url', null, InputOption::VALUE_NONE, 'Print the test report URL (contains sensitive data - use cautiously in public logs)' )
-			->addOption( 'timeout', null, InputOption::VALUE_OPTIONAL, 'Wait timeout in seconds for remote extension-set runs', null )
+			->addOption( 'timeout', null, InputOption::VALUE_OPTIONAL, 'Wait timeout in seconds for remote runs', null )
 			->addOption( 'ui', null, InputOption::VALUE_NONE, 'Run tests in Playwright UI mode' )
 			->addOption( 'keep-env', null, InputOption::VALUE_NONE, 'Keep the environment running after tests complete (for debugging with Playwright MCP)' );
 	}

--- a/src/src/Commands/RunE2ECommand.php
+++ b/src/src/Commands/RunE2ECommand.php
@@ -1463,8 +1463,9 @@ class RunE2ECommand extends QITCommand {
 
 					// Run the command using package phase runner
 					$temp_manifest_data = [
-						'package' => $pkg_id,
-						'test'    => [
+						'package'   => $pkg_id,
+						'test_type' => $manifest->get_test_type(),
+						'test'      => [
 							'phases' => [
 								'globalSetup' => [ $command ],
 							],
@@ -1818,8 +1819,9 @@ class RunE2ECommand extends QITCommand {
 					try {
 						// Run the command using package phase runner
 						$temp_manifest_data = [
-							'package' => $pkg_id,
-							'test'    => [
+							'package'   => $pkg_id,
+							'test_type' => $manifest->get_test_type(),
+							'test'      => [
 								'phases' => [
 									'globalTeardown' => [ $command ],
 								],

--- a/src/src/Commands/RunWooApiTestCommand.php
+++ b/src/src/Commands/RunWooApiTestCommand.php
@@ -16,6 +16,7 @@ class RunWooApiTestCommand extends RunE2ECommand {
 		parent::configure();
 		$this->setDescription( 'Run WooCommerce Core API tests' );
 		$this->configure_extension_set_option();
+		$this->configure_remote_option();
 		$this->addOption(
 			'optional_features',
 			null,
@@ -26,7 +27,7 @@ class RunWooApiTestCommand extends RunE2ECommand {
 	}
 
 	protected function doExecute( QITInput $input, OutputInterface $output ): int {
-		$remote_result = $this->run_remote_extension_set_if_provided( $input, $output, 'woo-api' );
+		$remote_result = $this->run_remote_if_requested( $input, $output, 'woo-api' );
 		if ( $remote_result !== null ) {
 			return $remote_result;
 		}

--- a/src/src/Commands/RunWooE2ETestCommand.php
+++ b/src/src/Commands/RunWooE2ETestCommand.php
@@ -15,10 +15,11 @@ class RunWooE2ETestCommand extends RunE2ECommand {
 		parent::configure();
 		$this->setDescription( 'Run WooCommerce Core E2E tests' );
 		$this->configure_extension_set_option();
+		$this->configure_remote_option();
 	}
 
 	protected function doExecute( QITInput $input, OutputInterface $output ): int {
-		$remote_result = $this->run_remote_extension_set_if_provided( $input, $output, 'woo-e2e', 'woo-e2e' );
+		$remote_result = $this->run_remote_if_requested( $input, $output, 'woo-e2e', 'woo-e2e' );
 		if ( $remote_result !== null ) {
 			return $remote_result;
 		}

--- a/src/src/PreCommand/Extensions/ExtensionResolver.php
+++ b/src/src/PreCommand/Extensions/ExtensionResolver.php
@@ -128,8 +128,10 @@ class ExtensionResolver {
 				// Step 2: Check if extension is already cached (avoid metadata API call if possible)
 				$is_cached = $this->cache_manager->is_cached( $extension, $cache_dir );
 
-				// Step 3: Fetch metadata only if not cached (version, download URL, etc.)
-				if ( ! $is_cached ) {
+				// Local metadata comes from the source itself, even when it is already cached.
+				if ( in_array( $extension->from, [ 'local', 'build' ], true ) ) {
+					$this->metadata_fetcher->fetch_metadata( [ $extension ] );
+				} elseif ( ! $is_cached ) {
 					try {
 						if ( in_array( $extension->from, [ 'wporg', 'wccom' ], true ) ) {
 							debug_log( '  Extension not cached, fetching metadata for remote extension' );

--- a/src/src/RemoteTestRunner.php
+++ b/src/src/RemoteTestRunner.php
@@ -175,30 +175,30 @@ class RemoteTestRunner {
 	): array {
 		$profile_name      = $input->get_profile_name();
 		$profile_test_type = $profile_test_type ?? $test_type;
-		$profile           = $this->get_profile_with_fallback( $command, $profile_test_type, $profile_name );
-		$options           = [];
+		$profile           = EnvironmentConfigResolver::normalize_aliases(
+			$this->get_profile_with_fallback( $command, $profile_test_type, $profile_name )
+		);
+		$environment       = [];
 
 		$environment_name = null;
 		$cli_environment  = $input->hasOption( 'environment' ) ? $input->getOption( 'environment' ) : null;
-		if ( is_string( $cli_environment ) ) {
+		if ( $input->hasOption( 'environment' ) && is_string( $cli_environment ) ) {
 			$environment_name = $cli_environment;
 		} elseif ( isset( $profile['environment'] ) && is_string( $profile['environment'] ) ) {
 			$environment_name = $profile['environment'];
 		}
 
 		if ( $environment_name !== null ) {
-			$options = EnvironmentConfigResolver::normalize_aliases( $command->get_environment_config( $environment_name ) );
+			$environment = EnvironmentConfigResolver::normalize_aliases( $command->get_environment_config( $environment_name ) );
 		}
 
-		foreach ( $profile as $key => $value ) {
-			if ( $key === 'environment' ) {
-				continue;
-			}
+		$effective_config = array_replace( $environment, $profile );
+		$payload_keys     = array_values( array_diff( array_keys( $options_to_send ), [ 'environment', 'remote', 'sut', 'zip' ] ) );
+		$this->validate_effective_remote_config( $effective_config, $payload_keys );
 
-			$options[ $key ] = $value;
-		}
+		$options = array_intersect_key( $effective_config, array_flip( $payload_keys ) );
 
-		foreach ( array_keys( $options_to_send ) as $opt_name ) {
+		foreach ( $payload_keys as $opt_name ) {
 			if ( ! $input->hasOption( $opt_name ) ) {
 				continue;
 			}
@@ -212,10 +212,15 @@ class RemoteTestRunner {
 			}
 		}
 
-		$sut_arg = $input->getArgument( 'sut' ) ?: ( $options['sut']['slug'] ?? '' );
+		$positional_sut = $input->getArgument( 'sut' );
+		$effective_sut  = isset( $effective_config['sut'] ) && is_array( $effective_config['sut'] )
+			? $effective_config['sut']
+			: [];
+		$sut_arg        = $positional_sut ?: ( $effective_sut['slug'] ?? '' );
 		if ( empty( $sut_arg ) ) {
 			throw new \InvalidArgumentException( 'No System-Under-Test specified (argument or profile).' );
 		}
+		$this->validate_remote_sut_source( $input, $positional_sut, $effective_sut );
 
 		$options['woo_id'] = $this->slug_or_id_to_id( (string) $sut_arg );
 		$this->process_zip_option( $input, $output, (string) $sut_arg, $options );
@@ -225,6 +230,59 @@ class RemoteTestRunner {
 		}
 
 		return $options;
+	}
+
+	/**
+	 * @param array<string,mixed> $effective_config Selected profile and environment configuration.
+	 * @param array<string>       $payload_keys     Manager-supported payload keys.
+	 */
+	private function validate_effective_remote_config( array $effective_config, array $payload_keys ): void {
+		$allowed     = array_merge( $payload_keys, [ 'environment', 'sut' ] );
+		$unsupported = [];
+
+		foreach ( $effective_config as $key => $value ) {
+			if ( in_array( $key, $allowed, true ) || $this->is_empty_config_value( $value ) ) {
+				continue;
+			}
+
+			$unsupported[] = $key;
+		}
+
+		if ( empty( $unsupported ) ) {
+			return;
+		}
+
+		sort( $unsupported );
+		throw new \InvalidArgumentException( sprintf(
+			'Remote execution does not support effective qit.json option(s): %s.',
+			implode( ', ', $unsupported )
+		) );
+	}
+
+	/**
+	 * @param mixed $value
+	 */
+	private function is_empty_config_value( $value ): bool {
+		return $value === null || $value === false || $value === '' || $value === [];
+	}
+
+	/**
+	 * @param QITInput            $input          The command input.
+	 * @param string|null         $positional_sut Explicit positional SUT override.
+	 * @param array<string,mixed> $effective_sut
+	 */
+	private function validate_remote_sut_source( QITInput $input, ?string $positional_sut, array $effective_sut ): void {
+		if ( ! empty( $positional_sut ) || $input->hasOption( 'zip' ) ) {
+			return;
+		}
+
+		$source      = $effective_sut['source'] ?? [];
+		$source_type = is_array( $source ) ? ( $source['type'] ?? null ) : null;
+		if ( in_array( $source_type, [ 'build', 'local', 'url' ], true ) ) {
+			throw new \InvalidArgumentException(
+				'Remote execution does not infer development SUT sources from qit.json. Pass the source explicitly with --zip.'
+			);
+		}
 	}
 
 	/**

--- a/src/tests/unit/ExtensionResolverWooVersionTest.php
+++ b/src/tests/unit/ExtensionResolverWooVersionTest.php
@@ -89,12 +89,31 @@ class ExtensionResolverWooVersionTest extends QITTestCase {
 	}
 
 	public function test_resolve_source_leaves_woo_dev_url_untouched_when_already_a_url(): void {
-		$ext          = $this->woo( '11.0.0-dev', 'url' );
-		$ext->source  = 'https://example.com/custom-woocommerce.zip';
+		$ext         = $this->woo( '11.0.0-dev', 'url' );
+		$ext->source = 'https://example.com/custom-woocommerce.zip';
 		$this->invoke( $this->resolver(), 'resolve_extension_source', $ext );
 
 		// An explicit url source is already resolved and must not be overridden.
 		$this->assertSame( 'url', $ext->from );
 		$this->assertSame( 'https://example.com/custom-woocommerce.zip', $ext->source );
+	}
+
+	public function test_resolve_extracts_version_from_cached_local_theme(): void {
+		$directory = sys_get_temp_dir() . '/qit-local-theme-' . uniqid();
+		mkdir( $directory );
+		file_put_contents( $directory . '/style.css', "/*\nTheme Name: Local Theme\nVersion: 1.2.3\n*/" );
+
+		$extension            = new Extension( 'local-theme', 'theme' );
+		$extension->from      = 'local';
+		$extension->source    = $directory;
+		$extension->directory = $directory;
+
+		try {
+			$this->resolver()->resolve( [ $extension ], sys_get_temp_dir() );
+			$this->assertSame( '1.2.3', $extension->version );
+		} finally {
+			unlink( $directory . '/style.css' );
+			rmdir( $directory );
+		}
 	}
 }

--- a/src/tests/unit/RunManagedTestExtensionSetTest.php
+++ b/src/tests/unit/RunManagedTestExtensionSetTest.php
@@ -37,6 +37,37 @@ class RunManagedTestExtensionSetTest extends QITTestCase {
 	}
 
 	/**
+	 * @return array<string,array{string,string}>
+	 */
+	public function remote_command_provider(): array {
+		return [
+			'activation' => [ 'run:activation', 'activation' ],
+			'woo-api'    => [ 'run:woo-api', 'woo-api' ],
+			'woo-e2e'    => [ 'run:woo-e2e', 'woo-e2e' ],
+		];
+	}
+
+	/**
+	 * @return array<string,array{array<string,string>}>
+	 */
+	public function development_sut_source_provider(): array {
+		return [
+			'local' => [
+				[
+					'type' => 'local',
+					'path' => '/tmp/private-plugin',
+				],
+			],
+			'url'   => [
+				[
+					'type' => 'url',
+					'url'  => 'https://example.test/private-plugin.zip',
+				],
+			],
+		];
+	}
+
+	/**
 	 * @dataProvider extension_set_command_provider
 	 */
 	public function test_command_exposes_extension_set_option( string $command_name ): void {
@@ -46,6 +77,101 @@ class RunManagedTestExtensionSetTest extends QITTestCase {
 			$command->getDefinition()->hasOption( 'extension_set' ),
 			sprintf( '%s must expose the --extension_set option.', $command_name )
 		);
+	}
+
+	/**
+	 * @dataProvider extension_set_command_provider
+	 */
+	public function test_managed_alias_exposes_remote_option( string $command_name ): void {
+		$command = $GLOBALS['qit_application']->find( $command_name );
+
+		$this->assertTrue(
+			$command->getDefinition()->hasOption( 'remote' ),
+			sprintf( '%s must expose the --remote option.', $command_name )
+		);
+	}
+
+	public function test_generic_e2e_does_not_expose_remote_option(): void {
+		$command = $GLOBALS['qit_application']->find( 'run:e2e' );
+
+		$this->assertFalse( $command->getDefinition()->hasOption( 'remote' ) );
+	}
+
+	/**
+	 * @dataProvider remote_command_provider
+	 */
+	public function test_explicit_remote_async_enqueues_the_managed_test_type( string $command_name, string $test_type ): void {
+		$enqueue_url = sprintf( '%s/wp-json/cd/v1/enqueue-%s', \QIT_CLI\get_manager_url(), $test_type );
+		App::setVar( 'mock_' . $enqueue_url, json_encode( [ 'test_run_id' => 4242 ] ) );
+		App::setVar( 'mocked_request', null );
+
+		try {
+			$application = $this->make_application_tester();
+			$exit_code   = $application->run( [
+				'command'  => $command_name,
+				'sut'      => 'woocommerce',
+				'--remote' => true,
+				'--async'  => true,
+				'--json'   => true,
+			] );
+			$request     = App::getVar( 'mocked_request' );
+		} finally {
+			App::setVar( 'mock_' . $enqueue_url, null );
+			App::setVar( 'mocked_request', null );
+		}
+
+		$this->assertSame( Command::SUCCESS, $exit_code, $application->getDisplay() );
+		$this->assertIsArray( $request );
+		$this->assertSame( $enqueue_url, $request['url'] );
+		$this->assertArrayNotHasKey( 'remote', $request['post_body'] );
+		$this->assertArrayNotHasKey( 'sut', $request['post_body'] );
+
+		$response = json_decode( $application->getDisplay(), true );
+		$this->assertIsArray( $response );
+		$this->assertSame( 4242, $response['test_run_id'] );
+	}
+
+	public function test_explicit_remote_rejects_local_only_options(): void {
+		putenv( 'QIT_SELF_TEST=remote_test' );
+		try {
+			$application = $this->make_application_tester( function ( $application ) {
+				$application->add( App::make( \QIT_CLI\Commands\RunWooApiTestCommand::class ) );
+			} );
+			$exit_code   = $application->run( [
+				'command'        => 'run:woo-api',
+				'sut'            => 'woocommerce',
+				'--remote'       => true,
+				'--test-package' => [ 'woocommerce/core-api-tests:latest' ],
+				'--json'         => true,
+			] );
+		} finally {
+			putenv( 'QIT_SELF_TEST' );
+		}
+
+		$this->assertSame( Command::INVALID, $exit_code );
+		$this->assertStringContainsString( 'local-only option', $application->getDisplay() );
+		$this->assertStringContainsString( '--test-package', $application->getDisplay() );
+	}
+
+	public function test_remote_run_is_rejected_inside_a_manager_worker(): void {
+		putenv( 'QIT_SELF_TEST=remote_test' );
+		putenv( 'QIT_TEST_RUN_ID=4242' );
+		try {
+			$application = $this->make_application_tester();
+			$exit_code   = $application->run( [
+				'command'  => 'run:woo-api',
+				'sut'      => 'woocommerce',
+				'--remote' => true,
+				'--json'   => true,
+			] );
+		} finally {
+			putenv( 'QIT_TEST_RUN_ID' );
+			putenv( 'QIT_SELF_TEST' );
+		}
+
+		$this->assertSame( Command::INVALID, $exit_code );
+		$this->assertStringContainsString( 'QIT_TEST_RUN_ID is set', $application->getDisplay() );
+		$this->assertStringNotContainsString( '4242', $application->getDisplay() );
 	}
 
 	public function test_resolves_extension_set_into_plugins(): void {
@@ -251,6 +377,129 @@ class RunManagedTestExtensionSetTest extends QITTestCase {
 
 		$this->assertSame( '6.6.1', $options['wordpress_version'] );
 		$this->assertSame( '8.3', $options['php_version'] );
+	}
+
+	public function test_remote_rejects_unsupported_effective_config_without_leaking_values(): void {
+		$config_path = $this->write_config( [
+			'environments' => [
+				'remote-env' => [
+					'envs' => [ 'API_TOKEN' => 'environment-secret-value' ],
+				],
+			],
+			'test_types'   => [
+				'woo-api' => [
+					'default' => [
+						'environment' => 'remote-env',
+						'blueprint'   => 'profile-secret-value',
+					],
+				],
+			],
+		] );
+
+		putenv( 'QIT_SELF_TEST=remote_test' );
+		try {
+			$application = $this->make_application_tester( function ( $application ) {
+				$application->add( App::make( \QIT_CLI\Commands\RunWooApiTestCommand::class ) );
+			} );
+			$exit_code   = $application->run( [
+				'command'  => 'run:woo-api',
+				'sut'      => 'woocommerce',
+				'--remote' => true,
+				'--config' => $config_path,
+				'--json'   => true,
+			] );
+		} finally {
+			putenv( 'QIT_SELF_TEST' );
+			unlink( $config_path );
+		}
+
+		$this->assertSame( Command::INVALID, $exit_code );
+		$this->assertStringContainsString( 'blueprint', $application->getDisplay() );
+		$this->assertStringContainsString( 'envs', $application->getDisplay() );
+		$this->assertStringNotContainsString( 'profile-secret-value', $application->getDisplay() );
+		$this->assertStringNotContainsString( 'environment-secret-value', $application->getDisplay() );
+	}
+
+	/**
+	 * @dataProvider development_sut_source_provider
+	 * @param array<string,string> $source
+	 */
+	public function test_configured_development_sut_requires_explicit_zip( array $source ): void {
+		$config_path = $this->write_config( [
+			'test_types' => [
+				'woo-api' => [
+					'default' => [
+						'sut' => [
+							'type'   => 'plugin',
+							'slug'   => 'woocommerce',
+							'source' => $source,
+						],
+					],
+				],
+			],
+		] );
+
+		putenv( 'QIT_SELF_TEST=remote_test' );
+		try {
+			$application = $this->make_application_tester( function ( $application ) {
+				$application->add( App::make( \QIT_CLI\Commands\RunWooApiTestCommand::class ) );
+			} );
+			$exit_code   = $application->run( [
+				'command'  => 'run:woo-api',
+				'--remote' => true,
+				'--config' => $config_path,
+				'--json'   => true,
+			] );
+		} finally {
+			putenv( 'QIT_SELF_TEST' );
+			unlink( $config_path );
+		}
+
+		$this->assertSame( Command::INVALID, $exit_code );
+		$this->assertStringContainsString( 'Pass the source explicitly with --zip', $application->getDisplay() );
+		$this->assertStringNotContainsString( $source['path'] ?? $source['url'] ?? $source['command'], $application->getDisplay() );
+	}
+
+	public function test_explicit_zip_strips_effective_sut_from_remote_payload(): void {
+		$config_path = $this->write_config( [
+			'test_types' => [
+				'woo-api' => [
+					'default' => [
+						'sut' => [
+							'type'   => 'plugin',
+							'slug'   => 'woocommerce',
+							'source' => [
+								'type' => 'local',
+								'path' => '/tmp/private-plugin',
+							],
+						],
+					],
+				],
+			],
+		] );
+		$zip_path    = $this->write_plugin_zip();
+		$this->mock_upload_response( 'upload-explicit-zip' );
+		App::setVar( 'QIT_JSON_MODE', true );
+
+		try {
+			$options = $this->run_remote_payload_command( [
+				'command'  => 'run:woo-api',
+				'--remote' => true,
+				'--config' => $config_path,
+				'--zip'    => $zip_path,
+				'--json'   => true,
+			] );
+		} finally {
+			App::setVar( 'QIT_JSON_MODE', null );
+			unlink( $zip_path );
+			unlink( $config_path );
+		}
+
+		$this->assertSame( 'upload-explicit-zip', $options['upload_id'] );
+		$this->assertSame( 'cli_development_extension_test', $options['event'] );
+		$this->assertArrayNotHasKey( 'remote', $options );
+		$this->assertArrayNotHasKey( 'sut', $options );
+		$this->assertArrayNotHasKey( 'zip', $options );
 	}
 
 	public function test_woo_e2e_extension_set_prefers_woo_e2e_profile(): void {


### PR DESCRIPTION
## Summary

- Add an explicit `--remote` execution switch to `run:activation`, `run:woo-api`, and `run:woo-e2e`.
- Reuse the existing Manager enqueue, ZIP upload, async, and polling path while keeping local package execution as the default.
- Reject worker recursion and unsupported local-only configuration instead of silently dropping configuration on remote runs.
- Preserve package test types in lifecycle CTRF data and resolve metadata for cached local extensions.

## Why

The package-backed managed commands now execute locally by default. Callers that need horizontal execution through the Manager still need an explicit, composable route: `--remote` chooses where the test runs, while `--async` independently chooses whether the caller waits.

Local ZIPs use the existing upload flow: the CLI uploads the build, enqueues its `upload_id`, and the remote worker downloads it before running the package locally. Generic `run:e2e` remains local because its blueprints, environments, secrets, volumes, and arbitrary package configuration do not have a lossless remote contract.

## Behavior

- No flag: local synchronous package run, unchanged.
- `--remote`: enqueue through the Manager and wait.
- `--remote --async --json`: enqueue and return the `test_run_id`.
- `--extension_set`: remains implicitly remote for backward compatibility.
- Inner CI workers reject remote recursion through `QIT_TEST_RUN_ID`.

## Validation

- `RunManagedTestExtensionSetTest`: 37 tests, 133 assertions.
- `ExtensionResolverWooVersionTest`: 8 tests, 11 assertions.
- `TestPackageManifestTest`: 11 tests, 32 assertions.
- Targeted PHPCS, PHP lint, and `git diff --check` pass.
- Full unit suite, PHPStan, and Phan passed before the final focused metadata commit; the changed metadata code is covered by the focused tests and PHPCS.

## Compatibility note

Remote execution now fails closed when the effective `qit.json` configuration contains unsupported local-only keys. This is intentional: silently ignoring those values could run a different test plan remotely.
