### PR TITLE
ci: add job-level timeout-minutes to workflow jobs

### DIFF
--- a/.github/workflows/check-runtime-version.yml
+++ b/.github/workflows/check-runtime-version.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   check-version:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 

--- a/.github/workflows/code-tests.yml
+++ b/.github/workflows/code-tests.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   code_tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/.github/workflows/phan.yml
+++ b/.github/workflows/phan.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   phan_tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       matrix:
         php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   phpunit_tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       matrix:
         php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 

--- a/.github/workflows/qit-custom-test-woocommerce.yml
+++ b/.github/workflows/qit-custom-test-woocommerce.yml
@@ -62,6 +62,7 @@ jobs:
     needs: [playwright-tests]
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/qit-environment-test-linux.yml
+++ b/.github/workflows/qit-environment-test-linux.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   linux_environment_test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     strategy:
       matrix:
         os: [ ubuntu-latest ]

--- a/.github/workflows/qit-environment-test-mac.yml
+++ b/.github/workflows/qit-environment-test-mac.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   mac_environment_test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     if: false # Docker on Mac in GitHub Actions is broken. We need to wait. https://github.com/douglascamata/setup-docker-macos-action/issues/37
     strategy:
       matrix:

--- a/.github/workflows/qit-self-group-test.yml
+++ b/.github/workflows/qit-self-group-test.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   self_test_custom_test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     env:
       NO_COLOR: 1
       QIT_DISABLE_ONBOARDING: yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     needs: [ code-tests ]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       NO_COLOR: 1
       QIT_DISABLE_ONBOARDING: yes

--- a/.github/workflows/restore-docker-cache.yml
+++ b/.github/workflows/restore-docker-cache.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   restore-docker-cache:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/.github/workflows/self-test-template.yml
+++ b/.github/workflows/self-test-template.yml
@@ -18,6 +18,7 @@ on:
 jobs:
   self_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       NO_COLOR: 1
       FORCE_COLOR: 0


### PR DESCRIPTION
Add job timeouts so runs fail fast instead of hanging for up to 6 hours.

| Job | Median (30d) | Max (30d) | `timeout-minutes` |
| -- | -- | -- | -- |
| `check-runtime-version.yml` / `check-version` | 0.12 min * | 0.18 min * | 5 |
| `code-tests.yml` / `code_tests` | 1.13 min | 1.57 min | 5 |
| `phan.yml` / `phan_tests` | 0.50 min | 1.07 min | 5 |
| `phpunit.yml` / `phpunit_tests` | 0.47 min | 1.13 min | 5 |
| `publish-runtime.yml` / `publish` | 0.30 min * | 0.30 min * | 5 |
| `qit-custom-test-woocommerce.yml` / `merge-reports` | no runs | no runs | 10 |
| `qit-environment-test-linux.yml` / `linux_environment_test` | 0.82 min | 1.22 min | 5 |
| `qit-environment-test-mac.yml` / `mac_environment_test` | disabled (`if: false`) | disabled (`if: false`) | 30 |
| `qit-self-group-test.yml` / `self_test_custom_test` | 0.55 min | 0.78 min | 5 |
| `release.yml` / `build` | 0.20 min * | 0.28 min * | 5 |
| `restore-docker-cache.yml` / `restore-docker-cache` | no runs | no runs | 20 |
| `self-test-template.yml` / `self_test` | 3.81 min | 23.52 min | 30 |

\* No success in the last 30 days; measured over the last 10 successful runs.

The nine `uses:` jobs take no `timeout-minutes`. They are bounded by `self-test-template.yml` (30) and `code-tests.yml` (5).

Part of TESTOPS-272
