### PR TITLE
Fix list-tests by dropping the default test_types filter

### DIFF
--- a/src/src/Commands/ListCommand.php
+++ b/src/src/Commands/ListCommand.php
@@ -29,12 +29,19 @@ class ListCommand extends QITCommand {
 
 	protected function configure(): void {
 		parent::configure();
-		$test_types_list = implode( ', ', $this->cache->get_manager_sync_data( 'test_types' ) );
+		$test_types_list = implode( ', ', $this->get_allowed_test_types() );
 		$this
 			->setDescription( 'List test runs.' )
 			->addOption( 'extensions', 'e', InputOption::VALUE_OPTIONAL, '(Optional) Retrieve results for these extensions (Accepts slugs or IDs, comma-separated).' )
 			->addOption( 'test_status', 's', InputOption::VALUE_OPTIONAL, '(Optional) What test status to retrieve.' )
-			->addOption( 'test_types', 't', InputOption::VALUE_OPTIONAL, '(Optional) What test types to retrieve. Allowed values: ' . $test_types_list, $test_types_list )
+
+			/*
+			 * No default on purpose: omitting "test_types" makes the Manager return every test type.
+			 * Defaulting to the full sync list instead sent every known test type as an explicit
+			 * filter, which failed validation as soon as sync advertised a test type that the
+			 * endpoint schema did not allow yet ("Invalid parameter(s): test_types").
+			 */
+			->addOption( 'test_types', 't', InputOption::VALUE_OPTIONAL, '(Optional) What test types to retrieve (comma-separated). Defaults to all. Allowed values: ' . $test_types_list )
 			->addOption( 'page', 'p', InputOption::VALUE_OPTIONAL, '(Optional) The page to get.', 1 )
 			->addOption( 'per_page', 'pp', InputOption::VALUE_OPTIONAL, '(Optional) How many results per page.', 10 )
 			->setHelp( <<<'HELP'
@@ -45,7 +52,33 @@ HELP
 			);
 	}
 
+	/**
+	 * The test types this CLI knows about, as advertised by the Manager sync.
+	 *
+	 * @return array<string>
+	 */
+	protected function get_allowed_test_types(): array {
+		return array_values( (array) $this->cache->get_manager_sync_data( 'test_types' ) );
+	}
+
 	protected function doExecute( QITInput $input, OutputInterface $output ): int {
+		$test_types = $input->getOption( 'test_types' );
+
+		if ( ! empty( $test_types ) ) {
+			$allowed_test_types = $this->get_allowed_test_types();
+			$invalid_test_types = array_diff( array_filter( array_map( 'trim', explode( ',', $test_types ) ) ), $allowed_test_types );
+
+			if ( ! empty( $invalid_test_types ) ) {
+				$output->writeln( sprintf(
+					'<error>Invalid test type(s): %s. Allowed values: %s</error>',
+					implode( ', ', $invalid_test_types ),
+					implode( ', ', $allowed_test_types )
+				) );
+
+				return Command::FAILURE;
+			}
+		}
+
 		if ( $input->getOption( 'extensions' ) ) {
 			foreach ( explode( ',', $input->getOption( 'extensions' ) ) as $e ) {
 				if ( is_numeric( $e ) ) {
@@ -64,16 +97,26 @@ HELP
 			$extensions = implode( ',', $extensions );
 		}
 
+		$post_body = [
+			'woo_ids'  => $extensions,
+			// The endpoint parameter is "paged", not "page".
+			'paged'    => $input->getOption( 'page' ),
+			'per_page' => $input->getOption( 'per_page' ),
+		];
+
+		// Only send the filters that were actually set. Empty filters would be rejected by the schema.
+		foreach ( [ 'test_status', 'test_types' ] as $filter ) {
+			$filter_value = $input->getOption( $filter );
+
+			if ( ! empty( $filter_value ) ) {
+				$post_body[ $filter ] = $filter_value;
+			}
+		}
+
 		try {
 			$response = ( new RequestBuilder( get_manager_url() . '/wp-json/cd/v1/get' ) )
 				->with_method( 'POST' )
-				->with_post_body( [
-					'woo_ids'     => $extensions,
-					'test_status' => $input->getOption( 'test_status' ),
-					'test_types'  => $input->getOption( 'test_types' ),
-					'page'        => $input->getOption( 'page' ),
-					'per_page'    => $input->getOption( 'per_page' ),
-				] )
+				->with_post_body( $post_body )
 				->request();
 		} catch ( \Exception $e ) {
 			$output->writeln( "<error>{$e->getMessage()}</error>" );

--- a/src/tests/unit/ListCommandTest.php
+++ b/src/tests/unit/ListCommandTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use QIT_CLI\App;
+use Symfony\Component\Console\Command\Command;
+use function QIT_CLI\get_manager_url;
+
+class ListCommandTest extends \QIT_CLI_Tests\QITTestCase {
+	protected $application_tester;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->application_tester = $this->make_application_tester();
+	}
+
+	/**
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function make_test_runs_response(): array {
+		return [
+			[
+				'test_run_id'         => 12345,
+				'test_type'           => 'e2e',
+				'wordpress_version'   => '6.7.1',
+				'woocommerce_version' => '9.6.0',
+				'status'              => 'success',
+				'woo_extension'       => [
+					'id'   => 123456,
+					'name' => 'WooCommerce',
+					'type' => 'plugin',
+				],
+				'version'             => '9.6.0',
+				'created_at'          => '2025-01-15 10:30:00',
+			],
+		];
+	}
+
+	private function mock_get_endpoint(): void {
+		App::setVar(
+			sprintf( 'mock_%s%s', get_manager_url(), '/wp-json/cd/v1/get' ),
+			json_encode( $this->make_test_runs_response() )
+		);
+	}
+
+	/**
+	 * Regression test: the command used to default "test_types" to every test type advertised by
+	 * the Manager sync. As soon as sync advertised a test type the endpoint schema did not allow,
+	 * every "qit list-tests" run failed with "Invalid parameter(s): test_types".
+	 */
+	public function test_list_tests_does_not_send_a_test_types_filter_by_default(): void {
+		$this->mock_get_endpoint();
+
+		$exit_code = $this->application_tester->run(
+			[ 'command' => 'list-tests' ],
+			[ 'capture_stderr_separately' => true ]
+		);
+
+		$this->assertSame( Command::SUCCESS, $exit_code );
+
+		$request = App::getVar( 'mocked_request' );
+		$this->assertArrayNotHasKey( 'test_types', $request['post_body'] );
+		$this->assertArrayNotHasKey( 'test_status', $request['post_body'] );
+	}
+
+	public function test_list_tests_sends_the_test_types_filter_when_given(): void {
+		$this->mock_get_endpoint();
+
+		$exit_code = $this->application_tester->run(
+			[
+				'command'      => 'list-tests',
+				'--test_types' => 'e2e,security',
+			],
+			[ 'capture_stderr_separately' => true ]
+		);
+
+		$this->assertSame( Command::SUCCESS, $exit_code );
+
+		$request = App::getVar( 'mocked_request' );
+		$this->assertSame( 'e2e,security', $request['post_body']['test_types'] );
+	}
+
+	public function test_list_tests_rejects_unknown_test_types_before_requesting(): void {
+		App::setVar(
+			sprintf( 'mock_%s%s', get_manager_url(), '/wp-json/cd/v1/get' ),
+			'exception: The request should not have been made'
+		);
+
+		$exit_code = $this->application_tester->run(
+			[
+				'command'      => 'list-tests',
+				'--test_types' => 'e2e,not-a-test-type',
+			],
+			[ 'capture_stderr_separately' => true ]
+		);
+
+		$this->assertSame( Command::FAILURE, $exit_code );
+		$this->assertStringContainsString( 'Invalid test type(s): not-a-test-type', $this->application_tester->getDisplay() );
+	}
+
+	/**
+	 * The endpoint parameter is "paged". Sending "page" meant --page was silently ignored and
+	 * every run returned the first page.
+	 */
+	public function test_list_tests_sends_the_page_as_paged(): void {
+		$this->mock_get_endpoint();
+
+		$exit_code = $this->application_tester->run(
+			[
+				'command'    => 'list-tests',
+				'--page'     => '3',
+				'--per_page' => '5',
+			],
+			[ 'capture_stderr_separately' => true ]
+		);
+
+		$this->assertSame( Command::SUCCESS, $exit_code );
+
+		$request = App::getVar( 'mocked_request' );
+		$this->assertSame( '3', $request['post_body']['paged'] );
+		$this->assertSame( '5', $request['post_body']['per_page'] );
+		$this->assertArrayNotHasKey( 'page', $request['post_body'] );
+	}
+}


### PR DESCRIPTION
## What changed

`qit list-tests` runs again. It sends a `test_types` filter only when one is given, and rejects unknown types locally, naming the allowed values.

## Why

`--test_types` defaulted to every test type in the Manager sync. Sync advertises `TestRun::get_cli_test_types()`, which includes the beta type `api-fuzz`; `/wp-json/cd/v1/get` validates against `TestRun::$allowed_test_types`, which does not. So every default run failed with `Invalid parameter(s): test_types`. Reported by @daniel.mallory.

## How it works

Omitting the parameter already means "all test types", so the default is dropped rather than kept in lockstep with the endpoint enum. Sync can now advertise a test type ahead of the schema without breaking the command.

Two adjacent bugs in the same request body: `--page` was posted as `page` while the endpoint expects `paged`, so paging was silently ignored; unset filters were posted as `null` and are now omitted.

## Validation

- New `ListCommandTest`: default request carries no `test_types`, an explicit filter is passed through, an unknown type is rejected before the request, `--page` is sent as `paged`.
- `make phpunit` (365 tests, 1052 assertions), `make phpcs`, `make phpstan`, `make phan` — clean.
- Against production: bare `list-tests` (exit 1 before this change), `--test_types=e2e`, `--test_status=failed`, and `--per_page=3 --page=2` returning a different page than `--page=1`.

## Known limitation

`--test_types=api-fuzz` still fails. This will be fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)