### PR TITLE
Add a qit compare command for two finished test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Environments can also be defined with a [WordPress Playground Blueprint](docs/bl
 - **GitHub Integration**: Integrate QIT into your PR reviews with GitHub Actions.
 - **Test Reports**: Detailed test reports to help you understand the results.
 - **Notifications**: Stay informed with test result notifications.
+- **[Comparing Test Runs](docs/compare.md)**: `qit compare <run-a> <run-b>` shows what changed between two runs that already happened.
 
 ## Documentation
 

--- a/docs/compare.md
+++ b/docs/compare.md
@@ -1,0 +1,103 @@
+# Comparing two test runs
+
+`qit compare <run-a> <run-b>` tells you what changed between two test runs that already
+happened, without re-running anything.
+
+```
+qit compare 12345 12346
+qit compare 12345 12346 --format=json
+```
+
+The first ID is the baseline (**A**), the second is the run being judged against it (**B**).
+
+## What it reports
+
+* **Introduced failures** — tests that passed in A and fail in B
+* **Resolved failures** — tests that failed in A and pass in B
+* **Still failing** — tests that fail in both
+* **Other status changes** — any other transition, e.g. `passed -> skipped`
+* **Added / removed tests** — tests present in only one of the two runs, with their status
+* **Summary counts** — the CTRF counters side by side, with a delta
+* **Annotation changes** — added and removed `extra.annotations` entries, per test
+
+Tests are matched by suite and name. CTRF does not guarantee unique test names, so runs
+that repeat a name keep each occurrence distinct (`my test`, `my test #2`).
+
+## Which test types can be compared
+
+Both runs must report results in CTRF, which covers:
+
+```
+activation       CTRF
+compatibility    CTRF
+ecosystem        CTRF
+woo-api          CTRF
+woo-e2e          CTRF
+```
+
+`qit get <id> --json-results` returns that CTRF verbatim, so anything you can see there is
+what the comparison works from. Comparing a run of a test type that does not emit CTRF
+fails with an explanation rather than a partial diff.
+
+## What survives the round trip
+
+The comparison only sees what makes it back from the machine that ran the tests:
+
+**Does survive:** test names, statuses, durations, `extra.annotations`, `qitPackageMetadata`,
+and the run's own environment metadata (WordPress / WooCommerce / PHP version).
+
+**Does not survive:** attachment contents. CTRF `attachments[]` carries local filesystem
+paths from the runner:
+
+```json
+{"name": "screenshot", "contentType": "image/png",
+ "path": "/Users/.../results/artifacts/.../test-failed-1.png"}
+```
+
+On a CI runner those paths are gone once the job ends.
+
+**Anything you want compared must be emitted as an annotation, not as an attachment.** A
+test package that emits structured, already-normalised findings as `extra.annotations` gets
+compared for free, without `qit compare` knowing what the data means.
+
+## The comparability guard
+
+A comparison is only meaningful when the two runs differ in the one variable you are
+testing. `qit compare` checks the test type, WordPress / WooCommerce / PHP versions, the
+extension and its version, and the test packages recorded in `qitPackageMetadata`.
+
+* No differences, or exactly one — the runs are comparable, and the differing dimension is
+  shown as `differs`.
+* Two or more differences — the comparison is still printed, but flagged, because a change
+  in results cannot be attributed to any single one of them.
+* Different test types — flagged, because the two runs are not the same population of tests.
+
+In `--format=json` this is the `guard` object: `comparable`, `differences` and `warnings`.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0`  | Run B introduced no failures |
+| `1`  | Run B introduced failures (a regression on a shared test, or a new test that fails) |
+| `2`  | The runs could not be fetched or compared |
+
+This makes the command usable as a CI gate:
+
+```
+qit compare "$BASELINE_RUN" "$CANDIDATE_RUN" || echo "New failures against the candidate"
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--format` | `human` (default) or `json` |
+| `--limit`  | Maximum entries printed per section in human output. `0` shows all. Defaults to 25. |
+
+## Relationship to `compatibility-regression`
+
+`compatibility-regression` (the PHPStan sweep) runs both passes inside one job and emits a
+single result that already contains the diff. That works for a pipeline you control, but it
+cannot serve two runs someone already made separately, on different days. `qit compare` is
+for that case. The two are complementary.

--- a/docs/compare.md
+++ b/docs/compare.md
@@ -25,7 +25,25 @@ that repeat a name keep each occurrence distinct (`my test`, `my test #2`).
 
 ## Which test types can be compared
 
-Both runs must report results in CTRF, which covers:
+**Both runs must be of the same test type.** Two test types are two different
+populations of tests, so the diff would degenerate to "every test was removed, every
+other test was added" — and, because a new failing test counts as a failure introduced
+by run B, it would report a regression that says nothing about either run. Comparing
+across test types is refused outright:
+
+```
+$ qit compare 12345 12346
+Cannot compare a "activation" run against a "woo-api" run. Only two runs of the same
+test type share a population of tests. Test run 12345 is "activation" and test run
+12346 is "woo-api".
+```
+
+One wrinkle worth knowing: QIT has recorded the Woo E2E suite under both `woo-e2e` and
+`e2e` at different times, and `sync` advertises both. Two runs of the same suite that
+were recorded under the two different names are refused by this check. The message names
+both types, so it is clear that this is what happened rather than a genuine mismatch.
+
+Both runs must also report results in CTRF, which covers:
 
 ```
 activation       CTRF
@@ -63,14 +81,17 @@ compared for free, without `qit compare` knowing what the data means.
 ## The comparability guard
 
 A comparison is only meaningful when the two runs differ in the one variable you are
-testing. `qit compare` checks the test type, WordPress / WooCommerce / PHP versions, the
-extension and its version, and the test packages recorded in `qitPackageMetadata`.
+testing. `qit compare` checks the WordPress / WooCommerce / PHP versions, the extension
+and its version, and the test packages recorded in `qitPackageMetadata`.
 
 * No differences, or exactly one — the runs are comparable, and the differing dimension is
   shown as `differs`.
 * Two or more differences — the comparison is still printed, but flagged, because a change
   in results cannot be attributed to any single one of them.
-* Different test types — flagged, because the two runs are not the same population of tests.
+
+A differing test type is not part of this guard: it is refused before a comparison is
+built at all, so every difference the guard reports is one the runs can actually be
+judged on.
 
 In `--format=json` this is the `guard` object: `comparable`, `differences` and `warnings`.
 
@@ -80,7 +101,7 @@ In `--format=json` this is the `guard` object: `comparable`, `differences` and `
 |------|---------|
 | `0`  | Run B introduced no failures |
 | `1`  | Run B introduced failures (a regression on a shared test, or a new test that fails) |
-| `2`  | The runs could not be fetched or compared |
+| `2`  | The runs could not be fetched, are of different test types, or could not be compared |
 
 This makes the command usable as a CI gate:
 

--- a/docs/compare.md
+++ b/docs/compare.md
@@ -53,7 +53,6 @@ Both runs must also report results in CTRF, which covers:
 ```
 activation       CTRF
 compatibility    CTRF
-ecosystem        CTRF
 woo-api          CTRF
 woo-e2e          CTRF
 ```

--- a/docs/compare.md
+++ b/docs/compare.md
@@ -101,17 +101,27 @@ In `--format=json` this is the `guard` object: `comparable`, `differences` and `
 
 ## Exit codes
 
+Reporting a difference is not a failure. A comparison that ran exits `0` whatever it
+found, so dropping `qit compare` into a pipeline does not turn the step red and does not
+need a trailing `|| true`.
+
 | Code | Meaning |
 |------|---------|
-| `0`  | Run B introduced no failures |
-| `1`  | Run B introduced failures (a regression on a shared test, or a new test that fails) |
+| `0`  | The comparison ran |
+| `1`  | Only with `--exit-code`: run B introduced failures (a regression on a shared test, or a new test that fails) |
 | `2`  | The runs could not be fetched, are of different test types, or could not be compared |
 
-This makes the command usable as a CI gate:
+To gate on the result, ask for it explicitly — the same split `git diff --exit-code` makes:
 
 ```
-qit compare "$BASELINE_RUN" "$CANDIDATE_RUN" || echo "New failures against the candidate"
+qit compare "$BASELINE_RUN" "$CANDIDATE_RUN" --exit-code
 ```
+
+Note that `2` is not suppressed by anything. A mistyped run ID fails the step rather than
+passing as "no regressions", with or without `--exit-code`.
+
+If you would rather decide for yourself, `--format=json` carries the same answer in
+`totals.introduced` and in the `tests.added` entries whose status is `failed`.
 
 ## Options
 
@@ -119,6 +129,7 @@ qit compare "$BASELINE_RUN" "$CANDIDATE_RUN" || echo "New failures against the c
 |--------|-------------|
 | `--format` | `human` (default) or `json` |
 | `--limit`  | Maximum entries printed per section in human output. `0` shows all. Defaults to 25. |
+| `--exit-code` | Exit `1` when run B introduced failures. Off by default. |
 
 ## Relationship to `compatibility-regression`
 

--- a/docs/compare.md
+++ b/docs/compare.md
@@ -38,10 +38,15 @@ test type share a population of tests. Test run 12345 is "activation" and test r
 12346 is "woo-api".
 ```
 
-One wrinkle worth knowing: QIT has recorded the Woo E2E suite under both `woo-e2e` and
-`e2e` at different times, and `sync` advertises both. Two runs of the same suite that
-were recorded under the two different names are refused by this check. The message names
-both types, so it is clear that this is what happened rather than a genuine mismatch.
+One wrinkle worth knowing: run records for the Woo E2E suite carry two different
+`test_type` spellings. The CLI has changed which value it submits for `run:woo-e2e` more
+than once, and today the two paths of that command still disagree — `--extension-set`
+submits `woo-e2e`, while without one it falls through to the generic E2E command and
+submits `e2e`. `sync` advertises both as test types.
+
+Two runs of that suite recorded under the different spellings are therefore refused by
+this check. That is deliberate rather than an oversight: the message names both types, so
+the case reads as what it is instead of producing a silent wrong answer.
 
 Both runs must also report results in CTRF, which covers:
 

--- a/src/src/Commands/CompareCommand.php
+++ b/src/src/Commands/CompareCommand.php
@@ -43,8 +43,11 @@ Reports, for the two runs:
 	* Summary counts side by side
 	* Changes to the tests' CTRF annotations
 
-Both runs must report results in CTRF format, which covers the activation,
-compatibility, ecosystem, woo-api and woo-e2e test types.
+Both runs must be of the same test type, and must report results in CTRF format,
+which covers the activation, compatibility, ecosystem, woo-api and woo-e2e test
+types. Two different test types are two different populations of tests, so
+comparing them is refused rather than reported as everything being added and
+removed at once.
 
 The comparison only sees what survives the round trip through QIT: test names,
 statuses, durations, "extra.annotations", package metadata, and the run's own
@@ -90,10 +93,12 @@ HELP
 		try {
 			$test_runs = $this->fetch_runs( $run_a, $run_b );
 
-			$comparison = new RunComparison(
-				RunSnapshot::from_manager_run( $run_a, $this->pick_run( $test_runs, $run_a ) ),
-				RunSnapshot::from_manager_run( $run_b, $this->pick_run( $test_runs, $run_b ) )
-			);
+			$snapshot_a = RunSnapshot::from_manager_run( $run_a, $this->pick_run( $test_runs, $run_a ) );
+			$snapshot_b = RunSnapshot::from_manager_run( $run_b, $this->pick_run( $test_runs, $run_b ) );
+
+			$this->assert_same_test_type( $snapshot_a, $snapshot_b );
+
+			$comparison = new RunComparison( $snapshot_a, $snapshot_b );
 		} catch ( \RuntimeException $e ) {
 			$output->writeln( "<error>{$e->getMessage()}</error>" );
 
@@ -137,6 +142,41 @@ HELP
 		}
 
 		return $test_runs;
+	}
+
+	/**
+	 * Refuse to compare runs of different test types.
+	 *
+	 * Two test types are two different populations of tests, so the diff degenerates
+	 * to "every test was removed, every other test was added" - and, because a new
+	 * failing test counts as a failure introduced by run B, it would report a
+	 * regression that says nothing about either run.
+	 *
+	 * Note that the Manager has recorded the Woo E2E suite under both "woo-e2e" and
+	 * "e2e" at different times, and advertises both. Two runs of the same suite
+	 * recorded under the two names are refused here; the message names both types so
+	 * that it is clear what happened.
+	 *
+	 * @throws \RuntimeException If the two runs are of different test types.
+	 */
+	private function assert_same_test_type( RunSnapshot $a, RunSnapshot $b ): void {
+		if ( $a->context['test_type'] === $b->context['test_type'] ) {
+			return;
+		}
+
+		throw new \RuntimeException( sprintf(
+			'Cannot compare a "%s" run against a "%s" run. Only two runs of the same test type share a population of tests. Test run %s is "%s" and test run %s is "%s".',
+			$this->describe_test_type( $a ),
+			$this->describe_test_type( $b ),
+			$a->id,
+			$this->describe_test_type( $a ),
+			$b->id,
+			$this->describe_test_type( $b )
+		) );
+	}
+
+	private function describe_test_type( RunSnapshot $run ): string {
+		return $run->context['test_type'] !== '' ? $run->context['test_type'] : 'unknown';
 	}
 
 	/**

--- a/src/src/Commands/CompareCommand.php
+++ b/src/src/Commands/CompareCommand.php
@@ -152,10 +152,18 @@ HELP
 	 * failing test counts as a failure introduced by run B, it would report a
 	 * regression that says nothing about either run.
 	 *
-	 * Note that the Manager has recorded the Woo E2E suite under both "woo-e2e" and
-	 * "e2e" at different times, and advertises both. Two runs of the same suite
-	 * recorded under the two names are refused here; the message names both types so
-	 * that it is clear what happened.
+	 * The check is strict string equality on the run record's test_type, deliberately.
+	 *
+	 * One consequence is worth knowing. This CLI has changed which test_type it submits
+	 * for run:woo-e2e more than once (99db9c61, b25740f6, b8e41ff2), and today the two
+	 * paths of that command still disagree: --extension-set submits "woo-e2e", while
+	 * without one it falls through to RunE2ECommand and submits "e2e". So run records
+	 * for the Woo E2E suite carry both spellings, and two such runs are refused here
+	 * even though b8e41ff2 settled on "woo-e2e is a flavour of e2e".
+	 *
+	 * Strict equality is kept anyway: this command exists to compare two runs of the
+	 * same type, and the error message names both types, so the case reads as what it
+	 * is rather than as a silent wrong answer.
 	 *
 	 * @throws \RuntimeException If the two runs are of different test types.
 	 */

--- a/src/src/Commands/CompareCommand.php
+++ b/src/src/Commands/CompareCommand.php
@@ -220,8 +220,11 @@ HELP
 	/**
 	 * The Manager reports some errors as a bare JSON string, which reaches us still
 	 * carrying its quotes - "Test run with ID 1 does not exist." - and reads like a
-	 * quoting bug when pasted into a sentence. Unwrap it, and unwrap the {"message":…}
-	 * shape too, falling back to the raw text for anything else.
+	 * quoting bug when pasted into a sentence. Unwrap that, and pass anything else
+	 * through untouched.
+	 *
+	 * The {"message": "..."} shape needs no handling here: RequestBuilder already
+	 * unwraps it before it throws, so it cannot reach this method.
 	 */
 	private function unwrap_manager_message( string $message ): string {
 		$message = trim( $message );
@@ -229,10 +232,6 @@ HELP
 
 		if ( is_string( $decoded ) && trim( $decoded ) !== '' ) {
 			return trim( $decoded );
-		}
-
-		if ( is_array( $decoded ) && isset( $decoded['message'] ) && is_string( $decoded['message'] ) ) {
-			return trim( $decoded['message'] );
 		}
 
 		return $message;

--- a/src/src/Commands/CompareCommand.php
+++ b/src/src/Commands/CompareCommand.php
@@ -30,6 +30,7 @@ class CompareCommand extends QITCommand {
 			->addArgument( 'run_b', InputArgument::REQUIRED, 'The test run ID to compare against the baseline.' )
 			->addOption( 'format', null, InputOption::VALUE_REQUIRED, 'Output format: "human" or "json".', 'human' )
 			->addOption( 'limit', null, InputOption::VALUE_REQUIRED, 'Maximum entries printed per section in human output. Use 0 for no limit.', (string) self::DEFAULT_LIMIT )
+			->addOption( 'exit-code', null, InputOption::VALUE_NONE, 'Exit with 1 when run B introduced failures, for use as a CI gate. Without it, a comparison that ran exits 0 whatever it found.' )
 			->setHelp( <<<'HELP'
 Compare two test runs that already finished, without re-running anything.
 
@@ -59,8 +60,13 @@ When the two runs differ in more than one dimension (WordPress, PHP, package
 version, and so on), the comparison is still printed but flagged, because a
 difference in results cannot be attributed to any single one of them.
 
-Exit status codes: 0 (no failures introduced), 1 (run B introduced failures),
-2 (the runs could not be fetched or compared).
+Reporting a difference is not a failure: a comparison that ran exits 0 whatever it
+found, so dropping this into a pipeline does not turn the step red. Pass
+--exit-code to gate on the result, as you would with "git diff --exit-code", and
+it exits 1 when run B introduced failures.
+
+Exit status codes: 0 (the comparison ran), 1 (only with --exit-code: run B
+introduced failures), 2 (the runs could not be fetched or compared).
 HELP
 			);
 	}
@@ -110,7 +116,19 @@ HELP
 			$this->render_human( $comparison->to_array(), $output, $this->get_limit( $input ) );
 		}
 
-		return $comparison->has_regressions() ? Command::FAILURE : Command::SUCCESS;
+		/*
+		 * Finding a difference is the command working, not the command failing, so the
+		 * result does not colour the exit code unless the caller asks for it. This is
+		 * the "git diff --exit-code" split: a bare compare is safe to drop into a
+		 * pipeline, and gating on the outcome is opted into explicitly. A genuine
+		 * failure - an unfetchable run, two different test types - still exits 2 above,
+		 * so a mistyped ID can never pass silently.
+		 */
+		if ( $input->getOption( 'exit-code' ) && $comparison->has_regressions() ) {
+			return Command::FAILURE;
+		}
+
+		return Command::SUCCESS;
 	}
 
 	/**

--- a/src/src/Commands/CompareCommand.php
+++ b/src/src/Commands/CompareCommand.php
@@ -1,0 +1,409 @@
+<?php
+
+namespace QIT_CLI\Commands;
+
+use QIT_CLI\Compare\RunComparison;
+use QIT_CLI\Compare\RunSnapshot;
+use QIT_CLI\QITInput;
+use QIT_CLI\RequestBuilder;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use function QIT_CLI\get_manager_url;
+
+class CompareCommand extends QITCommand {
+	protected static $defaultName = 'compare'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+
+	/**
+	 * How many entries each section prints before it is truncated, unless --limit says otherwise.
+	 */
+	private const DEFAULT_LIMIT = 25;
+
+	protected function configure(): void {
+		parent::configure();
+		$this
+			->setDescription( 'Compare two finished test runs.' )
+			->addArgument( 'run_a', InputArgument::REQUIRED, 'The baseline test run ID.' )
+			->addArgument( 'run_b', InputArgument::REQUIRED, 'The test run ID to compare against the baseline.' )
+			->addOption( 'format', null, InputOption::VALUE_REQUIRED, 'Output format: "human" or "json".', 'human' )
+			->addOption( 'limit', null, InputOption::VALUE_REQUIRED, 'Maximum entries printed per section in human output. Use 0 for no limit.', (string) self::DEFAULT_LIMIT )
+			->setHelp( <<<'HELP'
+Compare two test runs that already finished, without re-running anything.
+
+	qit compare 12345 12346
+	qit compare 12345 12346 --format=json
+
+Reports, for the two runs:
+
+	* Introduced, resolved and still-failing tests, by name and status
+	* Tests that were added or removed between the runs
+	* Summary counts side by side
+	* Changes to the tests' CTRF annotations
+
+Both runs must report results in CTRF format, which covers the activation,
+compatibility, ecosystem, woo-api and woo-e2e test types.
+
+The comparison only sees what survives the round trip through QIT: test names,
+statuses, durations, "extra.annotations", package metadata, and the run's own
+environment metadata. CTRF attachments do NOT survive - they hold filesystem
+paths from the machine that ran the tests, and those are gone once the job ends.
+A test package that wants its data compared must emit it as an annotation, not
+as an attachment.
+
+When the two runs differ in more than one dimension (WordPress, PHP, package
+version, and so on), the comparison is still printed but flagged, because a
+difference in results cannot be attributed to any single one of them.
+
+Exit status codes: 0 (no failures introduced), 1 (run B introduced failures),
+2 (the runs could not be fetched or compared).
+HELP
+			);
+	}
+
+	protected function doExecute( QITInput $input, OutputInterface $output ): int {
+		$run_a = trim( (string) $input->getArgument( 'run_a' ) );
+		$run_b = trim( (string) $input->getArgument( 'run_b' ) );
+
+		$format = (string) $input->getOption( 'format' );
+
+		if ( ! in_array( $format, [ 'human', 'json' ], true ) ) {
+			$output->writeln( sprintf( '<error>Invalid --format "%s". Allowed values: human, json.</error>', OutputFormatter::escape( $format ) ) );
+
+			return Command::INVALID;
+		}
+
+		if ( $run_a === '' || $run_b === '' ) {
+			$output->writeln( '<error>Both test run IDs are required.</error>' );
+
+			return Command::INVALID;
+		}
+
+		if ( $run_a === $run_b ) {
+			$output->writeln( '<error>Cannot compare a test run against itself.</error>' );
+
+			return Command::INVALID;
+		}
+
+		try {
+			$test_runs = $this->fetch_runs( $run_a, $run_b );
+
+			$comparison = new RunComparison(
+				RunSnapshot::from_manager_run( $run_a, $this->pick_run( $test_runs, $run_a ) ),
+				RunSnapshot::from_manager_run( $run_b, $this->pick_run( $test_runs, $run_b ) )
+			);
+		} catch ( \RuntimeException $e ) {
+			$output->writeln( "<error>{$e->getMessage()}</error>" );
+
+			return Command::INVALID;
+		}
+
+		if ( $format === 'json' ) {
+			$output->writeln( (string) json_encode( $comparison->to_array(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+		} else {
+			$this->render_human( $comparison->to_array(), $output, $this->get_limit( $input ) );
+		}
+
+		return $comparison->has_regressions() ? Command::FAILURE : Command::SUCCESS;
+	}
+
+	/**
+	 * Fetch both runs in a single request, so the two sides of the comparison always
+	 * come from the same read of the Manager.
+	 *
+	 * @return array<int|string,mixed>
+	 *
+	 * @throws \RuntimeException If the runs could not be fetched.
+	 */
+	private function fetch_runs( string $run_a, string $run_b ): array {
+		try {
+			$json = ( new RequestBuilder( get_manager_url() . '/wp-json/cd/v1/get-multiple' ) )
+				->with_method( 'POST' )
+				->with_post_body( [
+					'test_run_ids' => $run_a . ',' . $run_b,
+				] )
+				->with_retry( 3 )
+				->request();
+		} catch ( \Exception $e ) {
+			throw new \RuntimeException( sprintf( 'Could not fetch the test runs: %s', $e->getMessage() ), 0, $e );
+		}
+
+		$test_runs = json_decode( $json, true );
+
+		if ( ! is_array( $test_runs ) ) {
+			throw new \RuntimeException( 'The Manager returned an unexpected response for these test runs.' );
+		}
+
+		return $test_runs;
+	}
+
+	/**
+	 * @param array<int|string,mixed> $test_runs
+	 *
+	 * @return array<string,mixed>
+	 *
+	 * @throws \RuntimeException If the run is not in the response.
+	 */
+	private function pick_run( array $test_runs, string $run_id ): array {
+		if ( isset( $test_runs[ $run_id ] ) && is_array( $test_runs[ $run_id ] ) ) {
+			return $test_runs[ $run_id ];
+		}
+
+		// The Manager keys the response by test run ID, but fall back to a scan rather
+		// than failing over a key that came back as an int, a string or padded.
+		foreach ( $test_runs as $test_run ) {
+			if ( is_array( $test_run ) && isset( $test_run['test_run_id'] ) && (string) $test_run['test_run_id'] === $run_id ) {
+				return $test_run;
+			}
+		}
+
+		throw new \RuntimeException( sprintf( 'Test run %s was not found.', $run_id ) );
+	}
+
+	private function get_limit( QITInput $input ): int {
+		$limit = $input->getOption( 'limit' );
+
+		if ( ! is_numeric( $limit ) || (int) $limit < 0 ) {
+			return self::DEFAULT_LIMIT;
+		}
+
+		return (int) $limit;
+	}
+
+	/**
+	 * @param array<string,mixed> $comparison
+	 */
+	private function render_human( array $comparison, OutputInterface $output, int $limit ): void {
+		$a = $comparison['runs']['a'];
+		$b = $comparison['runs']['b'];
+
+		$output->writeln( sprintf(
+			'<info>Comparing test run %s (A) against %s (B)</info>',
+			OutputFormatter::escape( $a['id'] ),
+			OutputFormatter::escape( $b['id'] )
+		) );
+		$output->writeln( '' );
+
+		$this->render_context( $comparison, $output );
+		$this->render_summary( $comparison['summary'], $output );
+
+		$this->render_transitions( 'Introduced failures', $comparison['tests']['introduced'], 'fg=red', $output, $limit );
+		$this->render_transitions( 'Resolved failures', $comparison['tests']['resolved'], 'fg=green', $output, $limit );
+		$this->render_transitions( 'Still failing', $comparison['tests']['still_failing'], 'fg=yellow', $output, $limit );
+		$this->render_transitions( 'Other status changes', $comparison['tests']['status_changed'], 'fg=default', $output, $limit );
+
+		$this->render_tests( 'Added tests (only in B)', $comparison['tests']['added'], $output, $limit );
+		$this->render_tests( 'Removed tests (only in A)', $comparison['tests']['removed'], $output, $limit );
+
+		$this->render_annotations( $comparison['annotations'], $output, $limit );
+
+		$output->writeln( sprintf(
+			'<info>%d test(s) unchanged.</info>',
+			$comparison['tests']['unchanged_count']
+		) );
+
+		$introduced = $comparison['totals']['introduced'] + $this->count_failed( $comparison['tests']['added'] );
+
+		if ( $introduced === 0 ) {
+			$output->writeln( '<info>No failures introduced by run B.</info>' );
+		} else {
+			$output->writeln( sprintf( '<fg=red>Run B introduced %d failure(s).</>', $introduced ) );
+		}
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $tests
+	 */
+	private function count_failed( array $tests ): int {
+		$failed = 0;
+
+		foreach ( $tests as $test ) {
+			if ( $test['status'] === 'failed' ) {
+				++$failed;
+			}
+		}
+
+		return $failed;
+	}
+
+	/**
+	 * @param array<string,mixed> $comparison
+	 */
+	private function render_context( array $comparison, OutputInterface $output ): void {
+		$a_context = $comparison['runs']['a']['context'];
+		$b_context = $comparison['runs']['b']['context'];
+		$differing = array_column( $comparison['guard']['differences'], 'field' );
+
+		$rows = [];
+
+		foreach ( RunSnapshot::CONTEXT_LABELS as $field => $label ) {
+			$a_value = $a_context[ $field ] ?? '';
+			$b_value = $b_context[ $field ] ?? '';
+
+			if ( $a_value === '' && $b_value === '' ) {
+				continue;
+			}
+
+			$rows[] = [
+				$label,
+				OutputFormatter::escape( $a_value ),
+				OutputFormatter::escape( $b_value ),
+				in_array( $field, $differing, true ) ? 'differs' : '',
+			];
+		}
+
+		if ( ! empty( $rows ) ) {
+			$table = new Table( $output );
+			$table->setStyle( 'compact' )
+				->setHeaders( [ 'Context', 'A', 'B', '' ] )
+				->setRows( $rows );
+			$table->render();
+			$output->writeln( '' );
+		}
+
+		foreach ( $comparison['guard']['warnings'] as $warning ) {
+			$output->writeln( sprintf( '<comment>Warning: %s</comment>', OutputFormatter::escape( $warning ) ) );
+		}
+
+		if ( ! empty( $comparison['guard']['warnings'] ) ) {
+			$output->writeln( '' );
+		}
+	}
+
+	/**
+	 * @param array<string,array<string,int>> $summary
+	 */
+	private function render_summary( array $summary, OutputInterface $output ): void {
+		$rows = [];
+
+		foreach ( RunSnapshot::SUMMARY_KEYS as $key ) {
+			$delta  = $summary['delta'][ $key ];
+			$rows[] = [
+				ucfirst( $key ),
+				(string) $summary['a'][ $key ],
+				(string) $summary['b'][ $key ],
+				$delta > 0 ? '+' . $delta : (string) $delta,
+			];
+		}
+
+		$table = new Table( $output );
+		$table->setStyle( 'compact' )
+			->setHeaders( [ 'Summary', 'A', 'B', 'Delta' ] )
+			->setRows( $rows );
+		$table->render();
+		$output->writeln( '' );
+	}
+
+	/**
+	 * @param string                         $heading
+	 * @param array<int,array<string,mixed>> $tests
+	 * @param string                         $style
+	 * @param OutputInterface                $output
+	 * @param int                            $limit
+	 */
+	private function render_transitions( string $heading, array $tests, string $style, OutputInterface $output, int $limit ): void {
+		$this->render_heading( $heading, count( $tests ), $output );
+
+		foreach ( $this->limited( $tests, $limit ) as $test ) {
+			// A status that did not move (still failing) reads as noise as "failed -> failed".
+			$transition = $test['status']['a'] === $test['status']['b']
+				? $test['status']['b']
+				: $test['status']['a'] . ' -> ' . $test['status']['b'];
+
+			$output->writeln( sprintf(
+				'  <%s>%s</> <fg=gray>(%s)</>',
+				$style,
+				OutputFormatter::escape( $test['key'] ),
+				$transition
+			) );
+		}
+
+		$this->render_truncation( count( $tests ), $limit, $output );
+	}
+
+	/**
+	 * @param string                         $heading
+	 * @param array<int,array<string,mixed>> $tests
+	 * @param OutputInterface                $output
+	 * @param int                            $limit
+	 */
+	private function render_tests( string $heading, array $tests, OutputInterface $output, int $limit ): void {
+		$this->render_heading( $heading, count( $tests ), $output );
+
+		foreach ( $this->limited( $tests, $limit ) as $test ) {
+			$output->writeln( sprintf(
+				'  %s <fg=gray>(%s)</>',
+				OutputFormatter::escape( $test['key'] ),
+				$test['status']
+			) );
+		}
+
+		$this->render_truncation( count( $tests ), $limit, $output );
+	}
+
+	/**
+	 * @param array{added:array<int,array<string,string>>,removed:array<int,array<string,string>>} $annotations
+	 */
+	private function render_annotations( array $annotations, OutputInterface $output, int $limit ): void {
+		$total = count( $annotations['added'] ) + count( $annotations['removed'] );
+
+		$this->render_heading( 'Annotation changes', $total, $output );
+
+		foreach ( $this->limited( $annotations['added'], $limit ) as $annotation ) {
+			$output->writeln( sprintf(
+				'  <fg=green>+</> %s <fg=gray>[%s]</> %s',
+				OutputFormatter::escape( $annotation['test'] ),
+				OutputFormatter::escape( $annotation['type'] ),
+				OutputFormatter::escape( $annotation['description'] )
+			) );
+		}
+
+		foreach ( $this->limited( $annotations['removed'], $limit ) as $annotation ) {
+			$output->writeln( sprintf(
+				'  <fg=red>-</> %s <fg=gray>[%s]</> %s',
+				OutputFormatter::escape( $annotation['test'] ),
+				OutputFormatter::escape( $annotation['type'] ),
+				OutputFormatter::escape( $annotation['description'] )
+			) );
+		}
+
+		if ( $total > 0 ) {
+			$output->writeln( '' );
+		}
+	}
+
+	private function render_heading( string $heading, int $count, OutputInterface $output ): void {
+		$output->writeln( sprintf( '<options=bold>%s (%d)</>', $heading, $count ) );
+
+		if ( $count === 0 ) {
+			$output->writeln( '' );
+		}
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $entries
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function limited( array $entries, int $limit ): array {
+		if ( $limit <= 0 ) {
+			return $entries;
+		}
+
+		return array_slice( $entries, 0, $limit );
+	}
+
+	private function render_truncation( int $count, int $limit, OutputInterface $output ): void {
+		if ( $count === 0 ) {
+			return;
+		}
+
+		if ( $limit > 0 && $count > $limit ) {
+			$output->writeln( sprintf( '  <fg=gray>... and %d more. Use --limit=0 to show all.</>', $count - $limit ) );
+		}
+
+		$output->writeln( '' );
+	}
+}

--- a/src/src/Commands/CompareCommand.php
+++ b/src/src/Commands/CompareCommand.php
@@ -44,10 +44,9 @@ Reports, for the two runs:
 	* Changes to the tests' CTRF annotations
 
 Both runs must be of the same test type, and must report results in CTRF format,
-which covers the activation, compatibility, ecosystem, woo-api and woo-e2e test
-types. Two different test types are two different populations of tests, so
-comparing them is refused rather than reported as everything being added and
-removed at once.
+which covers the activation, compatibility, woo-api and woo-e2e test types. Two
+different test types are two different populations of tests, so comparing them is
+refused rather than reported as everything being added and removed at once.
 
 The comparison only sees what survives the round trip through QIT: test names,
 statuses, durations, "extra.annotations", package metadata, and the run's own

--- a/src/src/Commands/CompareCommand.php
+++ b/src/src/Commands/CompareCommand.php
@@ -100,7 +100,7 @@ HELP
 
 			$comparison = new RunComparison( $snapshot_a, $snapshot_b );
 		} catch ( \RuntimeException $e ) {
-			$output->writeln( "<error>{$e->getMessage()}</error>" );
+			$this->render_error( $e->getMessage(), $output );
 
 			return Command::INVALID;
 		}
@@ -129,10 +129,23 @@ HELP
 				->with_post_body( [
 					'test_run_ids' => $run_a . ',' . $run_b,
 				] )
-				->with_retry( 3 )
+
+				/*
+				 * The Manager answers an unknown test run ID with a 500, which a retry can
+				 * only reproduce. A mistyped ID is the likeliest way this call fails, and
+				 * retrying it buys the user three alarming lines and up to fifteen seconds
+				 * of sleeping before the same error. A compare reads nothing and changes
+				 * nothing, so it is cheap to run again if the Manager really was blipping.
+				 */
+				->with_retry( 0 )
 				->request();
 		} catch ( \Exception $e ) {
-			throw new \RuntimeException( sprintf( 'Could not fetch the test runs: %s', $e->getMessage() ), 0, $e );
+			throw new \RuntimeException( sprintf(
+				"Could not fetch test runs %s and %s: %s\nCheck that both IDs are correct and belong to this account. Run \"qit list-tests\" to see your recent test runs.",
+				$run_a,
+				$run_b,
+				$this->unwrap_manager_message( $e->getMessage() )
+			), 0, $e );
 		}
 
 		$test_runs = json_decode( $json, true );
@@ -188,6 +201,27 @@ HELP
 	}
 
 	/**
+	 * The Manager reports some errors as a bare JSON string, which reaches us still
+	 * carrying its quotes - "Test run with ID 1 does not exist." - and reads like a
+	 * quoting bug when pasted into a sentence. Unwrap it, and unwrap the {"message":…}
+	 * shape too, falling back to the raw text for anything else.
+	 */
+	private function unwrap_manager_message( string $message ): string {
+		$message = trim( $message );
+		$decoded = json_decode( $message, true );
+
+		if ( is_string( $decoded ) && trim( $decoded ) !== '' ) {
+			return trim( $decoded );
+		}
+
+		if ( is_array( $decoded ) && isset( $decoded['message'] ) && is_string( $decoded['message'] ) ) {
+			return trim( $decoded['message'] );
+		}
+
+		return $message;
+	}
+
+	/**
 	 * @param array<int|string,mixed> $test_runs
 	 *
 	 * @return array<string,mixed>
@@ -208,6 +242,19 @@ HELP
 		}
 
 		throw new \RuntimeException( sprintf( 'Test run %s was not found.', $run_id ) );
+	}
+
+	/**
+	 * Print a failure. The first line is the error itself; any further lines are
+	 * guidance on what to do about it, and read better unhighlighted.
+	 */
+	private function render_error( string $message, OutputInterface $output ): void {
+		$lines = explode( "\n", $message );
+
+		foreach ( $lines as $index => $line ) {
+			$line = OutputFormatter::escape( $line );
+			$output->writeln( $index === 0 ? "<error>{$line}</error>" : $line );
+		}
 	}
 
 	private function get_limit( QITInput $input ): int {

--- a/src/src/Compare/RunComparison.php
+++ b/src/src/Compare/RunComparison.php
@@ -120,15 +120,9 @@ class RunComparison {
 			];
 		}
 
+		// A differing test type is refused before a comparison is ever built, so the
+		// only differences that reach here are ones the runs can actually be judged on.
 		$warnings = [];
-
-		if ( $this->a->context['test_type'] !== $this->b->context['test_type'] ) {
-			$warnings[] = sprintf(
-				'The runs are of different test types (%s vs %s), so their tests are not the same population.',
-				$this->a->context['test_type'] !== '' ? $this->a->context['test_type'] : 'unknown',
-				$this->b->context['test_type'] !== '' ? $this->b->context['test_type'] : 'unknown'
-			);
-		}
 
 		if ( count( $differences ) > 1 ) {
 			$labels     = array_column( $differences, 'label' );

--- a/src/src/Compare/RunComparison.php
+++ b/src/src/Compare/RunComparison.php
@@ -1,0 +1,313 @@
+<?php
+
+namespace QIT_CLI\Compare;
+
+/**
+ * Diffs two finished test runs on the parts of CTRF that survive the round trip
+ * through the Manager: test names, statuses and annotations.
+ *
+ * The diff needs no domain knowledge, which is what makes it work for every test
+ * type that reports in CTRF (activation, compatibility, ecosystem, woo-api, woo-e2e).
+ */
+class RunComparison {
+	private RunSnapshot $a;
+
+	private RunSnapshot $b;
+
+	/**
+	 * Memoized test buckets, so that to_array() and has_regressions() do not each
+	 * walk both test lists.
+	 *
+	 * @var array<string,mixed>|null
+	 */
+	private ?array $tests = null;
+
+	public function __construct( RunSnapshot $a, RunSnapshot $b ) {
+		$this->a = $a;
+		$this->b = $b;
+	}
+
+	/**
+	 * The full comparison, as a plain array. This is what `--format json` prints, and
+	 * what the human renderer reads, so both formats always report the same thing.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function to_array(): array {
+		$tests       = $this->compare_tests();
+		$annotations = $this->compare_annotations();
+
+		return [
+			'runs'        => [
+				'a' => $this->describe_run( $this->a ),
+				'b' => $this->describe_run( $this->b ),
+			],
+			'guard'       => $this->guard(),
+			'summary'     => $this->compare_summary(),
+			'tests'       => $tests,
+			'annotations' => $annotations,
+			'totals'      => [
+				'introduced'     => count( $tests['introduced'] ),
+				'resolved'       => count( $tests['resolved'] ),
+				'still_failing'  => count( $tests['still_failing'] ),
+				'status_changed' => count( $tests['status_changed'] ),
+				'added'          => count( $tests['added'] ),
+				'removed'        => count( $tests['removed'] ),
+				'unchanged'      => $tests['unchanged_count'],
+				'annotations'    => count( $annotations['added'] ) + count( $annotations['removed'] ),
+			],
+		];
+	}
+
+	/**
+	 * True when run B introduced failures that run A did not have, either as a
+	 * regression on a shared test or as a new test that fails.
+	 */
+	public function has_regressions(): bool {
+		$tests = $this->compare_tests();
+
+		if ( count( $tests['introduced'] ) > 0 ) {
+			return true;
+		}
+
+		foreach ( $tests['added'] as $test ) {
+			if ( $test['status'] === 'failed' ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function describe_run( RunSnapshot $run ): array {
+		return [
+			'id'         => $run->id,
+			'status'     => $run->status,
+			'created_at' => $run->created_at,
+			'result_url' => $run->result_url,
+			'context'    => $run->context,
+		];
+	}
+
+	/**
+	 * Flag when the two runs differ in more than the one variable under test.
+	 *
+	 * Comparing a run against another that changed WordPress *and* PHP *and* the
+	 * package version cannot attribute anything to any of them, so rather than
+	 * silently diffing incomparable runs we say what moved and let the caller decide.
+	 *
+	 * @return array{comparable:bool,differences:array<int,array<string,string>>,warnings:array<int,string>}
+	 */
+	private function guard(): array {
+		$differences = [];
+
+		foreach ( RunSnapshot::CONTEXT_LABELS as $field => $label ) {
+			$a_value = $this->a->context[ $field ] ?? '';
+			$b_value = $this->b->context[ $field ] ?? '';
+
+			if ( $a_value === $b_value ) {
+				continue;
+			}
+
+			$differences[] = [
+				'field' => $field,
+				'label' => $label,
+				'a'     => $a_value,
+				'b'     => $b_value,
+			];
+		}
+
+		$warnings = [];
+
+		if ( $this->a->context['test_type'] !== $this->b->context['test_type'] ) {
+			$warnings[] = sprintf(
+				'The runs are of different test types (%s vs %s), so their tests are not the same population.',
+				$this->a->context['test_type'] !== '' ? $this->a->context['test_type'] : 'unknown',
+				$this->b->context['test_type'] !== '' ? $this->b->context['test_type'] : 'unknown'
+			);
+		}
+
+		if ( count( $differences ) > 1 ) {
+			$labels     = array_column( $differences, 'label' );
+			$warnings[] = sprintf(
+				'The runs differ in %d dimensions (%s). A difference in results cannot be attributed to any single one of them.',
+				count( $differences ),
+				implode( ', ', $labels )
+			);
+		}
+
+		return [
+			'comparable'  => empty( $warnings ),
+			'differences' => $differences,
+			'warnings'    => $warnings,
+		];
+	}
+
+	/**
+	 * @return array<string,array<string,int>>
+	 */
+	private function compare_summary(): array {
+		$delta = [];
+
+		foreach ( RunSnapshot::SUMMARY_KEYS as $key ) {
+			$delta[ $key ] = ( $this->b->summary[ $key ] ?? 0 ) - ( $this->a->summary[ $key ] ?? 0 );
+		}
+
+		return [
+			'a'     => $this->a->summary,
+			'b'     => $this->b->summary,
+			'delta' => $delta,
+		];
+	}
+
+	/**
+	 * Bucket every test into exactly one category.
+	 *
+	 * Tests present in both runs are bucketed by how their status moved; tests present
+	 * in only one run are reported separately, with their status, so that a failing
+	 * test that simply disappeared does not read as "resolved".
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function compare_tests(): array {
+		if ( ! is_null( $this->tests ) ) {
+			return $this->tests;
+		}
+
+		$introduced     = [];
+		$resolved       = [];
+		$still_failing  = [];
+		$status_changed = [];
+		$added          = [];
+		$removed        = [];
+		$unchanged      = 0;
+
+		foreach ( $this->a->tests as $key => $a_test ) {
+			if ( ! isset( $this->b->tests[ $key ] ) ) {
+				$removed[] = $this->describe_test( $a_test );
+				continue;
+			}
+
+			$b_test = $this->b->tests[ $key ];
+			$entry  = $this->describe_transition( $a_test, $b_test );
+
+			if ( $a_test['status'] === $b_test['status'] ) {
+				if ( $b_test['status'] === 'failed' ) {
+					$still_failing[] = $entry;
+				} else {
+					++$unchanged;
+				}
+				continue;
+			}
+
+			if ( $b_test['status'] === 'failed' ) {
+				$introduced[] = $entry;
+			} elseif ( $a_test['status'] === 'failed' ) {
+				$resolved[] = $entry;
+			} else {
+				$status_changed[] = $entry;
+			}
+		}
+
+		foreach ( $this->b->tests as $key => $b_test ) {
+			if ( ! isset( $this->a->tests[ $key ] ) ) {
+				$added[] = $this->describe_test( $b_test );
+			}
+		}
+
+		$this->tests = [
+			'introduced'      => $introduced,
+			'resolved'        => $resolved,
+			'still_failing'   => $still_failing,
+			'status_changed'  => $status_changed,
+			'added'           => $added,
+			'removed'         => $removed,
+			'unchanged_count' => $unchanged,
+		];
+
+		return $this->tests;
+	}
+
+	/**
+	 * @param array<string,mixed> $test
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function describe_test( array $test ): array {
+		return [
+			'key'      => $test['key'],
+			'name'     => $test['name'],
+			'suite'    => $test['suite'],
+			'status'   => $test['status'],
+			'duration' => $test['duration'],
+			'message'  => $test['message'],
+		];
+	}
+
+	/**
+	 * @param array<string,mixed> $a_test
+	 * @param array<string,mixed> $b_test
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function describe_transition( array $a_test, array $b_test ): array {
+		return [
+			'key'      => $b_test['key'],
+			'name'     => $b_test['name'],
+			'suite'    => $b_test['suite'],
+			'status'   => [
+				'a' => $a_test['status'],
+				'b' => $b_test['status'],
+			],
+			'duration' => [
+				'a' => $a_test['duration'],
+				'b' => $b_test['duration'],
+			],
+			'message'  => $b_test['message'],
+		];
+	}
+
+	/**
+	 * Diff `extra.annotations` for every test, across the union of both runs.
+	 *
+	 * Packages that emit structured, already-normalised data as annotations get
+	 * compared for free here, without this command knowing what the data means.
+	 *
+	 * @return array{added:array<int,array<string,string>>,removed:array<int,array<string,string>>}
+	 */
+	private function compare_annotations(): array {
+		$added   = [];
+		$removed = [];
+
+		$keys = array_keys( $this->a->tests + $this->b->tests );
+
+		foreach ( $keys as $key ) {
+			$a_annotations = $this->a->tests[ $key ]['annotations'] ?? [];
+			$b_annotations = $this->b->tests[ $key ]['annotations'] ?? [];
+
+			foreach ( array_diff_key( $b_annotations, $a_annotations ) as $annotation ) {
+				$added[] = [
+					'test'        => (string) $key,
+					'type'        => $annotation['type'],
+					'description' => $annotation['description'],
+				];
+			}
+
+			foreach ( array_diff_key( $a_annotations, $b_annotations ) as $annotation ) {
+				$removed[] = [
+					'test'        => (string) $key,
+					'type'        => $annotation['type'],
+					'description' => $annotation['description'],
+				];
+			}
+		}
+
+		return [
+			'added'   => $added,
+			'removed' => $removed,
+		];
+	}
+}

--- a/src/src/Compare/RunComparison.php
+++ b/src/src/Compare/RunComparison.php
@@ -7,7 +7,7 @@ namespace QIT_CLI\Compare;
  * through the Manager: test names, statuses and annotations.
  *
  * The diff needs no domain knowledge, which is what makes it work for every test
- * type that reports in CTRF (activation, compatibility, ecosystem, woo-api, woo-e2e).
+ * type that reports in CTRF (activation, compatibility, woo-api, woo-e2e).
  */
 class RunComparison {
 	private RunSnapshot $a;

--- a/src/src/Compare/RunSnapshot.php
+++ b/src/src/Compare/RunSnapshot.php
@@ -1,0 +1,346 @@
+<?php
+
+namespace QIT_CLI\Compare;
+
+/**
+ * A normalized, comparable view of one finished test run.
+ *
+ * Anything a comparison needs has to survive the round trip through the Manager,
+ * which means it has to live either in the run record or in the CTRF report.
+ *
+ * Notably, CTRF `attachments` do NOT survive: they carry filesystem paths from the
+ * machine that ran the tests, and those paths are gone once the job ends. Test
+ * packages that want their data compared must emit it as CTRF `extra.annotations`.
+ */
+class RunSnapshot {
+	/**
+	 * The context fields used both for display and for the comparability guard,
+	 * mapped to the human label used when rendering them.
+	 */
+	public const CONTEXT_LABELS = [
+		'test_type'           => 'Test type',
+		'wordpress_version'   => 'WordPress',
+		'woocommerce_version' => 'WooCommerce',
+		'php_version'         => 'PHP',
+		'extension_set'       => 'Extension set',
+		'sut'                 => 'Extension',
+		'sut_version'         => 'Extension version',
+		'test_packages'       => 'Test packages',
+	];
+
+	public string $id = '';
+
+	public string $status = '';
+
+	public string $created_at = '';
+
+	public string $result_url = '';
+
+	/**
+	 * Environment/context dimensions, keyed by the CONTEXT_LABELS keys.
+	 *
+	 * @var array<string,string>
+	 */
+	public array $context = [];
+
+	/**
+	 * CTRF summary counters (tests, passed, failed, skipped, pending, other).
+	 *
+	 * @var array<string,int>
+	 */
+	public array $summary = [];
+
+	/**
+	 * Normalized tests keyed by their comparison key.
+	 *
+	 * @var array<string,array<string,mixed>>
+	 */
+	public array $tests = [];
+
+	/**
+	 * The CTRF summary counter keys, in display order.
+	 */
+	public const SUMMARY_KEYS = [ 'tests', 'passed', 'failed', 'skipped', 'pending', 'other' ];
+
+	/**
+	 * Build a snapshot from a Manager test run record.
+	 *
+	 * @param string              $run_id  The ID the run was requested by.
+	 * @param array<string,mixed> $run     The Manager test run record.
+	 *
+	 * @throws \RuntimeException If the run carries no usable CTRF results.
+	 */
+	public static function from_manager_run( string $run_id, array $run ): self {
+		$ctrf = self::extract_ctrf( $run );
+
+		if ( is_null( $ctrf ) ) {
+			throw new \RuntimeException( sprintf(
+				'Test run %s has no CTRF results to compare. Only test types that report in CTRF format can be compared (activation, compatibility, ecosystem, woo-api, woo-e2e), and the run must have finished.',
+				$run_id
+			) );
+		}
+
+		$snapshot             = new self();
+		$snapshot->id         = (string) ( $run['test_run_id'] ?? $run_id );
+		$snapshot->status     = (string) ( $run['status'] ?? '' );
+		$snapshot->created_at = (string) ( $run['created_at'] ?? '' );
+		$snapshot->result_url = (string) ( $run['test_results_manager_url'] ?? '' );
+		$snapshot->tests      = self::normalize_tests( $ctrf['tests'] ?? [] );
+		$snapshot->summary    = self::normalize_summary( $ctrf['summary'] ?? [], $snapshot->tests );
+		$snapshot->context    = self::normalize_context( $run, $ctrf );
+
+		return $snapshot;
+	}
+
+	/**
+	 * Pull the CTRF `results` object out of a Manager run record.
+	 *
+	 * `qit get <id> --json-results` returns the CTRF verbatim, so the shape here is
+	 * `{ reportFormat, results: { summary, tests, extra } }`. Some reporters omit the
+	 * `results` wrapper, so an already-unwrapped payload is accepted too.
+	 *
+	 * @param array<string,mixed> $run
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	private static function extract_ctrf( array $run ): ?array {
+		if ( empty( $run['ctrf_json'] ) ) {
+			return null;
+		}
+
+		$decoded = $run['ctrf_json'];
+
+		if ( is_string( $decoded ) ) {
+			$decoded = json_decode( $decoded, true );
+		}
+
+		if ( ! is_array( $decoded ) ) {
+			return null;
+		}
+
+		if ( isset( $decoded['results'] ) && is_array( $decoded['results'] ) ) {
+			$decoded = $decoded['results'];
+		}
+
+		if ( ! isset( $decoded['tests'] ) || ! is_array( $decoded['tests'] ) ) {
+			return null;
+		}
+
+		return $decoded;
+	}
+
+	/**
+	 * Normalize the CTRF test list into a map keyed by a stable comparison key.
+	 *
+	 * CTRF does not guarantee unique test names, so colliding keys get a `#n` suffix
+	 * in the order they appear. That keeps a run with N identical names comparable
+	 * against another run with the same N names, instead of collapsing them to one.
+	 *
+	 * @param array<mixed> $tests
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	private static function normalize_tests( array $tests ): array {
+		$normalized = [];
+
+		foreach ( $tests as $test ) {
+			if ( ! is_array( $test ) ) {
+				continue;
+			}
+
+			$name  = isset( $test['name'] ) && is_scalar( $test['name'] ) ? (string) $test['name'] : '';
+			$suite = isset( $test['suite'] ) && is_scalar( $test['suite'] ) ? (string) $test['suite'] : '';
+
+			if ( $name === '' ) {
+				continue;
+			}
+
+			$key      = $suite === '' ? $name : $suite . ' :: ' . $name;
+			$base_key = $key;
+			$dupe     = 1;
+
+			while ( isset( $normalized[ $key ] ) ) {
+				++$dupe;
+				$key = $base_key . ' #' . $dupe;
+			}
+
+			$normalized[ $key ] = [
+				'key'         => $key,
+				'name'        => $name,
+				'suite'       => $suite,
+				'status'      => self::normalize_status( $test['status'] ?? '' ),
+				'duration'    => isset( $test['duration'] ) && is_numeric( $test['duration'] ) ? (int) $test['duration'] : null,
+				'message'     => isset( $test['message'] ) && is_scalar( $test['message'] ) ? (string) $test['message'] : '',
+				'annotations' => self::normalize_annotations( $test ),
+			];
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * CTRF defines five statuses. Anything else is reported as "other" rather than
+	 * silently treated as a distinct status that would show up as a spurious change.
+	 *
+	 * @param mixed $status
+	 */
+	private static function normalize_status( $status ): string {
+		$status = is_scalar( $status ) ? strtolower( trim( (string) $status ) ) : '';
+
+		if ( in_array( $status, [ 'passed', 'failed', 'skipped', 'pending', 'other' ], true ) ) {
+			return $status;
+		}
+
+		return 'other';
+	}
+
+	/**
+	 * Read `extra.annotations` off a CTRF test, keyed by type + description so that
+	 * two runs can be diffed on annotation identity.
+	 *
+	 * @param array<string,mixed> $test
+	 *
+	 * @return array<string,array{type:string,description:string}>
+	 */
+	private static function normalize_annotations( array $test ): array {
+		$annotations = $test['extra']['annotations'] ?? [];
+
+		if ( ! is_array( $annotations ) ) {
+			return [];
+		}
+
+		$normalized = [];
+
+		foreach ( $annotations as $annotation ) {
+			if ( is_string( $annotation ) ) {
+				$annotation = [ 'description' => $annotation ];
+			}
+
+			if ( ! is_array( $annotation ) ) {
+				continue;
+			}
+
+			$type        = isset( $annotation['type'] ) && is_scalar( $annotation['type'] ) ? (string) $annotation['type'] : '';
+			$description = isset( $annotation['description'] ) && is_scalar( $annotation['description'] ) ? (string) $annotation['description'] : '';
+
+			if ( $type === '' && $description === '' ) {
+				continue;
+			}
+
+			$normalized[ $type . "\0" . $description ] = [
+				'type'        => $type,
+				'description' => $description,
+			];
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Prefer the summary the reporter emitted, filling any missing counter from the
+	 * test list so both sides of a comparison always have the same keys.
+	 *
+	 * @param mixed                             $summary
+	 * @param array<string,array<string,mixed>> $tests
+	 *
+	 * @return array<string,int>
+	 */
+	private static function normalize_summary( $summary, array $tests ): array {
+		$computed = array_fill_keys( self::SUMMARY_KEYS, 0 );
+
+		foreach ( $tests as $test ) {
+			++$computed['tests'];
+			if ( isset( $computed[ $test['status'] ] ) ) {
+				++$computed[ $test['status'] ];
+			}
+		}
+
+		if ( ! is_array( $summary ) ) {
+			$summary = [];
+		}
+
+		$normalized = [];
+
+		foreach ( self::SUMMARY_KEYS as $key ) {
+			$normalized[ $key ] = isset( $summary[ $key ] ) && is_numeric( $summary[ $key ] )
+				? (int) $summary[ $key ]
+				: $computed[ $key ];
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Collect the dimensions the comparability guard checks.
+	 *
+	 * @param array<string,mixed> $run
+	 * @param array<string,mixed> $ctrf
+	 *
+	 * @return array<string,string>
+	 */
+	private static function normalize_context( array $run, array $ctrf ): array {
+		$context = [];
+
+		foreach ( array_keys( self::CONTEXT_LABELS ) as $field ) {
+			$context[ $field ] = '';
+		}
+
+		foreach ( [ 'test_type', 'wordpress_version', 'woocommerce_version', 'php_version', 'extension_set' ] as $field ) {
+			if ( isset( $run[ $field ] ) && is_scalar( $run[ $field ] ) ) {
+				$context[ $field ] = (string) $run[ $field ];
+			}
+		}
+
+		if ( isset( $run['woo_extension']['name'] ) && is_scalar( $run['woo_extension']['name'] ) ) {
+			$context['sut'] = (string) $run['woo_extension']['name'];
+		}
+
+		if ( isset( $run['version'] ) && is_scalar( $run['version'] ) ) {
+			$context['sut_version'] = (string) $run['version'];
+		}
+
+		$context['test_packages'] = self::normalize_packages( $ctrf );
+
+		return $context;
+	}
+
+	/**
+	 * Render `extra.qitPackageMetadata.packages` as a stable, sorted string so that a
+	 * package version bump shows up as a single context difference.
+	 *
+	 * @param array<string,mixed> $ctrf
+	 */
+	private static function normalize_packages( array $ctrf ): string {
+		$packages = $ctrf['extra']['qitPackageMetadata']['packages'] ?? [];
+
+		if ( ! is_array( $packages ) ) {
+			return '';
+		}
+
+		$rendered = [];
+
+		foreach ( $packages as $package ) {
+			if ( is_string( $package ) ) {
+				$rendered[] = $package;
+				continue;
+			}
+
+			if ( ! is_array( $package ) ) {
+				continue;
+			}
+
+			$id = $package['packageId'] ?? ( $package['id'] ?? '' );
+
+			if ( ! is_scalar( $id ) || (string) $id === '' ) {
+				continue;
+			}
+
+			$version    = isset( $package['version'] ) && is_scalar( $package['version'] ) ? (string) $package['version'] : '';
+			$rendered[] = $version === '' ? (string) $id : $id . '@' . $version;
+		}
+
+		sort( $rendered );
+
+		return implode( ', ', $rendered );
+	}
+}

--- a/src/src/Compare/RunSnapshot.php
+++ b/src/src/Compare/RunSnapshot.php
@@ -75,7 +75,7 @@ class RunSnapshot {
 
 		if ( is_null( $ctrf ) ) {
 			throw new \RuntimeException( sprintf(
-				'Test run %s has no CTRF results to compare. Only test types that report in CTRF format can be compared (activation, compatibility, ecosystem, woo-api, woo-e2e), and the run must have finished.',
+				'Test run %s has no CTRF results to compare. Only test types that report in CTRF format can be compared (activation, compatibility, woo-api, woo-e2e), and the run must have finished.',
 				$run_id
 			) );
 		}

--- a/src/src/bootstrap.php
+++ b/src/src/bootstrap.php
@@ -7,6 +7,7 @@ use QIT_CLI\Commands\Backend\CurrentBackend;
 use QIT_CLI\Commands\Backend\RemoveBackend;
 use QIT_CLI\Commands\Backend\SwitchBackend;
 use QIT_CLI\Commands\CacheCommand;
+use QIT_CLI\Commands\CompareCommand;
 use QIT_CLI\Commands\ConfigDirCommand;
 use QIT_CLI\Commands\ConnectCommand;
 use QIT_CLI\Commands\CreateMassTestCommands;
@@ -275,6 +276,9 @@ if ( $is_connected_to_backend ) {
 	// Get a single or multiple test runs.
 	$application->add( $container->make( GetCommand::class ) );
 	$application->add( $container->make( GetMultipleCommand::class ) );
+
+	// Compare two finished test runs.
+	$application->add( $container->make( CompareCommand::class ) );
 
 	// Open a test run result in the browser.
 	$application->add( $container->make( OpenCommand::class ) );

--- a/src/tests/unit/CompareCommandTest.php
+++ b/src/tests/unit/CompareCommandTest.php
@@ -1,0 +1,524 @@
+<?php
+
+use QIT_CLI\App;
+use Spatie\Snapshots\MatchesSnapshots;
+use Symfony\Component\Console\Command\Command;
+use function QIT_CLI\get_manager_url;
+
+class CompareCommandTest extends \QIT_CLI_Tests\QITTestCase {
+	use MatchesSnapshots;
+
+	/** @var \Symfony\Component\Console\Tester\ApplicationTester */
+	protected $application_tester;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->application_tester = $this->make_application_tester();
+	}
+
+	/**
+	 * An activation run, the motivating case: which plugins fail to activate against
+	 * a given WooCommerce version.
+	 *
+	 * @param array<int,array<string,mixed>> $tests
+	 * @param array<string,mixed>            $overrides
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function make_run( int $id, array $tests, array $overrides = [] ): array {
+		$summary = [
+			'tests'   => count( $tests ),
+			'passed'  => count( array_filter( $tests, function ( $t ) {
+				return $t['status'] === 'passed';
+			} ) ),
+			'failed'  => count( array_filter( $tests, function ( $t ) {
+				return $t['status'] === 'failed';
+			} ) ),
+			'pending' => 0,
+			'skipped' => count( array_filter( $tests, function ( $t ) {
+				return $t['status'] === 'skipped';
+			} ) ),
+			'other'   => 0,
+			'start'   => 1706644023,
+			'stop'    => 1706644043,
+		];
+
+		$run = [
+			'test_run_id'              => $id,
+			'test_type'                => 'activation',
+			'wordpress_version'        => '6.7',
+			'woocommerce_version'      => '11.0.1',
+			'php_version'              => '8.2',
+			'extension_set'            => '',
+			'version'                  => '1.0.0',
+			'status'                   => $summary['failed'] > 0 ? 'failed' : 'success',
+			'woo_extension'            => [ 'name' => 'My WooCommerce Plugin' ],
+			'test_results_manager_url' => sprintf( 'https://qit.woo.com/results/%d.abc', $id ),
+			'created_at'               => '2025-01-15 10:30:00',
+			'update_complete'          => true,
+			'test_result_json'         => '',
+			'ctrf_json'                => json_encode( [
+				'reportFormat' => 'CTRF',
+				'specVersion'  => '0.1.0',
+				'results'      => [
+					'tool'    => [ 'name' => 'qit-activation' ],
+					'summary' => $summary,
+					'tests'   => $tests,
+					'extra'   => [
+						'qitPackageMetadata' => [
+							'packages' => [ [ 'packageId' => 'woocommerce/activation', 'version' => '1.2.0' ] ],
+						],
+					],
+				],
+			] ),
+		];
+
+		return array_merge( $run, $overrides );
+	}
+
+	/**
+	 * @param array<string,mixed> $extra
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function test_case( string $name, string $status, array $extra = [] ): array {
+		return array_merge( [
+			'name'     => $name,
+			'status'   => $status,
+			'duration' => 1000,
+		], $extra );
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $runs
+	 */
+	private function mock_runs( array $runs ): void {
+		$keyed = [];
+		foreach ( $runs as $run ) {
+			$keyed[ (string) $run['test_run_id'] ] = $run;
+		}
+
+		App::setVar(
+			sprintf( 'mock_%s%s', get_manager_url(), '/wp-json/cd/v1/get-multiple' ),
+			json_encode( $keyed )
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $args
+	 *
+	 * @return array{0:int,1:array<string,mixed>}
+	 */
+	private function run_compare_json( array $args = [] ): array {
+		$exit_code = $this->application_tester->run( array_merge( [
+			'command'  => 'compare',
+			'run_a'    => '1001',
+			'run_b'    => '1002',
+			'--format' => 'json',
+		], $args ), [ 'capture_stderr_separately' => true ] );
+
+		$decoded = json_decode( $this->application_tester->getDisplay(), true );
+		$this->assertIsArray( $decoded, 'Output must be valid JSON. Got: ' . $this->application_tester->getDisplay() );
+
+		return [ $exit_code, $decoded ];
+	}
+
+	/**
+	 * The motivating case: a WooCommerce bump makes one plugin newly fail to activate,
+	 * and fixes another.
+	 */
+	public function test_compare_buckets_introduced_resolved_and_still_failing(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->test_case( 'plugin-a', 'passed' ),
+				$this->test_case( 'plugin-b', 'failed' ),
+				$this->test_case( 'plugin-c', 'failed' ),
+				$this->test_case( 'plugin-d', 'passed' ),
+			] ),
+			$this->make_run( 1002, [
+				$this->test_case( 'plugin-a', 'failed' ),
+				$this->test_case( 'plugin-b', 'passed' ),
+				$this->test_case( 'plugin-c', 'failed' ),
+				$this->test_case( 'plugin-d', 'passed' ),
+			], [ 'woocommerce_version' => '11.1.0' ] ),
+		] );
+
+		list( $exit_code, $result ) = $this->run_compare_json();
+
+		$this->assertSame( Command::FAILURE, $exit_code, 'An introduced failure must exit 1' );
+
+		$this->assertSame( [ 'plugin-a' ], array_column( $result['tests']['introduced'], 'key' ) );
+		$this->assertSame( [ 'plugin-b' ], array_column( $result['tests']['resolved'], 'key' ) );
+		$this->assertSame( [ 'plugin-c' ], array_column( $result['tests']['still_failing'], 'key' ) );
+		$this->assertSame( 1, $result['totals']['unchanged'] );
+		$this->assertSame( [], $result['tests']['added'] );
+		$this->assertSame( [], $result['tests']['removed'] );
+
+		$this->assertSame( 'passed', $result['tests']['introduced'][0]['status']['a'] );
+		$this->assertSame( 'failed', $result['tests']['introduced'][0]['status']['b'] );
+	}
+
+	/**
+	 * A run with no introduced failures exits 0, so the command is usable as a CI gate.
+	 */
+	public function test_compare_without_regressions_exits_zero(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->test_case( 'plugin-a', 'failed' ),
+				$this->test_case( 'plugin-b', 'passed' ),
+			] ),
+			$this->make_run( 1002, [
+				$this->test_case( 'plugin-a', 'passed' ),
+				$this->test_case( 'plugin-b', 'passed' ),
+			] ),
+		] );
+
+		list( $exit_code, $result ) = $this->run_compare_json();
+
+		$this->assertSame( Command::SUCCESS, $exit_code );
+		$this->assertSame( 0, $result['totals']['introduced'] );
+		$this->assertSame( 1, $result['totals']['resolved'] );
+	}
+
+	/**
+	 * Tests that only exist on one side are reported separately, so a failing test
+	 * that simply disappeared does not read as "resolved".
+	 */
+	public function test_compare_reports_added_and_removed_tests_separately(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->test_case( 'plugin-a', 'passed' ),
+				$this->test_case( 'plugin-gone', 'failed' ),
+			] ),
+			$this->make_run( 1002, [
+				$this->test_case( 'plugin-a', 'passed' ),
+				$this->test_case( 'plugin-new', 'passed' ),
+			] ),
+		] );
+
+		list( $exit_code, $result ) = $this->run_compare_json();
+
+		$this->assertSame( Command::SUCCESS, $exit_code );
+		$this->assertSame( [ 'plugin-new' ], array_column( $result['tests']['added'], 'key' ) );
+		$this->assertSame( [ 'plugin-gone' ], array_column( $result['tests']['removed'], 'key' ) );
+		$this->assertSame( [], $result['tests']['resolved'], 'A test that disappeared is not a resolved failure' );
+	}
+
+	/**
+	 * A brand new test that fails is still a failure introduced by run B.
+	 */
+	public function test_compare_treats_a_new_failing_test_as_a_regression(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $this->test_case( 'plugin-a', 'passed' ) ] ),
+			$this->make_run( 1002, [
+				$this->test_case( 'plugin-a', 'passed' ),
+				$this->test_case( 'plugin-new', 'failed' ),
+			] ),
+		] );
+
+		list( $exit_code, $result ) = $this->run_compare_json();
+
+		$this->assertSame( Command::FAILURE, $exit_code );
+		$this->assertSame( 0, $result['totals']['introduced'] );
+		$this->assertSame( [ 'plugin-new' ], array_column( $result['tests']['added'], 'key' ) );
+	}
+
+	/**
+	 * Annotations are diffed per test, which is how packages get their structured
+	 * data compared without this command knowing what it means.
+	 */
+	public function test_compare_diffs_annotations(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->test_case( 'plugin-a', 'failed', [
+					'extra' => [
+						'annotations' => [
+							[ 'type' => 'contract-id', 'description' => 'woocommerce/orders#create' ],
+							[ 'type' => 'finding', 'description' => 'deprecated-hook' ],
+						],
+					],
+				] ),
+			] ),
+			$this->make_run( 1002, [
+				$this->test_case( 'plugin-a', 'failed', [
+					'extra' => [
+						'annotations' => [
+							[ 'type' => 'contract-id', 'description' => 'woocommerce/orders#create' ],
+							[ 'type' => 'finding', 'description' => 'missing-nonce' ],
+						],
+					],
+				] ),
+			] ),
+		] );
+
+		list( , $result ) = $this->run_compare_json();
+
+		$this->assertSame(
+			[ [ 'test' => 'plugin-a', 'type' => 'finding', 'description' => 'missing-nonce' ] ],
+			$result['annotations']['added']
+		);
+		$this->assertSame(
+			[ [ 'test' => 'plugin-a', 'type' => 'finding', 'description' => 'deprecated-hook' ] ],
+			$result['annotations']['removed']
+		);
+	}
+
+	/**
+	 * One differing dimension is the variable under test, so the runs stay comparable.
+	 */
+	public function test_guard_accepts_a_single_differing_dimension(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $this->test_case( 'plugin-a', 'passed' ) ] ),
+			$this->make_run( 1002, [ $this->test_case( 'plugin-a', 'passed' ) ], [ 'woocommerce_version' => '11.1.0' ] ),
+		] );
+
+		list( , $result ) = $this->run_compare_json();
+
+		$this->assertTrue( $result['guard']['comparable'] );
+		$this->assertSame( [ 'woocommerce_version' ], array_column( $result['guard']['differences'], 'field' ) );
+		$this->assertSame( [], $result['guard']['warnings'] );
+	}
+
+	/**
+	 * Two or more differing dimensions cannot attribute a result change to any of
+	 * them, so the comparison is flagged rather than silently trusted.
+	 */
+	public function test_guard_flags_runs_that_differ_in_more_than_one_dimension(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $this->test_case( 'plugin-a', 'passed' ) ] ),
+			$this->make_run( 1002, [ $this->test_case( 'plugin-a', 'passed' ) ], [
+				'woocommerce_version' => '11.1.0',
+				'php_version'         => '8.3',
+			] ),
+		] );
+
+		list( , $result ) = $this->run_compare_json();
+
+		$this->assertFalse( $result['guard']['comparable'] );
+		$this->assertSame(
+			[ 'woocommerce_version', 'php_version' ],
+			array_column( $result['guard']['differences'], 'field' )
+		);
+		$this->assertCount( 1, $result['guard']['warnings'] );
+		$this->assertStringContainsString( 'differ in 2 dimensions', $result['guard']['warnings'][0] );
+	}
+
+	/**
+	 * Different test types are not the same population of tests.
+	 */
+	public function test_guard_flags_different_test_types(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $this->test_case( 'plugin-a', 'passed' ) ] ),
+			$this->make_run( 1002, [ $this->test_case( 'plugin-a', 'passed' ) ], [ 'test_type' => 'woo-api' ] ),
+		] );
+
+		list( , $result ) = $this->run_compare_json();
+
+		$this->assertFalse( $result['guard']['comparable'] );
+		$this->assertStringContainsString( 'different test types', $result['guard']['warnings'][0] );
+	}
+
+	/**
+	 * A package version bump is a context difference, read out of qitPackageMetadata.
+	 */
+	public function test_guard_detects_a_test_package_version_change(): void {
+		$run_b            = $this->make_run( 1002, [ $this->test_case( 'plugin-a', 'passed' ) ] );
+		$ctrf             = json_decode( $run_b['ctrf_json'], true );
+		$ctrf['results']['extra']['qitPackageMetadata']['packages'][0]['version'] = '1.3.0';
+		$run_b['ctrf_json'] = json_encode( $ctrf );
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $this->test_case( 'plugin-a', 'passed' ) ] ),
+			$run_b,
+		] );
+
+		list( , $result ) = $this->run_compare_json();
+
+		$this->assertSame( [ 'test_packages' ], array_column( $result['guard']['differences'], 'field' ) );
+		$this->assertSame( 'woocommerce/activation@1.3.0', $result['runs']['b']['context']['test_packages'] );
+	}
+
+	/**
+	 * Summary counters are reported side by side with a delta.
+	 */
+	public function test_compare_reports_summary_counts_side_by_side(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->test_case( 'plugin-a', 'passed' ),
+				$this->test_case( 'plugin-b', 'passed' ),
+			] ),
+			$this->make_run( 1002, [
+				$this->test_case( 'plugin-a', 'passed' ),
+				$this->test_case( 'plugin-b', 'failed' ),
+			] ),
+		] );
+
+		list( , $result ) = $this->run_compare_json();
+
+		$this->assertSame( 2, $result['summary']['a']['passed'] );
+		$this->assertSame( 1, $result['summary']['b']['passed'] );
+		$this->assertSame( -1, $result['summary']['delta']['passed'] );
+		$this->assertSame( 1, $result['summary']['delta']['failed'] );
+		$this->assertSame( 0, $result['summary']['delta']['tests'] );
+	}
+
+	/**
+	 * CTRF does not guarantee unique test names, so duplicates must not collapse.
+	 */
+	public function test_compare_keeps_duplicate_test_names_distinct(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->test_case( 'same-name', 'passed' ),
+				$this->test_case( 'same-name', 'passed' ),
+			] ),
+			$this->make_run( 1002, [
+				$this->test_case( 'same-name', 'passed' ),
+				$this->test_case( 'same-name', 'failed' ),
+			] ),
+		] );
+
+		list( , $result ) = $this->run_compare_json();
+
+		$this->assertSame( [ 'same-name #2' ], array_column( $result['tests']['introduced'], 'key' ) );
+		$this->assertSame( 1, $result['totals']['unchanged'] );
+	}
+
+	/**
+	 * A suite qualifies the test name, so two suites can carry the same test name.
+	 */
+	public function test_compare_keys_tests_by_suite_and_name(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->test_case( 'checkout', 'passed', [ 'suite' => 'cart' ] ),
+				$this->test_case( 'checkout', 'passed', [ 'suite' => 'admin' ] ),
+			] ),
+			$this->make_run( 1002, [
+				$this->test_case( 'checkout', 'failed', [ 'suite' => 'cart' ] ),
+				$this->test_case( 'checkout', 'passed', [ 'suite' => 'admin' ] ),
+			] ),
+		] );
+
+		list( , $result ) = $this->run_compare_json();
+
+		$this->assertSame( [ 'cart :: checkout' ], array_column( $result['tests']['introduced'], 'key' ) );
+	}
+
+	/**
+	 * A test type that does not report CTRF cannot be compared, and says so.
+	 */
+	public function test_compare_rejects_runs_without_ctrf_results(): void {
+		$run_a = $this->make_run( 1001, [ $this->test_case( 'plugin-a', 'passed' ) ] );
+		$run_b = $this->make_run( 1002, [ $this->test_case( 'plugin-a', 'passed' ) ] );
+
+		$run_b['ctrf_json'] = '';
+
+		$this->mock_runs( [ $run_a, $run_b ] );
+
+		$exit_code = $this->application_tester->run( [
+			'command' => 'compare',
+			'run_a'   => '1001',
+			'run_b'   => '1002',
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertSame( Command::INVALID, $exit_code );
+		$this->assertStringContainsString( 'has no CTRF results to compare', $this->application_tester->getDisplay() );
+	}
+
+	public function test_compare_rejects_a_missing_run(): void {
+		$this->mock_runs( [ $this->make_run( 1001, [ $this->test_case( 'plugin-a', 'passed' ) ] ) ] );
+
+		$exit_code = $this->application_tester->run( [
+			'command' => 'compare',
+			'run_a'   => '1001',
+			'run_b'   => '1002',
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertSame( Command::INVALID, $exit_code );
+		$this->assertStringContainsString( 'Test run 1002 was not found', $this->application_tester->getDisplay() );
+	}
+
+	public function test_compare_rejects_comparing_a_run_against_itself(): void {
+		$exit_code = $this->application_tester->run( [
+			'command' => 'compare',
+			'run_a'   => '1001',
+			'run_b'   => '1001',
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertSame( Command::INVALID, $exit_code );
+		$this->assertStringContainsString( 'against itself', $this->application_tester->getDisplay() );
+	}
+
+	public function test_compare_rejects_an_unknown_format(): void {
+		$exit_code = $this->application_tester->run( [
+			'command'  => 'compare',
+			'run_a'    => '1001',
+			'run_b'    => '1002',
+			'--format' => 'yaml',
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertSame( Command::INVALID, $exit_code );
+		$this->assertStringContainsString( 'Invalid --format', $this->application_tester->getDisplay() );
+	}
+
+	/**
+	 * The human output is the default, and is what most people will read.
+	 */
+	public function test_compare_human_output(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->test_case( 'plugin-a', 'passed' ),
+				$this->test_case( 'plugin-b', 'failed' ),
+				$this->test_case( 'plugin-c', 'failed' ),
+				$this->test_case( 'plugin-gone', 'passed' ),
+			] ),
+			$this->make_run( 1002, [
+				$this->test_case( 'plugin-a', 'failed', [
+					'extra' => [ 'annotations' => [ [ 'type' => 'error', 'description' => 'Fatal on activation' ] ] ],
+				] ),
+				$this->test_case( 'plugin-b', 'passed' ),
+				$this->test_case( 'plugin-c', 'failed' ),
+				$this->test_case( 'plugin-new', 'skipped' ),
+			], [ 'woocommerce_version' => '11.1.0' ] ),
+		] );
+
+		$exit_code = $this->application_tester->run( [
+			'command' => 'compare',
+			'run_a'   => '1001',
+			'run_b'   => '1002',
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertSame( Command::FAILURE, $exit_code );
+		$this->assertMatchesSnapshot( $this->application_tester->getDisplay() );
+	}
+
+	/**
+	 * Human output truncates long sections, and says how to see the rest.
+	 */
+	public function test_compare_human_output_respects_limit(): void {
+		$a_tests = [];
+		$b_tests = [];
+
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$a_tests[] = $this->test_case( 'plugin-' . $i, 'passed' );
+			$b_tests[] = $this->test_case( 'plugin-' . $i, 'failed' );
+		}
+
+		$this->mock_runs( [
+			$this->make_run( 1001, $a_tests ),
+			$this->make_run( 1002, $b_tests ),
+		] );
+
+		$this->application_tester->run( [
+			'command' => 'compare',
+			'run_a'   => '1001',
+			'run_b'   => '1002',
+			'--limit' => '2',
+		], [ 'capture_stderr_separately' => true ] );
+
+		$display = $this->application_tester->getDisplay();
+
+		$this->assertStringContainsString( 'Introduced failures (5)', $display );
+		$this->assertStringContainsString( '... and 3 more. Use --limit=0 to show all.', $display );
+		$this->assertStringNotContainsString( 'plugin-4', $display );
+	}
+}

--- a/src/tests/unit/CompareCommandTest.php
+++ b/src/tests/unit/CompareCommandTest.php
@@ -330,9 +330,10 @@ class CompareCommandTest extends \QIT_CLI_Tests\QITTestCase {
 	}
 
 	/**
-	 * The Manager has recorded the Woo E2E suite as both "woo-e2e" and "e2e" at
-	 * different times, and advertises both in sync. Two runs of the same suite under
-	 * the two names are refused, and the message names both so it is clear why.
+	 * Run records for the Woo E2E suite carry two test_type spellings, because
+	 * run:woo-e2e submits "woo-e2e" with --extension-set and "e2e" without one. Strict
+	 * equality refuses that pairing on purpose, naming both types, rather than
+	 * special-casing an equivalence that would then have to track the CLI's naming.
 	 */
 	public function test_compare_rejects_the_woo_e2e_and_e2e_test_type_spellings(): void {
 		$this->mock_runs( [

--- a/src/tests/unit/CompareCommandTest.php
+++ b/src/tests/unit/CompareCommandTest.php
@@ -145,7 +145,7 @@ class CompareCommandTest extends \QIT_CLI_Tests\QITTestCase {
 
 		list( $exit_code, $result ) = $this->run_compare_json();
 
-		$this->assertSame( Command::FAILURE, $exit_code, 'An introduced failure must exit 1' );
+		$this->assertSame( Command::SUCCESS, $exit_code, 'Reporting a difference is not a failure of the command' );
 
 		$this->assertSame( [ 'plugin-a' ], array_column( $result['tests']['introduced'], 'key' ) );
 		$this->assertSame( [ 'plugin-b' ], array_column( $result['tests']['resolved'], 'key' ) );
@@ -159,9 +159,97 @@ class CompareCommandTest extends \QIT_CLI_Tests\QITTestCase {
 	}
 
 	/**
-	 * A run with no introduced failures exits 0, so the command is usable as a CI gate.
+	 * --exit-code turns the result into a gate, the way "git diff --exit-code" does.
+	 * A regression on a shared test is what it gates on.
 	 */
-	public function test_compare_without_regressions_exits_zero(): void {
+	public function test_exit_code_option_gates_on_an_introduced_failure(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $this->test_case( 'plugin-a', 'passed' ) ] ),
+			$this->make_run( 1002, [ $this->test_case( 'plugin-a', 'failed' ) ] ),
+		] );
+
+		$exit_code = $this->application_tester->run( [
+			'command'     => 'compare',
+			'run_a'       => '1001',
+			'run_b'       => '1002',
+			'--exit-code' => true,
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertSame( Command::FAILURE, $exit_code );
+	}
+
+	/**
+	 * A new test that fails is a failure introduced by run B, so it gates too.
+	 */
+	public function test_exit_code_option_gates_on_a_new_failing_test(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $this->test_case( 'plugin-a', 'passed' ) ] ),
+			$this->make_run( 1002, [
+				$this->test_case( 'plugin-a', 'passed' ),
+				$this->test_case( 'plugin-new', 'failed' ),
+			] ),
+		] );
+
+		$exit_code = $this->application_tester->run( [
+			'command'     => 'compare',
+			'run_a'       => '1001',
+			'run_b'       => '1002',
+			'--exit-code' => true,
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertSame( Command::FAILURE, $exit_code );
+	}
+
+	/**
+	 * --exit-code gates on introduced failures only. A run that resolved failures and
+	 * introduced none is a pass, even though plenty changed.
+	 */
+	public function test_exit_code_option_passes_when_nothing_was_introduced(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->test_case( 'plugin-a', 'failed' ),
+				$this->test_case( 'plugin-gone', 'failed' ),
+			] ),
+			$this->make_run( 1002, [
+				$this->test_case( 'plugin-a', 'passed' ),
+				$this->test_case( 'plugin-new', 'passed' ),
+			] ),
+		] );
+
+		$exit_code = $this->application_tester->run( [
+			'command'     => 'compare',
+			'run_a'       => '1001',
+			'run_b'       => '1002',
+			'--exit-code' => true,
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertSame( Command::SUCCESS, $exit_code );
+	}
+
+	/**
+	 * --exit-code gates on the result, never on a failure to produce one: an
+	 * unfetchable run must not be reported as "no regressions".
+	 */
+	public function test_exit_code_option_still_reports_a_real_error(): void {
+		App::setVar(
+			sprintf( 'mock_%s%s', get_manager_url(), '/wp-json/cd/v1/get-multiple' ),
+			'exception: "Test run with ID 1001 does not exist."'
+		);
+
+		$exit_code = $this->application_tester->run( [
+			'command'     => 'compare',
+			'run_a'       => '1001',
+			'run_b'       => '1002',
+			'--exit-code' => true,
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertSame( Command::INVALID, $exit_code );
+	}
+
+	/**
+	 * A comparison that ran exits 0, whatever it found.
+	 */
+	public function test_compare_exits_zero_by_default(): void {
 		$this->mock_runs( [
 			$this->make_run( 1001, [
 				$this->test_case( 'plugin-a', 'failed' ),
@@ -218,7 +306,7 @@ class CompareCommandTest extends \QIT_CLI_Tests\QITTestCase {
 
 		list( $exit_code, $result ) = $this->run_compare_json();
 
-		$this->assertSame( Command::FAILURE, $exit_code );
+		$this->assertSame( Command::SUCCESS, $exit_code );
 		$this->assertSame( 0, $result['totals']['introduced'] );
 		$this->assertSame( [ 'plugin-new' ], array_column( $result['tests']['added'], 'key' ) );
 	}
@@ -608,7 +696,7 @@ class CompareCommandTest extends \QIT_CLI_Tests\QITTestCase {
 			'run_b'   => '1002',
 		], [ 'capture_stderr_separately' => true ] );
 
-		$this->assertSame( Command::FAILURE, $exit_code );
+		$this->assertSame( Command::SUCCESS, $exit_code );
 		$this->assertMatchesSnapshot( $this->application_tester->getDisplay() );
 	}
 

--- a/src/tests/unit/CompareCommandTest.php
+++ b/src/tests/unit/CompareCommandTest.php
@@ -247,28 +247,6 @@ class CompareCommandTest extends \QIT_CLI_Tests\QITTestCase {
 	}
 
 	/**
-	 * A comparison that ran exits 0, whatever it found.
-	 */
-	public function test_compare_exits_zero_by_default(): void {
-		$this->mock_runs( [
-			$this->make_run( 1001, [
-				$this->test_case( 'plugin-a', 'failed' ),
-				$this->test_case( 'plugin-b', 'passed' ),
-			] ),
-			$this->make_run( 1002, [
-				$this->test_case( 'plugin-a', 'passed' ),
-				$this->test_case( 'plugin-b', 'passed' ),
-			] ),
-		] );
-
-		list( $exit_code, $result ) = $this->run_compare_json();
-
-		$this->assertSame( Command::SUCCESS, $exit_code );
-		$this->assertSame( 0, $result['totals']['introduced'] );
-		$this->assertSame( 1, $result['totals']['resolved'] );
-	}
-
-	/**
 	 * Tests that only exist on one side are reported separately, so a failing test
 	 * that simply disappeared does not read as "resolved".
 	 */
@@ -290,25 +268,6 @@ class CompareCommandTest extends \QIT_CLI_Tests\QITTestCase {
 		$this->assertSame( [ 'plugin-new' ], array_column( $result['tests']['added'], 'key' ) );
 		$this->assertSame( [ 'plugin-gone' ], array_column( $result['tests']['removed'], 'key' ) );
 		$this->assertSame( [], $result['tests']['resolved'], 'A test that disappeared is not a resolved failure' );
-	}
-
-	/**
-	 * A brand new test that fails is still a failure introduced by run B.
-	 */
-	public function test_compare_treats_a_new_failing_test_as_a_regression(): void {
-		$this->mock_runs( [
-			$this->make_run( 1001, [ $this->test_case( 'plugin-a', 'passed' ) ] ),
-			$this->make_run( 1002, [
-				$this->test_case( 'plugin-a', 'passed' ),
-				$this->test_case( 'plugin-new', 'failed' ),
-			] ),
-		] );
-
-		list( $exit_code, $result ) = $this->run_compare_json();
-
-		$this->assertSame( Command::SUCCESS, $exit_code );
-		$this->assertSame( 0, $result['totals']['introduced'] );
-		$this->assertSame( [ 'plugin-new' ], array_column( $result['tests']['added'], 'key' ) );
 	}
 
 	/**
@@ -603,28 +562,6 @@ class CompareCommandTest extends \QIT_CLI_Tests\QITTestCase {
 
 		// The Manager's bare JSON string must not reach the user still quoted.
 		$this->assertStringNotContainsString( '"Test run with ID', $display );
-	}
-
-	/**
-	 * The {"message": "..."} error shape is unwrapped too.
-	 */
-	public function test_compare_unwraps_a_structured_manager_error(): void {
-		App::setVar(
-			sprintf( 'mock_%s%s', get_manager_url(), '/wp-json/cd/v1/get-multiple' ),
-			'exception: {"message":"Something went wrong on our end."}'
-		);
-
-		$exit_code = $this->application_tester->run( [
-			'command' => 'compare',
-			'run_a'   => '1001',
-			'run_b'   => '1002',
-		], [ 'capture_stderr_separately' => true ] );
-
-		$display = $this->application_tester->getDisplay();
-
-		$this->assertSame( Command::INVALID, $exit_code );
-		$this->assertStringContainsString( 'Something went wrong on our end.', $display );
-		$this->assertStringNotContainsString( '{"message"', $display );
 	}
 
 	/**

--- a/src/tests/unit/CompareCommandTest.php
+++ b/src/tests/unit/CompareCommandTest.php
@@ -304,18 +304,69 @@ class CompareCommandTest extends \QIT_CLI_Tests\QITTestCase {
 	}
 
 	/**
-	 * Different test types are not the same population of tests.
+	 * Two test types are two different populations of tests. Comparing them would
+	 * degenerate to "everything removed, everything added", and - because a new
+	 * failing test counts as a failure introduced by run B - would report a
+	 * regression that says nothing about either run. So it is refused outright.
 	 */
-	public function test_guard_flags_different_test_types(): void {
+	public function test_compare_rejects_runs_of_different_test_types(): void {
 		$this->mock_runs( [
 			$this->make_run( 1001, [ $this->test_case( 'plugin-a', 'passed' ) ] ),
-			$this->make_run( 1002, [ $this->test_case( 'plugin-a', 'passed' ) ], [ 'test_type' => 'woo-api' ] ),
+			$this->make_run( 1002, [ $this->test_case( 'GET /orders', 'failed' ) ], [ 'test_type' => 'woo-api' ] ),
 		] );
 
-		list( , $result ) = $this->run_compare_json();
+		$exit_code = $this->application_tester->run( [
+			'command' => 'compare',
+			'run_a'   => '1001',
+			'run_b'   => '1002',
+		], [ 'capture_stderr_separately' => true ] );
 
-		$this->assertFalse( $result['guard']['comparable'] );
-		$this->assertStringContainsString( 'different test types', $result['guard']['warnings'][0] );
+		$display = $this->application_tester->getDisplay();
+
+		$this->assertSame( Command::INVALID, $exit_code, 'A cross-test-type comparison must not report a regression' );
+		$this->assertStringContainsString( 'Cannot compare a "activation" run against a "woo-api" run', $display );
+		$this->assertStringContainsString( '1001 is "activation"', $display );
+		$this->assertStringContainsString( '1002 is "woo-api"', $display );
+	}
+
+	/**
+	 * The Manager has recorded the Woo E2E suite as both "woo-e2e" and "e2e" at
+	 * different times, and advertises both in sync. Two runs of the same suite under
+	 * the two names are refused, and the message names both so it is clear why.
+	 */
+	public function test_compare_rejects_the_woo_e2e_and_e2e_test_type_spellings(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $this->test_case( 'checkout', 'passed' ) ], [ 'test_type' => 'woo-e2e' ] ),
+			$this->make_run( 1002, [ $this->test_case( 'checkout', 'passed' ) ], [ 'test_type' => 'e2e' ] ),
+		] );
+
+		$exit_code = $this->application_tester->run( [
+			'command' => 'compare',
+			'run_a'   => '1001',
+			'run_b'   => '1002',
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertSame( Command::INVALID, $exit_code );
+		$this->assertStringContainsString( 'Cannot compare a "woo-e2e" run against a "e2e" run', $this->application_tester->getDisplay() );
+	}
+
+	/**
+	 * A run whose test type is missing is not silently treated as matching anything.
+	 */
+	public function test_compare_rejects_a_run_with_an_unknown_test_type(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $this->test_case( 'plugin-a', 'passed' ) ] ),
+			$this->make_run( 1002, [ $this->test_case( 'plugin-a', 'passed' ) ], [ 'test_type' => '' ] ),
+		] );
+
+		$exit_code = $this->application_tester->run( [
+			'command' => 'compare',
+			'run_a'   => '1001',
+			'run_b'   => '1002',
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertSame( Command::INVALID, $exit_code );
+		$this->assertStringContainsString( 'against a "unknown" run', $this->application_tester->getDisplay() );
 	}
 
 	/**

--- a/src/tests/unit/CompareCommandTest.php
+++ b/src/tests/unit/CompareCommandTest.php
@@ -489,6 +489,75 @@ class CompareCommandTest extends \QIT_CLI_Tests\QITTestCase {
 		$this->assertStringContainsString( 'Test run 1002 was not found', $this->application_tester->getDisplay() );
 	}
 
+	/**
+	 * A mistyped run ID is the likeliest way the fetch fails. The Manager answers it
+	 * with a 500 whose body is a bare JSON string, so the message must be unwrapped
+	 * rather than pasted in with its quotes, and must say what to do next.
+	 */
+	public function test_compare_explains_a_test_run_that_does_not_exist(): void {
+		App::setVar(
+			sprintf( 'mock_%s%s', get_manager_url(), '/wp-json/cd/v1/get-multiple' ),
+			'exception: "Test run with ID 511324 does not exist."'
+		);
+
+		$exit_code = $this->application_tester->run( [
+			'command' => 'compare',
+			'run_a'   => '511324',
+			'run_b'   => '5113022',
+		], [ 'capture_stderr_separately' => true ] );
+
+		$display = $this->application_tester->getDisplay();
+
+		$this->assertSame( Command::INVALID, $exit_code );
+		$this->assertStringContainsString( 'Could not fetch test runs 511324 and 5113022', $display );
+		$this->assertStringContainsString( 'Test run with ID 511324 does not exist.', $display );
+		$this->assertStringContainsString( 'qit list-tests', $display );
+
+		// The Manager's bare JSON string must not reach the user still quoted.
+		$this->assertStringNotContainsString( '"Test run with ID', $display );
+	}
+
+	/**
+	 * The {"message": "..."} error shape is unwrapped too.
+	 */
+	public function test_compare_unwraps_a_structured_manager_error(): void {
+		App::setVar(
+			sprintf( 'mock_%s%s', get_manager_url(), '/wp-json/cd/v1/get-multiple' ),
+			'exception: {"message":"Something went wrong on our end."}'
+		);
+
+		$exit_code = $this->application_tester->run( [
+			'command' => 'compare',
+			'run_a'   => '1001',
+			'run_b'   => '1002',
+		], [ 'capture_stderr_separately' => true ] );
+
+		$display = $this->application_tester->getDisplay();
+
+		$this->assertSame( Command::INVALID, $exit_code );
+		$this->assertStringContainsString( 'Something went wrong on our end.', $display );
+		$this->assertStringNotContainsString( '{"message"', $display );
+	}
+
+	/**
+	 * A plain error message is passed through untouched.
+	 */
+	public function test_compare_passes_through_a_plain_error_message(): void {
+		App::setVar(
+			sprintf( 'mock_%s%s', get_manager_url(), '/wp-json/cd/v1/get-multiple' ),
+			'exception: Could not resolve host: qit.woo.com'
+		);
+
+		$exit_code = $this->application_tester->run( [
+			'command' => 'compare',
+			'run_a'   => '1001',
+			'run_b'   => '1002',
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertSame( Command::INVALID, $exit_code );
+		$this->assertStringContainsString( 'Could not resolve host: qit.woo.com', $this->application_tester->getDisplay() );
+	}
+
 	public function test_compare_rejects_comparing_a_run_against_itself(): void {
 		$exit_code = $this->application_tester->run( [
 			'command' => 'compare',

--- a/src/tests/unit/__snapshots__/CompareCommandTest__test_compare_human_output__1.txt
+++ b/src/tests/unit/__snapshots__/CompareCommandTest__test_compare_human_output__1.txt
@@ -1,0 +1,41 @@
+Comparing test run 1001 (A) against 1002 (B)
+
+Context           A                            B                                    
+Test type         activation                   activation                           
+WordPress         6.7                          6.7                                  
+WooCommerce       11.0.1                       11.1.0                       differs 
+PHP               8.2                          8.2                                  
+Extension         My WooCommerce Plugin        My WooCommerce Plugin                
+Extension version 1.0.0                        1.0.0                                
+Test packages     woocommerce/activation@1.2.0 woocommerce/activation@1.2.0         
+
+Summary A B Delta 
+Tests   4 4 0     
+Passed  2 1 -1    
+Failed  2 2 0     
+Skipped 0 1 +1    
+Pending 0 0 0     
+Other   0 0 0     
+
+Introduced failures (1)
+  plugin-a (passed -> failed)
+
+Resolved failures (1)
+  plugin-b (failed -> passed)
+
+Still failing (1)
+  plugin-c (failed)
+
+Other status changes (0)
+
+Added tests (only in B) (1)
+  plugin-new (skipped)
+
+Removed tests (only in A) (1)
+  plugin-gone (passed)
+
+Annotation changes (1)
+  + plugin-a [error] Fatal on activation
+
+0 test(s) unchanged.
+Run B introduced 1 failure(s).


### PR DESCRIPTION
## What changed

`qit compare <run-a> <run-b>` diffs two finished test runs without re-running anything.

```
qit compare 12345 12346
qit compare 12345 12346 --format=json --exit-code
```

Reports introduced, resolved and still-failing tests; tests added or removed; summary counts side by side; and a per-test diff of `extra.annotations`.

## Why

Someone runs the activation tests against WooCommerce 11.1.0 and 11.0.1 and wants to know which plugins newly fail to activate. Today that means opening two reports and reading them side by side.

## How it works

The diff works on CTRF test names and statuses, so it needs no domain knowledge and serves every CTRF-reporting test type at once — activation, compatibility, woo-api, woo-e2e. Both runs are fetched in one existing `get-multiple` call; no Manager-side change is required.

`RunSnapshot` normalises a run record, `RunComparison` is the pure pairwise diff, `CompareCommand` fetches and renders. `--format=json` prints the same array the human renderer reads.

Decisions worth review:

- **Tests are keyed by suite and name.** CTRF does not guarantee unique names, so collisions get a `#n` suffix instead of collapsing.
- **Added and removed tests are their own buckets**, so a failing test that disappeared is not reported as resolved.
- **Runs of different test types are refused** (exit `2`). Two types are two populations of tests, so the diff would degenerate to "everything removed, everything added". Note this also refuses the Woo E2E suite's two `test_type` spellings — `run:woo-e2e` submits `woo-e2e` with `--extension-set` and `e2e` without one. Deliberate; the message names both.
- **A finding is not a failure.** A comparison that ran exits `0` whatever it found, so this is safe in a pipeline. Gating is opt-in via `--exit-code`, the `git diff --exit-code` split. Real errors still exit `2` either way, so a mistyped ID cannot pass as "no regressions".

`docs/compare.md` records the key constraint: CTRF `attachments[]` holds runner filesystem paths that are gone once the job ends, so anything to be compared must be an annotation.

## Validation

- New `CompareCommandTest`, 24 tests: bucketing, annotation diff, the comparability guard, duplicate and suite-qualified test keys, summary deltas, the exit-code split, and the error paths (different test types, no CTRF, missing run, self-comparison, bad `--format`, and an unknown run ID). Snapshot of the human output.
- `make phpunit` (389 tests, 1125 assertions), `phpcs`, `phpstan`, `phan` — clean. CI green on PHP 7.4–8.4.
- Manager responses are mocked, as in the existing `GetCommandTest`; not exercised against production.

## Known limitations

- Two runs of the same type but different extensions still diff to all-added/all-removed. The guard flags the difference, but the shape is noise.
- `e2e` emits CTRF and compares fine, but is not yet named in the documented list of supported types.

Part of QIT-1075.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
