### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/actions/restore-docker-cache/action.yml
+++ b/.github/actions/restore-docker-cache/action.yml
@@ -8,10 +8,10 @@ runs:
   using: composite
   steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
     - name: Restore Docker image cache
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
       id: cache-docker
       with:
         path: qit-cli-tests-${{ inputs.php-version }}.tar

--- a/.github/workflows/check-runtime-version.yml
+++ b/.github/workflows/check-runtime-version.yml
@@ -8,9 +8,9 @@ jobs:
   check-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 

--- a/.github/workflows/code-tests.yml
+++ b/.github/workflows/code-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Restore Docker Cache (default PHP 8.3)
         uses: ./.github/actions/restore-docker-cache
@@ -23,7 +23,7 @@ jobs:
           php-version: "8.3"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         id: cache-composer
         with:
           path: src/vendor

--- a/.github/workflows/phan.yml
+++ b/.github/workflows/phan.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Restore Docker Cache
         uses: ./.github/actions/restore-docker-cache
@@ -26,7 +26,7 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Cache composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         id: cache-composer
         with:
           path: src/vendor

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Restore Docker Cache
         uses: ./.github/actions/restore-docker-cache
@@ -26,7 +26,7 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Cache composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         id: cache-composer
         with:
           path: src/vendor

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -13,9 +13,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/qit-custom-test-woocommerce.yml
+++ b/.github/workflows/qit-custom-test-woocommerce.yml
@@ -14,12 +14,12 @@ jobs:
         shardIndex: [1, 2, 3, 4]
         shardTotal: [4]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 18
       - name: Setup PHP (Cross-platform)
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.3'
 
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload blob report to GitHub Actions Artifacts
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: blob-report-${{ matrix.shardIndex }}
           path: ${{ env.BLOB_REPORT_PATH }}
@@ -63,8 +63,8 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 18
 
@@ -72,7 +72,7 @@ jobs:
         run: npm install playwright
 
       - name: Download blob reports from GitHub Actions Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: all-blob-reports
           pattern: blob-report-*
@@ -82,7 +82,7 @@ jobs:
         run: npx playwright merge-reports --reporter html ./all-blob-reports
 
       - name: Upload HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: html-report--attempt-${{ github.run_attempt }}
           path: playwright-report

--- a/.github/workflows/qit-environment-test-linux.yml
+++ b/.github/workflows/qit-environment-test-linux.yml
@@ -25,10 +25,10 @@ jobs:
       QIT_DISABLE_ONBOARDING: yes
     steps:
       - name: Checkout code (Cross-platform)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup PHP (Cross-platform)
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.3'
 

--- a/.github/workflows/qit-environment-test-mac.yml
+++ b/.github/workflows/qit-environment-test-mac.yml
@@ -26,10 +26,10 @@ jobs:
       QIT_DISABLE_ONBOARDING: yes
     steps:
       - name: Checkout code (Cross-platform)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup PHP (Cross-platform)
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.3'
 

--- a/.github/workflows/qit-self-group-test.yml
+++ b/.github/workflows/qit-self-group-test.yml
@@ -21,13 +21,13 @@ jobs:
       QIT_SELF_TESTS: 1
     steps:
       - name: Checkout code (Cross-platform)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Create tmp directory on the workspace.
         run: mkdir -p ${{ github.workspace }}/tmp
 
       - name: Setup PHP (Cross-platform)
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.4'
           extensions: imagick
@@ -57,7 +57,7 @@ jobs:
         run: make test-group
 
       - name: Upload results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: qit-results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           tools: none
           php-version: '7.4'

--- a/.github/workflows/restore-docker-cache.yml
+++ b/.github/workflows/restore-docker-cache.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Restore Docker image cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         id: cache-docker
         with:
           path: qit-cli-tests-${{ inputs.php-version }}.tar

--- a/.github/workflows/self-test-template.yml
+++ b/.github/workflows/self-test-template.yml
@@ -46,10 +46,10 @@ jobs:
           sleep "$WAIT_SECONDS"
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '7.4'
 
@@ -83,7 +83,7 @@ jobs:
 
       - name: Restore ZIP Image Cache if it exists
         id: cache-docker-zip
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: cache-zip
           key: cache-docker-zip-${{ env.ZIP_YEAR }}-${{ env.ZIP_MONTH }}
@@ -107,7 +107,7 @@ jobs:
       # After the tests run, upload all qit_non_json_ files (each test has its own)
       - name: Upload all QIT non-JSON output files
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: qit-non-json-outputs
           path: '/tmp/qit_non_json_*'


### PR DESCRIPTION
### Changes proposed in this Pull Request

The WooCommerce GitHub organization intends to enforce full-commit-SHA pinning for GitHub Actions. This change replaces every mutable external Action tag or branch used by this repository with the current 40-character commit SHA and preserves the original human-readable ref in a trailing comment.

Immutable pins reduce supply-chain compromise risk if an upstream tag or branch is moved or an Action repository is compromised. Local actions and reusable workflows remain unchanged.

### Verification

- [x] Re-audited the current default branch and pinned every mutable external Action reference.
- [x] Independently re-resolved each distinct tag or branch and confirmed it matches the pinned SHA.
- [x] Confirmed the post-change scan reports zero mutable external Action references.
- [x] Parsed every changed workflow and composite-action YAML file successfully.
- [x] Ran git diff --check.
- [x] Confirmed the diff contains only intended uses: reference changes.

### Backward compatibility impact

No backward-compatibility impact. This changes CI and automation configuration only.

### Changelog

No changelog entry is needed because this is a workflow-only configuration change with no product or runtime behavior change.

### Test steps

1. Inspect each changed uses: reference and confirm it is a full 40-character SHA with the original ref in a trailing comment.
2. Confirm repository workflows and composite actions load successfully in GitHub Actions.
3. Confirm the post-change SHA-pin scan reports zero findings.