### PR TITLE
Tell a moved canary finding from one the candidate introduced

### DIFF
--- a/src/src/Commands/CompareCommand.php
+++ b/src/src/Commands/CompareCommand.php
@@ -586,8 +586,8 @@ HELP
 			) );
 			$output->writeln( sprintf(
 				'      <fg=gray>%s -> %s</>',
-				OutputFormatter::escape( implode( ', ', array_column( $finding['from'], 'test' ) ) ),
-				OutputFormatter::escape( implode( ', ', array_column( $finding['to'], 'test' ) ) )
+				OutputFormatter::escape( implode( ', ', array_column( $finding['from'], 'probe' ) ) ),
+				OutputFormatter::escape( implode( ', ', array_column( $finding['to'], 'probe' ) ) )
 			) );
 		}
 
@@ -603,7 +603,7 @@ HELP
 		foreach ( $this->limited( $changed, $limit ) as $probe ) {
 			$output->writeln( sprintf(
 				'    %s <fg=gray>(%s -> %s)</>',
-				OutputFormatter::escape( $probe['test'] ),
+				OutputFormatter::escape( $probe['probe'] ),
 				$probe['a'],
 				$probe['b']
 			) );

--- a/src/src/Commands/CompareCommand.php
+++ b/src/src/Commands/CompareCommand.php
@@ -2,6 +2,7 @@
 
 namespace QIT_CLI\Commands;
 
+use QIT_CLI\Compare\CanaryComparison;
 use QIT_CLI\Compare\RunComparison;
 use QIT_CLI\Compare\RunSnapshot;
 use QIT_CLI\QITInput;
@@ -43,6 +44,14 @@ Reports, for the two runs:
 	* Tests that were added or removed between the runs
 	* Summary counts side by side
 	* Changes to the tests' CTRF annotations
+
+Runs of the WooCommerce ecosystem canary get an extra section, because two of
+its properties defeat a plain annotation diff. A canary finding is not tied to
+the probe that recorded it - a fatal from a loopback request or a scheduled
+action lands under whichever probe was running - so a finding that changed
+probes is reported as "moved" rather than as a regression and a fix at once. And
+each probe says how far it got: a finding missing from a probe that stopped
+early was never looked for, so it is reported as such instead of as resolved.
 
 Both runs must be of the same test type, and must report results in CTRF format,
 which covers the activation, compatibility, woo-api and woo-e2e test types. Two
@@ -310,6 +319,10 @@ HELP
 
 		$this->render_annotations( $comparison['annotations'], $output, $limit );
 
+		if ( isset( $comparison['canary'] ) ) {
+			$this->render_canary( $comparison['canary'], $output, $limit );
+		}
+
 		$output->writeln( sprintf(
 			'<info>%d test(s) unchanged.</info>',
 			$comparison['tests']['unchanged_count']
@@ -483,6 +496,120 @@ HELP
 		if ( $total > 0 ) {
 			$output->writeln( '' );
 		}
+	}
+
+	/**
+	 * Print the ecosystem canary section, which reports observations rather than
+	 * assertions and so is bucketed on its own terms.
+	 *
+	 * "Moved" and "unverified" are the two buckets that only exist here, and both
+	 * are there to avoid claiming something the runs do not show: a finding that
+	 * changed probes is neither a regression nor a fix, and a finding missing from
+	 * a probe that stopped early was never looked for.
+	 *
+	 * @param array<string,mixed> $canary
+	 */
+	private function render_canary( array $canary, OutputInterface $output, int $limit ): void {
+		$output->writeln( '<options=bold>Ecosystem canary findings</>' );
+		$output->writeln( '' );
+
+		$this->render_findings( 'Introduced', $canary['findings']['introduced'], 'fg=red', $output, $limit );
+		$this->render_findings( 'Resolved', $canary['findings']['resolved'], 'fg=green', $output, $limit );
+		$this->render_moved_findings( $canary['findings']['moved'], $output, $limit );
+		$this->render_findings( 'Not looked for in run B', $canary['findings']['unverified'], 'fg=yellow', $output, $limit );
+		$this->render_findings( 'Pre-existing', $canary['findings']['pre_existing'], 'fg=gray', $output, $limit );
+
+		$this->render_probe_states( $canary['probes']['changed'], $output, $limit );
+
+		foreach ( $canary['warnings'] as $warning ) {
+			$output->writeln( sprintf( '<comment>Warning: %s</comment>', OutputFormatter::escape( $warning ) ) );
+		}
+
+		if ( ! empty( $canary['warnings'] ) ) {
+			$output->writeln( '' );
+		}
+	}
+
+	/**
+	 * @param string                         $heading
+	 * @param array<int,array<string,mixed>> $findings
+	 * @param string                         $style
+	 * @param OutputInterface                $output
+	 * @param int                            $limit
+	 */
+	private function render_findings( string $heading, array $findings, string $style, OutputInterface $output, int $limit ): void {
+		$this->render_heading( '  ' . $heading, count( $findings ), $output );
+
+		foreach ( $this->limited( $findings, $limit ) as $finding ) {
+			$output->writeln( sprintf(
+				'    <%s>%s</> <fg=gray>(%s)</>',
+				$style,
+				OutputFormatter::escape( (string) $finding['key'] ),
+				OutputFormatter::escape( $this->describe_finding_context( $finding ) )
+			) );
+		}
+
+		$this->render_truncation( count( $findings ), $limit, $output );
+	}
+
+	/**
+	 * @param array<string,mixed> $finding
+	 */
+	private function describe_finding_context( array $finding ): string {
+		$parts = array_filter( [ (string) $finding['surface'], (string) $finding['profile'] ] );
+
+		if ( ! empty( $finding['fixtures'] ) ) {
+			$parts[] = 'fixtures: ' . implode( ' + ', $finding['fixtures'] );
+		}
+
+		if ( isset( $finding['probe_state'] ) && $finding['probe_state'] !== CanaryComparison::STATE_COMPLETE ) {
+			$parts[] = 'run B probe: ' . $finding['probe_state'];
+		}
+
+		if ( isset( $finding['baseline_probe_state'] ) && $finding['baseline_probe_state'] !== CanaryComparison::STATE_COMPLETE ) {
+			$parts[] = 'run A probe: ' . $finding['baseline_probe_state'];
+		}
+
+		return implode( ', ', $parts );
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $moved
+	 */
+	private function render_moved_findings( array $moved, OutputInterface $output, int $limit ): void {
+		$this->render_heading( '  Moved between probes', count( $moved ), $output );
+
+		foreach ( $this->limited( $moved, $limit ) as $finding ) {
+			$output->writeln( sprintf(
+				'    %s',
+				OutputFormatter::escape( (string) $finding['signature'] )
+			) );
+			$output->writeln( sprintf(
+				'      <fg=gray>%s -> %s</>',
+				OutputFormatter::escape( implode( ', ', array_column( $finding['from'], 'test' ) ) ),
+				OutputFormatter::escape( implode( ', ', array_column( $finding['to'], 'test' ) ) )
+			) );
+		}
+
+		$this->render_truncation( count( $moved ), $limit, $output );
+	}
+
+	/**
+	 * @param array<int,array<string,string>> $changed
+	 */
+	private function render_probe_states( array $changed, OutputInterface $output, int $limit ): void {
+		$this->render_heading( '  Probe state changes', count( $changed ), $output );
+
+		foreach ( $this->limited( $changed, $limit ) as $probe ) {
+			$output->writeln( sprintf(
+				'    %s <fg=gray>(%s -> %s)</>',
+				OutputFormatter::escape( $probe['test'] ),
+				$probe['a'],
+				$probe['b']
+			) );
+		}
+
+		$this->render_truncation( count( $changed ), $limit, $output );
 	}
 
 	private function render_heading( string $heading, int $count, OutputInterface $output ): void {

--- a/src/src/Commands/CompareCommand.php
+++ b/src/src/Commands/CompareCommand.php
@@ -328,28 +328,22 @@ HELP
 			$comparison['tests']['unchanged_count']
 		) );
 
-		$introduced = $comparison['totals']['introduced'] + $this->count_failed( $comparison['tests']['added'] );
+		/*
+		 * The same number the exit code gates on, so the summary cannot contradict
+		 * either the sections above it or the status the command exits with. For a
+		 * canary run that means findings rather than probe statuses: a probe fails
+		 * when it records anything, so "one more failing probe" and "one new finding"
+		 * are not the same statement.
+		 */
+		$regressions = $comparison['totals']['regressions'];
 
-		if ( $introduced === 0 ) {
+		if ( $regressions === 0 ) {
 			$output->writeln( '<info>No failures introduced by run B.</info>' );
+		} elseif ( isset( $comparison['canary'] ) ) {
+			$output->writeln( sprintf( '<fg=red>Run B introduced %d finding(s) or failure(s).</>', $regressions ) );
 		} else {
-			$output->writeln( sprintf( '<fg=red>Run B introduced %d failure(s).</>', $introduced ) );
+			$output->writeln( sprintf( '<fg=red>Run B introduced %d failure(s).</>', $regressions ) );
 		}
-	}
-
-	/**
-	 * @param array<int,array<string,mixed>> $tests
-	 */
-	private function count_failed( array $tests ): int {
-		$failed = 0;
-
-		foreach ( $tests as $test ) {
-			if ( $test['status'] === 'failed' ) {
-				++$failed;
-			}
-		}
-
-		return $failed;
 	}
 
 	/**

--- a/src/src/Commands/CompareCommand.php
+++ b/src/src/Commands/CompareCommand.php
@@ -339,10 +339,23 @@ HELP
 
 		if ( $regressions === 0 ) {
 			$output->writeln( '<info>No failures introduced by run B.</info>' );
-		} elseif ( isset( $comparison['canary'] ) ) {
-			$output->writeln( sprintf( '<fg=red>Run B introduced %d finding(s) or failure(s).</>', $regressions ) );
+
+			return;
+		}
+
+		// The two are counted separately because they are different things. A probe
+		// fails when it records anything, so its findings are the finer statement and
+		// the ones the buckets above name; a failure left over is one no finding
+		// accounts for, which usually means the harness rather than the product.
+		$findings = isset( $comparison['canary'] ) ? $comparison['canary']['totals']['introduced'] : 0;
+		$failures = $regressions - $findings;
+
+		if ( $findings > 0 && $failures > 0 ) {
+			$output->writeln( sprintf( '<fg=red>Run B introduced %d canary finding(s) and %d unexplained failure(s).</>', $findings, $failures ) );
+		} elseif ( $findings > 0 ) {
+			$output->writeln( sprintf( '<fg=red>Run B introduced %d canary finding(s).</>', $findings ) );
 		} else {
-			$output->writeln( sprintf( '<fg=red>Run B introduced %d failure(s).</>', $regressions ) );
+			$output->writeln( sprintf( '<fg=red>Run B introduced %d failure(s).</>', $failures ) );
 		}
 	}
 

--- a/src/src/Commands/CompareCommand.php
+++ b/src/src/Commands/CompareCommand.php
@@ -515,6 +515,19 @@ HELP
 
 		$this->render_probe_states( $canary['probes']['changed'], $output, $limit );
 
+		/*
+		 * The sections above this one are about findings; the test buckets near the
+		 * top of the report are about probe results, which are a different thing. A
+		 * probe fails when it records anything, so a finding that only moved probes
+		 * shows up there as one probe passing and another failing. Both readings are
+		 * true, and a reader who has just been told the finding moved needs to know
+		 * why the other section disagrees.
+		 */
+		if ( count( $canary['findings']['moved'] ) > 0 ) {
+			$output->writeln( '<comment>A probe fails when it records anything, so a finding that moved probes also shows above as one probe resolved and another introduced. Neither is a change in what the build does.</comment>' );
+			$output->writeln( '' );
+		}
+
 		foreach ( $canary['warnings'] as $warning ) {
 			$output->writeln( sprintf( '<comment>Warning: %s</comment>', OutputFormatter::escape( $warning ) ) );
 		}

--- a/src/src/Compare/CanaryComparison.php
+++ b/src/src/Compare/CanaryComparison.php
@@ -1,0 +1,614 @@
+<?php
+
+namespace QIT_CLI\Compare;
+
+/**
+ * The part of a comparison that a generic annotation diff gets wrong.
+ *
+ * The `woocommerce/ecosystem-canary` package publishes what each probe saw as
+ * `canary-finding` annotations, already normalised at record time, so a diff of
+ * annotation strings compares the right things. Two properties of that data make
+ * a plain per-test diff report things that did not happen:
+ *
+ * 1. A finding is not tied to the probe that recorded it. A fatal raised by a
+ *    loopback request or a scheduled action lands under whichever probe happened
+ *    to be running, and that is not stable between runs. Diffed per test, one
+ *    relocated finding reads as a regression *and* a fix, and both are wrong. So
+ *    every finding carries two identities: a `key` scoped to its probe, and a
+ *    `signature` for the problem on its own. A signature that left one probe and
+ *    appeared under another moved; it was not introduced, and the baseline's copy
+ *    was not resolved.
+ *
+ * 2. An absent finding does not always mean a fixed one. Each probe publishes a
+ *    `canary-probe-state`, and only `complete` means the probe ran to the end of
+ *    its scenario. A `truncated` probe stopped early after recording why, and an
+ *    `incomplete` one broke and published nothing: in both cases the checks after
+ *    the stopping point were never made, so a baseline finding the other run
+ *    lacks was never looked for. Reporting it resolved invents an improvement,
+ *    which is the failure mode this whole comparison exists to avoid.
+ *
+ * Nothing here knows anything about WooCommerce. Normalisation happens in the
+ * package, at record time, so this only ever compares already-normalised strings
+ * against each other and reads two annotation types it does not interpret.
+ */
+class CanaryComparison {
+	/**
+	 * The annotation carrying one finding, as a JSON object with at least a `key`
+	 * and a `signature`.
+	 */
+	public const FINDING_ANNOTATION = 'canary-finding';
+
+	/**
+	 * The annotation carrying how far the probe got.
+	 */
+	public const PROBE_STATE_ANNOTATION = 'canary-probe-state';
+
+	/**
+	 * The annotation types this class accounts for, and which the generic
+	 * annotation diff therefore leaves alone: reporting a moved finding as one
+	 * annotation added and another removed is exactly what this exists to prevent.
+	 */
+	public const HANDLED_ANNOTATIONS = [ self::FINDING_ANNOTATION, self::PROBE_STATE_ANNOTATION ];
+
+	/**
+	 * The one probe state that makes an absent finding mean something.
+	 */
+	public const STATE_COMPLETE = 'complete';
+
+	/**
+	 * A probe that has no state at all is treated as one that did not finish. The
+	 * package publishes a state on every probe that published anything, so a
+	 * missing one means the probe never got that far - or is not in this run.
+	 */
+	public const STATE_UNKNOWN = 'unknown';
+
+	/**
+	 * Probe states, from the most to the least of the scenario covered. A probe
+	 * that somehow published two states is read as the least covered of them,
+	 * because that is the only reading that cannot invent an improvement.
+	 */
+	private const STATE_RANK = [
+		self::STATE_COMPLETE => 0,
+		'truncated'          => 1,
+		'incomplete'         => 2,
+		self::STATE_UNKNOWN  => 3,
+	];
+
+	/**
+	 * Findings in run A, keyed by their finding key.
+	 *
+	 * @var array<string,array<string,mixed>>
+	 */
+	private array $a_findings;
+
+	/**
+	 * @var array<string,array<string,mixed>>
+	 */
+	private array $b_findings;
+
+	/**
+	 * Probe state in run A, keyed by CTRF test key.
+	 *
+	 * @var array<string,string>
+	 */
+	private array $a_states;
+
+	/**
+	 * @var array<string,string>
+	 */
+	private array $b_states;
+
+	/**
+	 * Findings whose annotation could not be read, per run.
+	 *
+	 * Counted rather than dropped: a finding that silently disappears from one
+	 * side of the comparison reads as an improvement.
+	 *
+	 * @var array<string,int>
+	 */
+	private array $malformed;
+
+	public function __construct( RunSnapshot $a, RunSnapshot $b ) {
+		$this->a_findings = self::findings( $a );
+		$this->b_findings = self::findings( $b );
+		$this->a_states   = self::probe_states( $a );
+		$this->b_states   = self::probe_states( $b );
+		$this->malformed  = [
+			'a' => self::malformed_findings( $a ),
+			'b' => self::malformed_findings( $b ),
+		];
+	}
+
+	/**
+	 * True when either run carries canary data, and a canary-aware comparison is
+	 * therefore something other than an empty section.
+	 */
+	public static function present( RunSnapshot $a, RunSnapshot $b ): bool {
+		return self::carries_canary_data( $a ) || self::carries_canary_data( $b );
+	}
+
+	private static function carries_canary_data( RunSnapshot $run ): bool {
+		foreach ( $run->tests as $test ) {
+			foreach ( $test['annotations'] as $annotation ) {
+				if ( in_array( $annotation['type'], self::HANDLED_ANNOTATIONS, true ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * The canary comparison, as a plain array, which is what `--format json` prints
+	 * and what the human renderer reads.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function to_array(): array {
+		$a_keys = array_keys( $this->a_findings );
+		$b_keys = array_keys( $this->b_findings );
+
+		$only_a = array_values( array_diff( $a_keys, $b_keys ) );
+		$only_b = array_values( array_diff( $b_keys, $a_keys ) );
+
+		/*
+		 * A signature moved when it left at least one probe and turned up under at
+		 * least one other. Requiring both directions matters: a signature that is
+		 * still recorded under its original probe in both runs and *also* appears
+		 * under a new one in B has not moved anywhere, it happened somewhere new,
+		 * and calling that a move would hide it.
+		 */
+		$moved_signatures = array_intersect_key(
+			self::signatures_of( $only_a, $this->a_findings ),
+			self::signatures_of( $only_b, $this->b_findings )
+		);
+
+		$moved        = $this->compare_moved( $moved_signatures, $only_a, $only_b );
+		$introduced   = $this->compare_introduced( $only_b, $moved_signatures );
+		$verdicts     = $this->compare_absent( $only_a, $moved_signatures );
+		$pre_existing = $this->compare_pre_existing( $a_keys, $b_keys );
+
+		$findings = [
+			'introduced'   => $introduced,
+			'resolved'     => $verdicts['resolved'],
+			'moved'        => $moved,
+			'unverified'   => $verdicts['unverified'],
+			'pre_existing' => $pre_existing,
+		];
+
+		return [
+			'findings' => $findings,
+			'probes'   => [
+				'a'       => $this->a_states,
+				'b'       => $this->b_states,
+				'changed' => $this->changed_probe_states(),
+			],
+			'warnings' => $this->warnings( $findings ),
+			'totals'   => [
+				'introduced'   => count( $findings['introduced'] ),
+				'resolved'     => count( $findings['resolved'] ),
+				'moved'        => count( $findings['moved'] ),
+				'unverified'   => count( $findings['unverified'] ),
+				'pre_existing' => count( $findings['pre_existing'] ),
+			],
+		];
+	}
+
+	/**
+	 * One entry per signature that changed probes, listing where it went from and to.
+	 *
+	 * Grouped by signature rather than paired up key by key, because a signature
+	 * that left two probes and arrived under one has no honest pairing - and the
+	 * point of the bucket is that none of these keys is a regression or a fix.
+	 *
+	 * @param array<string,bool> $moved_signatures
+	 * @param array<int,string>  $only_a
+	 * @param array<int,string>  $only_b
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function compare_moved( array $moved_signatures, array $only_a, array $only_b ): array {
+		$moved = [];
+
+		foreach ( array_keys( $moved_signatures ) as $signature ) {
+			$moved[ $signature ] = [
+				'signature' => $signature,
+				'type'      => '',
+				'from'      => [],
+				'to'        => [],
+			];
+		}
+
+		foreach ( [
+			'from' => [ $only_a, $this->a_findings ],
+			'to'   => [ $only_b, $this->b_findings ],
+		] as $side => $source ) {
+			list( $keys, $findings ) = $source;
+
+			foreach ( $keys as $key ) {
+				$finding = $findings[ $key ];
+
+				if ( ! isset( $moved[ $finding['signature'] ] ) ) {
+					continue;
+				}
+
+				$moved[ $finding['signature'] ]['type']    = $finding['type'];
+				$moved[ $finding['signature'] ][ $side ][] = [
+					'key'     => $finding['key'],
+					'test'    => $finding['test'],
+					'surface' => $finding['surface'],
+				];
+			}
+		}
+
+		ksort( $moved );
+
+		return array_values( $moved );
+	}
+
+	/**
+	 * Findings run B has that run A does not, and that did not simply move.
+	 *
+	 * The baseline's probe state rides along rather than gating the bucket. An
+	 * absence on the baseline side is as uninformative as one on the candidate
+	 * side, but the two errors are not symmetric: a finding wrongly called
+	 * resolved is an improvement that never happened, while a finding wrongly
+	 * called introduced is one more advisory line for a human to dismiss. This
+	 * package gates nothing, so the safe direction is to report and to say what
+	 * the baseline probe did.
+	 *
+	 * @param array<int,string>  $only_b
+	 * @param array<string,bool> $moved_signatures
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function compare_introduced( array $only_b, array $moved_signatures ): array {
+		$introduced = [];
+
+		foreach ( $only_b as $key ) {
+			$finding = $this->b_findings[ $key ];
+
+			if ( isset( $moved_signatures[ $finding['signature'] ] ) ) {
+				continue;
+			}
+
+			$introduced[] = $this->describe_finding( $finding, [
+				'baseline_probe_state' => $this->state_of( $this->a_states, $finding['test'] ),
+			] );
+		}
+
+		return self::sorted( $introduced );
+	}
+
+	/**
+	 * Findings run A has that run B does not, split by whether run B looked.
+	 *
+	 * The probe read is the one the baseline finding was published on, matched by
+	 * test: that is the scenario whose later steps would have found it again.
+	 *
+	 * @param array<int,string>  $only_a
+	 * @param array<string,bool> $moved_signatures
+	 *
+	 * @return array{resolved:array<int,array<string,mixed>>,unverified:array<int,array<string,mixed>>}
+	 */
+	private function compare_absent( array $only_a, array $moved_signatures ): array {
+		$resolved   = [];
+		$unverified = [];
+
+		foreach ( $only_a as $key ) {
+			$finding = $this->a_findings[ $key ];
+
+			if ( isset( $moved_signatures[ $finding['signature'] ] ) ) {
+				continue;
+			}
+
+			$state = $this->state_of( $this->b_states, $finding['test'] );
+			$entry = $this->describe_finding( $finding, [ 'probe_state' => $state ] );
+
+			if ( self::STATE_COMPLETE === $state ) {
+				$resolved[] = $entry;
+				continue;
+			}
+
+			$entry['reason'] = self::absence_reason( $state, $finding['test'] );
+
+			$unverified[] = $entry;
+		}
+
+		return [
+			'resolved'   => self::sorted( $resolved ),
+			'unverified' => self::sorted( $unverified ),
+		];
+	}
+
+	/**
+	 * Findings both runs recorded under the same key: how the product already
+	 * behaves, and the bulk of a healthy comparison.
+	 *
+	 * @param array<int,string> $a_keys
+	 * @param array<int,string> $b_keys
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function compare_pre_existing( array $a_keys, array $b_keys ): array {
+		$pre_existing = [];
+
+		foreach ( array_intersect( $a_keys, $b_keys ) as $key ) {
+			$pre_existing[] = $this->describe_finding( $this->b_findings[ $key ] );
+		}
+
+		return self::sorted( $pre_existing );
+	}
+
+	/**
+	 * Why an absence proves nothing, in the words of the state that caused it.
+	 */
+	private static function absence_reason( string $state, string $test ): string {
+		if ( 'truncated' === $state ) {
+			return sprintf( 'The probe "%s" stopped early in run B, so this was never looked for.', $test );
+		}
+
+		if ( 'incomplete' === $state ) {
+			return sprintf( 'The probe "%s" broke in run B and published nothing, so this was never looked for.', $test );
+		}
+
+		return sprintf( 'Run B has no completed probe "%s", so this was never looked for.', $test );
+	}
+
+	/**
+	 * Probes whose state is not the same in both runs, including the ones that only
+	 * one run has. A probe that stopped earlier than it used to is the reason half
+	 * of the findings above cannot be judged, so it is reported next to them.
+	 *
+	 * @return array<int,array<string,string>>
+	 */
+	private function changed_probe_states(): array {
+		$changed = [];
+
+		foreach ( array_keys( $this->a_states + $this->b_states ) as $test ) {
+			$a = $this->state_of( $this->a_states, $test );
+			$b = $this->state_of( $this->b_states, $test );
+
+			if ( $a === $b ) {
+				continue;
+			}
+
+			$changed[] = [
+				'test' => (string) $test,
+				'a'    => $a,
+				'b'    => $b,
+			];
+		}
+
+		return $changed;
+	}
+
+	/**
+	 * Say what the comparison could not answer, and why.
+	 *
+	 * @param array<string,array<int,array<string,mixed>>> $findings
+	 *
+	 * @return array<int,string>
+	 */
+	private function warnings( array $findings ): array {
+		$warnings = [];
+
+		if ( count( $findings['unverified'] ) > 0 ) {
+			$warnings[] = sprintf(
+				'%d baseline finding(s) could not be judged: the probe that recorded them did not run to completion in run B, so their absence is not a fix.',
+				count( $findings['unverified'] )
+			);
+		}
+
+		$on_unfinished_baseline = 0;
+
+		foreach ( $findings['introduced'] as $finding ) {
+			if ( self::STATE_COMPLETE !== $finding['baseline_probe_state'] ) {
+				++$on_unfinished_baseline;
+			}
+		}
+
+		if ( $on_unfinished_baseline > 0 ) {
+			$warnings[] = sprintf(
+				'%d introduced finding(s) sit on a probe that did not run to completion in run A, so they may be pre-existing rather than new.',
+				$on_unfinished_baseline
+			);
+		}
+
+		foreach ( $this->malformed as $side => $count ) {
+			if ( $count > 0 ) {
+				$warnings[] = sprintf(
+					'%d finding annotation(s) in run %s could not be read and are not part of this comparison.',
+					$count,
+					strtoupper( $side )
+				);
+			}
+		}
+
+		return $warnings;
+	}
+
+	/**
+	 * @param array<string,mixed> $finding
+	 * @param array<string,mixed> $extra
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function describe_finding( array $finding, array $extra = [] ): array {
+		return array_merge( [
+			'key'       => $finding['key'],
+			'signature' => $finding['signature'],
+			'type'      => $finding['type'],
+			'surface'   => $finding['surface'],
+			'profile'   => $finding['profile'],
+			'fixtures'  => $finding['fixtures'],
+			'test'      => $finding['test'],
+		], $extra );
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $findings
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function sorted( array $findings ): array {
+		usort( $findings, function ( array $a, array $b ): int {
+			return strcmp( (string) $a['key'], (string) $b['key'] );
+		} );
+
+		return $findings;
+	}
+
+	/**
+	 * The set of signatures carried by the given finding keys.
+	 *
+	 * @param array<int,string>                 $keys
+	 * @param array<string,array<string,mixed>> $findings
+	 *
+	 * @return array<string,bool>
+	 */
+	private static function signatures_of( array $keys, array $findings ): array {
+		$signatures = [];
+
+		foreach ( $keys as $key ) {
+			$signatures[ (string) $findings[ $key ]['signature'] ] = true;
+		}
+
+		return $signatures;
+	}
+
+	/**
+	 * @param array<string,string> $states
+	 */
+	private function state_of( array $states, string $test ): string {
+		return $states[ $test ] ?? self::STATE_UNKNOWN;
+	}
+
+	/**
+	 * Read every `canary-finding` annotation in a run, keyed by finding key.
+	 *
+	 * Two annotations with the same key are the same identity by construction, so
+	 * the first one wins - the comparison is over identities, not occurrences.
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	private static function findings( RunSnapshot $run ): array {
+		$findings = [];
+
+		foreach ( $run->tests as $test_key => $test ) {
+			foreach ( $test['annotations'] as $annotation ) {
+				if ( self::FINDING_ANNOTATION !== $annotation['type'] ) {
+					continue;
+				}
+
+				$finding = self::decode_finding( $annotation['description'] );
+
+				if ( is_null( $finding ) || isset( $findings[ $finding['key'] ] ) ) {
+					continue;
+				}
+
+				$finding['test']             = (string) $test_key;
+				$findings[ $finding['key'] ] = $finding;
+			}
+		}
+
+		return $findings;
+	}
+
+	/**
+	 * A finding annotation is a JSON object. Anything without both identities is
+	 * not one this comparison can place, and is counted rather than guessed at.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	private static function decode_finding( string $description ): ?array {
+		$decoded = json_decode( $description, true );
+
+		if ( ! is_array( $decoded ) ) {
+			return null;
+		}
+
+		$key       = isset( $decoded['key'] ) && is_scalar( $decoded['key'] ) ? (string) $decoded['key'] : '';
+		$signature = isset( $decoded['signature'] ) && is_scalar( $decoded['signature'] ) ? (string) $decoded['signature'] : '';
+
+		if ( '' === $key || '' === $signature ) {
+			return null;
+		}
+
+		return [
+			'key'       => $key,
+			'signature' => $signature,
+			'type'      => isset( $decoded['type'] ) && is_scalar( $decoded['type'] ) ? (string) $decoded['type'] : '',
+			'surface'   => isset( $decoded['surface'] ) && is_scalar( $decoded['surface'] ) ? (string) $decoded['surface'] : '',
+			'profile'   => isset( $decoded['profile'] ) && is_scalar( $decoded['profile'] ) ? (string) $decoded['profile'] : '',
+			'fixtures'  => self::string_list( $decoded['fixtures'] ?? [] ),
+		];
+	}
+
+	/**
+	 * @param mixed $value
+	 *
+	 * @return array<int,string>
+	 */
+	private static function string_list( $value ): array {
+		if ( ! is_array( $value ) ) {
+			return [];
+		}
+
+		$strings = [];
+
+		foreach ( $value as $entry ) {
+			if ( is_scalar( $entry ) ) {
+				$strings[] = (string) $entry;
+			}
+		}
+
+		return $strings;
+	}
+
+	private static function malformed_findings( RunSnapshot $run ): int {
+		$malformed = 0;
+
+		foreach ( $run->tests as $test ) {
+			foreach ( $test['annotations'] as $annotation ) {
+				if ( self::FINDING_ANNOTATION === $annotation['type'] && is_null( self::decode_finding( $annotation['description'] ) ) ) {
+					++$malformed;
+				}
+			}
+		}
+
+		return $malformed;
+	}
+
+	/**
+	 * How far each probe got, keyed by CTRF test key.
+	 *
+	 * @return array<string,string>
+	 */
+	private static function probe_states( RunSnapshot $run ): array {
+		$states = [];
+
+		foreach ( $run->tests as $test_key => $test ) {
+			foreach ( $test['annotations'] as $annotation ) {
+				if ( self::PROBE_STATE_ANNOTATION !== $annotation['type'] ) {
+					continue;
+				}
+
+				$state = strtolower( trim( $annotation['description'] ) );
+
+				if ( ! isset( self::STATE_RANK[ $state ] ) ) {
+					$state = self::STATE_UNKNOWN;
+				}
+
+				$states[ (string) $test_key ] = self::least_covered( $states[ (string) $test_key ] ?? self::STATE_COMPLETE, $state );
+			}
+		}
+
+		return $states;
+	}
+
+	private static function least_covered( string $a, string $b ): string {
+		return self::STATE_RANK[ $a ] >= self::STATE_RANK[ $b ] ? $a : $b;
+	}
+}

--- a/src/src/Compare/CanaryComparison.php
+++ b/src/src/Compare/CanaryComparison.php
@@ -59,8 +59,20 @@ class CanaryComparison {
 	 * The annotation types this class accounts for, and which the generic
 	 * annotation diff therefore leaves alone: reporting a moved finding as one
 	 * annotation added and another removed is exactly what this exists to prevent.
+	 *
+	 * `probe-id` is in here because it is read as the probe's identity. Rewording a
+	 * probe changes its CTRF test key, so the generic diff would report the
+	 * unchanged id as removed from one test and added to another, contradicting the
+	 * canary section that has just recognised it as the same probe.
 	 */
-	public const HANDLED_ANNOTATIONS = [ self::FINDING_ANNOTATION, self::PROBE_STATE_ANNOTATION ];
+	public const HANDLED_ANNOTATIONS = [ self::FINDING_ANNOTATION, self::PROBE_STATE_ANNOTATION, self::PROBE_ID_ANNOTATION ];
+
+	/**
+	 * The types that make a run a canary run. `probe-id` is deliberately absent: it
+	 * is a generic enough name that another package could emit it, and one stray
+	 * annotation should not conjure a canary section onto an unrelated comparison.
+	 */
+	private const CANARY_ANNOTATIONS = [ self::FINDING_ANNOTATION, self::PROBE_STATE_ANNOTATION ];
 
 	/**
 	 * The one probe state that makes an absent finding mean something.
@@ -121,10 +133,22 @@ class CanaryComparison {
 	private array $malformed;
 
 	public function __construct( RunSnapshot $a, RunSnapshot $b ) {
-		$this->a_findings = self::findings( $a );
-		$this->b_findings = self::findings( $b );
-		$this->a_states   = self::probe_states( $a );
-		$this->b_states   = self::probe_states( $b );
+		/*
+		 * One keying scheme for both runs, decided here rather than per run.
+		 *
+		 * Keying by published id where a run has one and by test key where it does
+		 * not would key the same probe two different ways across a comparison: the
+		 * probe would look absent from the candidate, its findings would go to
+		 * unverified, and two probe state changes would appear that nobody caused.
+		 * Where either run is missing an id, both fall back to the test key, which
+		 * at least matches itself.
+		 */
+		$by_id = self::publishes_probe_ids( $a ) && self::publishes_probe_ids( $b );
+
+		$this->a_findings = self::findings( $a, $by_id );
+		$this->b_findings = self::findings( $b, $by_id );
+		$this->a_states   = self::probe_states( $a, $by_id );
+		$this->b_states   = self::probe_states( $b, $by_id );
 		$this->malformed  = [
 			'a' => self::malformed_findings( $a ),
 			'b' => self::malformed_findings( $b ),
@@ -142,7 +166,7 @@ class CanaryComparison {
 	private static function carries_canary_data( RunSnapshot $run ): bool {
 		foreach ( $run->tests as $test ) {
 			foreach ( $test['annotations'] as $annotation ) {
-				if ( in_array( $annotation['type'], self::HANDLED_ANNOTATIONS, true ) ) {
+				if ( in_array( $annotation['type'], self::CANARY_ANNOTATIONS, true ) ) {
 					return true;
 				}
 			}
@@ -202,6 +226,14 @@ class CanaryComparison {
 				'pre_existing' => count( $findings['pre_existing'] ),
 			],
 		];
+	}
+
+	/**
+	 * How many findings the candidate introduced, for a caller that wants the
+	 * verdict without the whole report.
+	 */
+	public function introduced_count(): int {
+		return count( $this->compare_introduced( $this->only_b(), $this->moved_signatures() ) );
 	}
 
 	/**
@@ -521,7 +553,7 @@ class CanaryComparison {
 
 		if ( count( $findings['unverified'] ) > 0 ) {
 			$warnings[] = sprintf(
-				'%d baseline finding(s) could not be judged: the probe that recorded them did not run to completion in run B, so their absence is not a fix.',
+				'%d baseline finding(s) could not be judged: run B did not complete every probe that could have recorded them, so their absence is not a fix. Each one says which probe.',
 				count( $findings['unverified'] )
 			);
 		}
@@ -617,15 +649,49 @@ class CanaryComparison {
 	 *
 	 * @param string                                              $test_key
 	 * @param array<string,array{type:string,description:string}> $annotations
+	 * @param bool                                                $by_id
 	 */
-	private static function probe_identity( string $test_key, array $annotations ): string {
+	private static function probe_identity( string $test_key, array $annotations, bool $by_id ): string {
+		if ( ! $by_id ) {
+			return $test_key;
+		}
+
+		return self::published_probe_id( $annotations ) ?? $test_key;
+	}
+
+	/**
+	 * @param array<string,array{type:string,description:string}> $annotations
+	 */
+	private static function published_probe_id( array $annotations ): ?string {
 		foreach ( $annotations as $annotation ) {
 			if ( self::PROBE_ID_ANNOTATION === $annotation['type'] && '' !== trim( $annotation['description'] ) ) {
 				return trim( $annotation['description'] );
 			}
 		}
 
-		return $test_key;
+		return null;
+	}
+
+	/**
+	 * True when every canary result in the run publishes a probe id.
+	 */
+	private static function publishes_probe_ids( RunSnapshot $run ): bool {
+		foreach ( $run->tests as $test ) {
+			$is_canary = false;
+
+			foreach ( $test['annotations'] as $annotation ) {
+				if ( in_array( $annotation['type'], self::CANARY_ANNOTATIONS, true ) ) {
+					$is_canary = true;
+					break;
+				}
+			}
+
+			if ( $is_canary && is_null( self::published_probe_id( $test['annotations'] ) ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**
@@ -636,11 +702,11 @@ class CanaryComparison {
 	 *
 	 * @return array<string,array<string,mixed>>
 	 */
-	private static function findings( RunSnapshot $run ): array {
+	private static function findings( RunSnapshot $run, bool $by_id ): array {
 		$findings = [];
 
 		foreach ( $run->tests as $test_key => $test ) {
-			$probe = self::probe_identity( (string) $test_key, $test['annotations'] );
+			$probe = self::probe_identity( (string) $test_key, $test['annotations'], $by_id );
 
 			foreach ( $test['annotations'] as $annotation ) {
 				if ( self::FINDING_ANNOTATION !== $annotation['type'] ) {
@@ -732,11 +798,11 @@ class CanaryComparison {
 	 *
 	 * @return array<string,string>
 	 */
-	private static function probe_states( RunSnapshot $run ): array {
+	private static function probe_states( RunSnapshot $run, bool $by_id ): array {
 		$states = [];
 
 		foreach ( $run->tests as $test_key => $test ) {
-			$probe = self::probe_identity( (string) $test_key, $test['annotations'] );
+			$probe = self::probe_identity( (string) $test_key, $test['annotations'], $by_id );
 
 			foreach ( $test['annotations'] as $annotation ) {
 				if ( self::PROBE_STATE_ANNOTATION !== $annotation['type'] ) {

--- a/src/src/Compare/CanaryComparison.php
+++ b/src/src/Compare/CanaryComparison.php
@@ -237,39 +237,32 @@ class CanaryComparison {
 	}
 
 	/**
-	 * The CTRF tests in run B whose findings are all accounted for as moved or
-	 * pre-existing, so a status change on them says nothing new.
+	 * The CTRF tests in run B carrying findings this comparison could read, and
+	 * whose status change the canary buckets have therefore already spoken for.
 	 *
-	 * A probe fails when it records anything at all, so a finding that only changed
-	 * probes flips two results: the probe that lost it passes, the probe that
-	 * gained it fails. Read as ordinary test statuses that is a fix and a
-	 * regression, which is the double report the moved bucket exists to prevent -
-	 * and it would still reach the exit code through the generic verdict.
+	 * A probe fails when it records anything at all, so its status is a poor proxy
+	 * for what changed: a finding that only moved probes flips two results, and a
+	 * probe that was failing already stays failed when a new finding lands on it.
+	 * Whichever it is, the buckets have said it, and the status change would say it
+	 * again or contradict it.
 	 *
-	 * A test that failed while recording nothing is deliberately not listed. Its
-	 * failure is the harness rather than an observation, and that is a real
-	 * regression whatever the findings say.
+	 * Only readable findings count. A probe that failed carrying an annotation
+	 * nobody could parse has been classified into no bucket at all, so its status
+	 * change is the only evidence left that something happened, and discarding that
+	 * would let a run go green on a finding the comparison silently dropped. The
+	 * same goes for a probe that failed while recording nothing: that failure is
+	 * the harness, and no bucket will ever mention it.
 	 *
 	 * @return array<string,bool>
 	 */
-	public function tests_explained_by_moves(): array {
-		$introduced = [];
-
-		foreach ( $this->compare_introduced( $this->only_b(), $this->moved_signatures() ) as $finding ) {
-			$introduced[ $finding['test'] ] = true;
-		}
-
-		$explained = [];
+	public function tests_with_findings(): array {
+		$tests = [];
 
 		foreach ( $this->b_findings as $finding ) {
-			if ( isset( $introduced[ $finding['test'] ] ) ) {
-				continue;
-			}
-
-			$explained[ $finding['test'] ] = true;
+			$tests[ $finding['test'] ] = true;
 		}
 
-		return $explained;
+		return $tests;
 	}
 
 	/**
@@ -441,6 +434,21 @@ class CanaryComparison {
 				continue;
 			}
 
+			/*
+			 * An annotation nobody could read is not an absence. It may be this very
+			 * finding, still present and merely unreadable, and calling that a fix is
+			 * the same invented improvement as reading a truncated probe's silence.
+			 */
+			if ( $this->malformed['b'] > 0 ) {
+				$entry['reason'] = sprintf(
+					'Run B carries %d finding annotation(s) that could not be read, any of which could be this one.',
+					$this->malformed['b']
+				);
+
+				$unverified[] = $entry;
+				continue;
+			}
+
 			$resolved[] = $entry;
 		}
 
@@ -478,13 +486,36 @@ class CanaryComparison {
 	private function unfinished_probes(): array {
 		$unfinished = [];
 
-		foreach ( array_keys( $this->a_states + $this->b_states ) as $probe ) {
-			if ( self::STATE_COMPLETE !== $this->state_of( $this->b_states, (string) $probe ) ) {
-				$unfinished[] = (string) $probe;
+		foreach ( $this->probe_universe() as $probe ) {
+			if ( self::STATE_COMPLETE !== $this->state_of( $this->b_states, $probe ) ) {
+				$unfinished[] = $probe;
 			}
 		}
 
 		return $unfinished;
+	}
+
+	/**
+	 * Every probe either run is known to have, whether or not it said how far it
+	 * got.
+	 *
+	 * Reading this off the state annotations alone would make a probe that recorded
+	 * findings but published no state invisible to the completeness check, and a
+	 * probe nobody can account for is the one most likely to have swallowed
+	 * something.
+	 *
+	 * @return array<int,string>
+	 */
+	private function probe_universe(): array {
+		$probes = $this->a_states + $this->b_states;
+
+		foreach ( [ $this->a_findings, $this->b_findings ] as $findings ) {
+			foreach ( $findings as $finding ) {
+				$probes[ $finding['probe'] ] = self::STATE_UNKNOWN;
+			}
+		}
+
+		return array_map( 'strval', array_keys( $probes ) );
 	}
 
 	/**

--- a/src/src/Compare/CanaryComparison.php
+++ b/src/src/Compare/CanaryComparison.php
@@ -132,6 +132,28 @@ class CanaryComparison {
 	 */
 	private array $malformed;
 
+	/**
+	 * Test keys, on either side, that are canary probe results.
+	 *
+	 * @var array<string,bool>
+	 */
+	private array $canary_tests;
+
+	/**
+	 * CTRF status of each of run A's probes, keyed by probe identity rather than
+	 * test key, so a reworded probe is still the same probe.
+	 *
+	 * @var array<string,string>
+	 */
+	private array $a_probe_status;
+
+	/**
+	 * Run B's test key to probe identity.
+	 *
+	 * @var array<string,string>
+	 */
+	private array $b_test_probe;
+
 	public function __construct( RunSnapshot $a, RunSnapshot $b ) {
 		/*
 		 * One keying scheme for both runs, decided here rather than per run.
@@ -153,6 +175,38 @@ class CanaryComparison {
 			'a' => self::malformed_findings( $a ),
 			'b' => self::malformed_findings( $b ),
 		];
+
+		$this->canary_tests   = self::canary_test_keys( $a ) + self::canary_test_keys( $b );
+		$this->a_probe_status = self::probe_statuses( $a, $by_id );
+		$this->b_test_probe   = self::test_probes( $b, $by_id );
+	}
+
+	/**
+	 * The CTRF tests, on either side, that are canary probe results.
+	 *
+	 * @return array<string,bool>
+	 */
+	public function canary_tests(): array {
+		return $this->canary_tests;
+	}
+
+	/**
+	 * True when the run B test names a probe that was already failing in run A.
+	 *
+	 * A probe keeps its published id across a rename, but its CTRF test key is its
+	 * filename and description, so rewording one makes the generic diff report the
+	 * probe as removed and a different one added. If it was failing before and is
+	 * failing now, nothing regressed, and the verdict should not read the rename as
+	 * a new failure.
+	 */
+	public function failed_before( string $b_test_key ): bool {
+		$probe = $this->b_test_probe[ $b_test_key ] ?? null;
+
+		if ( is_null( $probe ) ) {
+			return false;
+		}
+
+		return ( $this->a_probe_status[ $probe ] ?? '' ) === 'failed';
 	}
 
 	/**
@@ -701,6 +755,50 @@ class CanaryComparison {
 		}
 
 		return null;
+	}
+
+	/**
+	 * @return array<string,bool>
+	 */
+	private static function canary_test_keys( RunSnapshot $run ): array {
+		$keys = [];
+
+		foreach ( $run->tests as $test_key => $test ) {
+			foreach ( $test['annotations'] as $annotation ) {
+				if ( in_array( $annotation['type'], self::CANARY_ANNOTATIONS, true ) ) {
+					$keys[ (string) $test_key ] = true;
+					break;
+				}
+			}
+		}
+
+		return $keys;
+	}
+
+	/**
+	 * @return array<string,string>
+	 */
+	private static function probe_statuses( RunSnapshot $run, bool $by_id ): array {
+		$statuses = [];
+
+		foreach ( self::test_probes( $run, $by_id ) as $test_key => $probe ) {
+			$statuses[ $probe ] = (string) $run->tests[ $test_key ]['status'];
+		}
+
+		return $statuses;
+	}
+
+	/**
+	 * @return array<string,string>
+	 */
+	private static function test_probes( RunSnapshot $run, bool $by_id ): array {
+		$probes = [];
+
+		foreach ( self::canary_test_keys( $run ) as $test_key => $unused ) {
+			$probes[ $test_key ] = self::probe_identity( $test_key, $run->tests[ $test_key ]['annotations'], $by_id );
+		}
+
+		return $probes;
 	}
 
 	/**

--- a/src/src/Compare/CanaryComparison.php
+++ b/src/src/Compare/CanaryComparison.php
@@ -44,6 +44,18 @@ class CanaryComparison {
 	public const PROBE_STATE_ANNOTATION = 'canary-probe-state';
 
 	/**
+	 * The annotation carrying the probe's stable id.
+	 *
+	 * A CTRF test key is suite plus name, which for a probe means its filename and
+	 * its human-readable description. Both are prose that can be reworded without
+	 * the probe changing, and a reworded description would make a completed probe
+	 * look absent - turning resolved findings into unverified ones and inventing
+	 * probe state changes. The package publishes an id built for this, validated
+	 * against a pattern at declaration time, so that is the identity used here.
+	 */
+	public const PROBE_ID_ANNOTATION = 'probe-id';
+
+	/**
 	 * The annotation types this class accounts for, and which the generic
 	 * annotation diff therefore leaves alone: reporting a moved finding as one
 	 * annotation added and another removed is exactly what this exists to prevent.
@@ -149,8 +161,8 @@ class CanaryComparison {
 		$a_keys = array_keys( $this->a_findings );
 		$b_keys = array_keys( $this->b_findings );
 
-		$only_a = array_values( array_diff( $a_keys, $b_keys ) );
-		$only_b = array_values( array_diff( $b_keys, $a_keys ) );
+		$only_a = $this->only_a();
+		$only_b = $this->only_b();
 
 		/*
 		 * A signature moved when it left at least one probe and turned up under at
@@ -159,10 +171,7 @@ class CanaryComparison {
 		 * under a new one in B has not moved anywhere, it happened somewhere new,
 		 * and calling that a move would hide it.
 		 */
-		$moved_signatures = array_intersect_key(
-			self::signatures_of( $only_a, $this->a_findings ),
-			self::signatures_of( $only_b, $this->b_findings )
-		);
+		$moved_signatures = $this->moved_signatures();
 
 		$moved        = $this->compare_moved( $moved_signatures, $only_a, $only_b );
 		$introduced   = $this->compare_introduced( $only_b, $moved_signatures );
@@ -193,6 +202,66 @@ class CanaryComparison {
 				'pre_existing' => count( $findings['pre_existing'] ),
 			],
 		];
+	}
+
+	/**
+	 * The CTRF tests in run B whose findings are all accounted for as moved or
+	 * pre-existing, so a status change on them says nothing new.
+	 *
+	 * A probe fails when it records anything at all, so a finding that only changed
+	 * probes flips two results: the probe that lost it passes, the probe that
+	 * gained it fails. Read as ordinary test statuses that is a fix and a
+	 * regression, which is the double report the moved bucket exists to prevent -
+	 * and it would still reach the exit code through the generic verdict.
+	 *
+	 * A test that failed while recording nothing is deliberately not listed. Its
+	 * failure is the harness rather than an observation, and that is a real
+	 * regression whatever the findings say.
+	 *
+	 * @return array<string,bool>
+	 */
+	public function tests_explained_by_moves(): array {
+		$introduced = [];
+
+		foreach ( $this->compare_introduced( $this->only_b(), $this->moved_signatures() ) as $finding ) {
+			$introduced[ $finding['test'] ] = true;
+		}
+
+		$explained = [];
+
+		foreach ( $this->b_findings as $finding ) {
+			if ( isset( $introduced[ $finding['test'] ] ) ) {
+				continue;
+			}
+
+			$explained[ $finding['test'] ] = true;
+		}
+
+		return $explained;
+	}
+
+	/**
+	 * @return array<int,string>
+	 */
+	private function only_a(): array {
+		return array_values( array_diff( array_keys( $this->a_findings ), array_keys( $this->b_findings ) ) );
+	}
+
+	/**
+	 * @return array<int,string>
+	 */
+	private function only_b(): array {
+		return array_values( array_diff( array_keys( $this->b_findings ), array_keys( $this->a_findings ) ) );
+	}
+
+	/**
+	 * @return array<string,bool>
+	 */
+	private function moved_signatures(): array {
+		return array_intersect_key(
+			self::signatures_of( $this->only_a(), $this->a_findings ),
+			self::signatures_of( $this->only_b(), $this->b_findings )
+		);
 	}
 
 	/**
@@ -236,6 +305,7 @@ class CanaryComparison {
 				$moved[ $finding['signature'] ]['type']    = $finding['type'];
 				$moved[ $finding['signature'] ][ $side ][] = [
 					'key'     => $finding['key'],
+					'probe'   => $finding['probe'],
 					'test'    => $finding['test'],
 					'surface' => $finding['surface'],
 				];
@@ -274,7 +344,7 @@ class CanaryComparison {
 			}
 
 			$introduced[] = $this->describe_finding( $finding, [
-				'baseline_probe_state' => $this->state_of( $this->a_states, $finding['test'] ),
+				'baseline_probe_state' => $this->state_of( $this->a_states, $finding['probe'] ),
 			] );
 		}
 
@@ -284,8 +354,21 @@ class CanaryComparison {
 	/**
 	 * Findings run A has that run B does not, split by whether run B looked.
 	 *
-	 * The probe read is the one the baseline finding was published on, matched by
-	 * test: that is the scenario whose later steps would have found it again.
+	 * Two conditions, not one. The obvious read is the probe that recorded the
+	 * finding in the baseline, since its later steps are what would have found it
+	 * again. But a finding is not tied to the probe that recorded it - that is the
+	 * premise of the moved bucket - so a fatal the candidate's probe did not see
+	 * may simply have landed during another probe's window, and if that probe did
+	 * not finish it published nothing. Gating on the recording probe alone would
+	 * call that a fix.
+	 *
+	 * So the whole candidate run has to be conclusive. That is deliberately
+	 * stricter than it needs to be for a finding a probe measures inside its own
+	 * workflow, where another probe's truncation is irrelevant. Telling those apart
+	 * means deciding which finding types can travel, and the cost of guessing that
+	 * wrong is a false resolution, which is the one error this comparison exists to
+	 * avoid. A run where every probe completed - the healthy case, and the case in
+	 * the reproduction - is unaffected.
 	 *
 	 * @param array<int,string>  $only_a
 	 * @param array<string,bool> $moved_signatures
@@ -303,17 +386,30 @@ class CanaryComparison {
 				continue;
 			}
 
-			$state = $this->state_of( $this->b_states, $finding['test'] );
+			$state = $this->state_of( $this->b_states, $finding['probe'] );
 			$entry = $this->describe_finding( $finding, [ 'probe_state' => $state ] );
 
-			if ( self::STATE_COMPLETE === $state ) {
-				$resolved[] = $entry;
+			if ( self::STATE_COMPLETE !== $state ) {
+				$entry['reason'] = self::absence_reason( $state, $finding['probe'] );
+
+				$unverified[] = $entry;
 				continue;
 			}
 
-			$entry['reason'] = self::absence_reason( $state, $finding['test'] );
+			$unfinished = $this->unfinished_probes();
 
-			$unverified[] = $entry;
+			if ( ! empty( $unfinished ) ) {
+				$entry['reason'] = sprintf(
+					'The probe "%s" completed in run B, but %s did not, and a finding can be recorded by whichever probe is running when it happens.',
+					$finding['probe'],
+					self::list_probes( $unfinished )
+				);
+
+				$unverified[] = $entry;
+				continue;
+			}
+
+			$resolved[] = $entry;
 		}
 
 		return [
@@ -342,18 +438,47 @@ class CanaryComparison {
 	}
 
 	/**
+	 * The probes run B did not carry to completion, including any that ran in the
+	 * baseline and are missing from it altogether.
+	 *
+	 * @return array<int,string>
+	 */
+	private function unfinished_probes(): array {
+		$unfinished = [];
+
+		foreach ( array_keys( $this->a_states + $this->b_states ) as $probe ) {
+			if ( self::STATE_COMPLETE !== $this->state_of( $this->b_states, (string) $probe ) ) {
+				$unfinished[] = (string) $probe;
+			}
+		}
+
+		return $unfinished;
+	}
+
+	/**
+	 * @param array<int,string> $probes
+	 */
+	private static function list_probes( array $probes ): string {
+		if ( count( $probes ) === 1 ) {
+			return sprintf( '"%s"', $probes[0] );
+		}
+
+		return sprintf( '%d other probes', count( $probes ) );
+	}
+
+	/**
 	 * Why an absence proves nothing, in the words of the state that caused it.
 	 */
-	private static function absence_reason( string $state, string $test ): string {
+	private static function absence_reason( string $state, string $probe ): string {
 		if ( 'truncated' === $state ) {
-			return sprintf( 'The probe "%s" stopped early in run B, so this was never looked for.', $test );
+			return sprintf( 'The probe "%s" stopped early in run B, so this was never looked for.', $probe );
 		}
 
 		if ( 'incomplete' === $state ) {
-			return sprintf( 'The probe "%s" broke in run B and published nothing, so this was never looked for.', $test );
+			return sprintf( 'The probe "%s" broke in run B and published nothing, so this was never looked for.', $probe );
 		}
 
-		return sprintf( 'Run B has no completed probe "%s", so this was never looked for.', $test );
+		return sprintf( 'Run B has no completed probe "%s", so this was never looked for.', $probe );
 	}
 
 	/**
@@ -366,18 +491,18 @@ class CanaryComparison {
 	private function changed_probe_states(): array {
 		$changed = [];
 
-		foreach ( array_keys( $this->a_states + $this->b_states ) as $test ) {
-			$a = $this->state_of( $this->a_states, $test );
-			$b = $this->state_of( $this->b_states, $test );
+		foreach ( array_keys( $this->a_states + $this->b_states ) as $probe ) {
+			$a = $this->state_of( $this->a_states, (string) $probe );
+			$b = $this->state_of( $this->b_states, (string) $probe );
 
 			if ( $a === $b ) {
 				continue;
 			}
 
 			$changed[] = [
-				'test' => (string) $test,
-				'a'    => $a,
-				'b'    => $b,
+				'probe' => (string) $probe,
+				'a'     => $a,
+				'b'     => $b,
 			];
 		}
 
@@ -443,6 +568,7 @@ class CanaryComparison {
 			'surface'   => $finding['surface'],
 			'profile'   => $finding['profile'],
 			'fixtures'  => $finding['fixtures'],
+			'probe'     => $finding['probe'],
 			'test'      => $finding['test'],
 		], $extra );
 	}
@@ -486,6 +612,23 @@ class CanaryComparison {
 	}
 
 	/**
+	 * The probe's identity: its published id, or the CTRF test key when a run
+	 * predates the id being published.
+	 *
+	 * @param string                                              $test_key
+	 * @param array<string,array{type:string,description:string}> $annotations
+	 */
+	private static function probe_identity( string $test_key, array $annotations ): string {
+		foreach ( $annotations as $annotation ) {
+			if ( self::PROBE_ID_ANNOTATION === $annotation['type'] && '' !== trim( $annotation['description'] ) ) {
+				return trim( $annotation['description'] );
+			}
+		}
+
+		return $test_key;
+	}
+
+	/**
 	 * Read every `canary-finding` annotation in a run, keyed by finding key.
 	 *
 	 * Two annotations with the same key are the same identity by construction, so
@@ -497,6 +640,8 @@ class CanaryComparison {
 		$findings = [];
 
 		foreach ( $run->tests as $test_key => $test ) {
+			$probe = self::probe_identity( (string) $test_key, $test['annotations'] );
+
 			foreach ( $test['annotations'] as $annotation ) {
 				if ( self::FINDING_ANNOTATION !== $annotation['type'] ) {
 					continue;
@@ -508,6 +653,7 @@ class CanaryComparison {
 					continue;
 				}
 
+				$finding['probe']            = $probe;
 				$finding['test']             = (string) $test_key;
 				$findings[ $finding['key'] ] = $finding;
 			}
@@ -590,6 +736,8 @@ class CanaryComparison {
 		$states = [];
 
 		foreach ( $run->tests as $test_key => $test ) {
+			$probe = self::probe_identity( (string) $test_key, $test['annotations'] );
+
 			foreach ( $test['annotations'] as $annotation ) {
 				if ( self::PROBE_STATE_ANNOTATION !== $annotation['type'] ) {
 					continue;
@@ -601,7 +749,7 @@ class CanaryComparison {
 					$state = self::STATE_UNKNOWN;
 				}
 
-				$states[ (string) $test_key ] = self::least_covered( $states[ (string) $test_key ] ?? self::STATE_COMPLETE, $state );
+				$states[ $probe ] = self::least_covered( $states[ $probe ] ?? self::STATE_COMPLETE, $state );
 			}
 		}
 

--- a/src/src/Compare/RunComparison.php
+++ b/src/src/Compare/RunComparison.php
@@ -30,6 +30,14 @@ class RunComparison {
 	 */
 	private ?bool $canary = null;
 
+	/**
+	 * Memoized canary comparison, built once and read by both the report and the
+	 * verdict.
+	 *
+	 * @var CanaryComparison|null
+	 */
+	private ?CanaryComparison $canary_comparison = null;
+
 	public function __construct( RunSnapshot $a, RunSnapshot $b ) {
 		$this->a = $a;
 		$this->b = $b;
@@ -72,7 +80,7 @@ class RunComparison {
 		 * from "these runs are not canary runs at all".
 		 */
 		if ( $this->has_canary_data() ) {
-			$comparison['canary'] = ( new CanaryComparison( $this->a, $this->b ) )->to_array();
+			$comparison['canary'] = $this->canary_comparison()->to_array();
 		}
 
 		return $comparison;
@@ -81,16 +89,26 @@ class RunComparison {
 	/**
 	 * True when run B introduced failures that run A did not have, either as a
 	 * regression on a shared test or as a new test that fails.
+	 *
+	 * Canary results are read through their own classification rather than through
+	 * the status change. A probe fails when it records anything at all, so a
+	 * finding that only changed probes flips two results and would otherwise reach
+	 * the exit code as a regression the comparison has already said is not one. A
+	 * probe that failed while recording nothing still counts: that failure is the
+	 * harness, not an observation.
 	 */
 	public function has_regressions(): bool {
-		$tests = $this->compare_tests();
+		$tests     = $this->compare_tests();
+		$explained = $this->has_canary_data() ? $this->canary_comparison()->tests_explained_by_moves() : [];
 
-		if ( count( $tests['introduced'] ) > 0 ) {
-			return true;
+		foreach ( $tests['introduced'] as $test ) {
+			if ( ! isset( $explained[ $test['key'] ] ) ) {
+				return true;
+			}
 		}
 
 		foreach ( $tests['added'] as $test ) {
-			if ( $test['status'] === 'failed' ) {
+			if ( $test['status'] === 'failed' && ! isset( $explained[ $test['key'] ] ) ) {
 				return true;
 			}
 		}
@@ -347,6 +365,14 @@ class RunComparison {
 		return array_filter( $annotations, function ( array $annotation ): bool {
 			return ! in_array( $annotation['type'], CanaryComparison::HANDLED_ANNOTATIONS, true );
 		} );
+	}
+
+	private function canary_comparison(): CanaryComparison {
+		if ( is_null( $this->canary_comparison ) ) {
+			$this->canary_comparison = new CanaryComparison( $this->a, $this->b );
+		}
+
+		return $this->canary_comparison;
 	}
 
 	private function has_canary_data(): bool {

--- a/src/src/Compare/RunComparison.php
+++ b/src/src/Compare/RunComparison.php
@@ -71,6 +71,7 @@ class RunComparison {
 				'removed'        => count( $tests['removed'] ),
 				'unchanged'      => $tests['unchanged_count'],
 				'annotations'    => count( $annotations['added'] ) + count( $annotations['removed'] ),
+				'regressions'    => $this->count_regressions(),
 			],
 		];
 
@@ -91,24 +92,60 @@ class RunComparison {
 	 * regression on a shared test or as a new test that fails.
 	 *
 	 * Canary results are read through their own classification rather than through
-	 * the status change. A probe fails when it records anything at all, so a
-	 * finding that only changed probes flips two results and would otherwise reach
-	 * the exit code as a regression the comparison has already said is not one. A
-	 * probe that failed while recording nothing still counts: that failure is the
-	 * harness, not an observation.
+	 * the status change, in both directions.
+	 *
+	 * A probe fails when it records anything at all, so the status is a poor proxy
+	 * for what changed. A finding that only moved probes flips two results and
+	 * would otherwise arrive here as a regression the comparison has already said
+	 * is not one. And a probe that was failing already stays failed when the
+	 * candidate adds a finding to it, so a confirmed new observation would
+	 * otherwise never reach the verdict at all.
+	 *
+	 * A probe that failed while recording nothing still counts. That failure is the
+	 * harness, not an observation, and no canary bucket will ever mention it.
 	 */
 	public function has_regressions(): bool {
-		$tests     = $this->compare_tests();
-		$explained = $this->has_canary_data() ? $this->canary_comparison()->tests_explained_by_moves() : [];
+		return $this->count_regressions() > 0;
+	}
+
+	/**
+	 * How many distinct things run B introduced, by the reckoning the exit code
+	 * uses. Reported alongside the buckets so the JSON, the human summary and the
+	 * exit code cannot disagree.
+	 */
+	private function count_regressions(): int {
+		$tests       = $this->compare_tests();
+		$has_canary  = $this->has_canary_data();
+		$explained   = $has_canary ? $this->canary_comparison()->tests_explained_by_moves() : [];
+		$regressions = $has_canary ? $this->canary_comparison()->introduced_count() : 0;
 
 		foreach ( $tests['introduced'] as $test ) {
-			if ( ! isset( $explained[ $test['key'] ] ) ) {
-				return true;
+			if ( ! isset( $explained[ $test['key'] ] ) && ! $this->recorded_findings( $test['key'] ) ) {
+				++$regressions;
 			}
 		}
 
 		foreach ( $tests['added'] as $test ) {
-			if ( $test['status'] === 'failed' && ! isset( $explained[ $test['key'] ] ) ) {
+			if ( $test['status'] === 'failed' && ! isset( $explained[ $test['key'] ] ) && ! $this->recorded_findings( $test['key'] ) ) {
+				++$regressions;
+			}
+		}
+
+		return $regressions;
+	}
+
+	/**
+	 * True when the test carries canary findings in run B, so the canary buckets
+	 * have already spoken for it and counting its status change as well would
+	 * report the same thing twice.
+	 */
+	private function recorded_findings( string $key ): bool {
+		if ( ! $this->has_canary_data() ) {
+			return false;
+		}
+
+		foreach ( $this->b->tests[ $key ]['annotations'] ?? [] as $annotation ) {
+			if ( $annotation['type'] === CanaryComparison::FINDING_ANNOTATION ) {
 				return true;
 			}
 		}

--- a/src/src/Compare/RunComparison.php
+++ b/src/src/Compare/RunComparison.php
@@ -22,6 +22,14 @@ class RunComparison {
 	 */
 	private ?array $tests = null;
 
+	/**
+	 * Memoized answer to "do these runs carry ecosystem canary annotations", which
+	 * both the canary section and the generic annotation diff need.
+	 *
+	 * @var bool|null
+	 */
+	private ?bool $canary = null;
+
 	public function __construct( RunSnapshot $a, RunSnapshot $b ) {
 		$this->a = $a;
 		$this->b = $b;
@@ -37,7 +45,7 @@ class RunComparison {
 		$tests       = $this->compare_tests();
 		$annotations = $this->compare_annotations();
 
-		return [
+		$comparison = [
 			'runs'        => [
 				'a' => $this->describe_run( $this->a ),
 				'b' => $this->describe_run( $this->b ),
@@ -57,6 +65,17 @@ class RunComparison {
 				'annotations'    => count( $annotations['added'] ) + count( $annotations['removed'] ),
 			],
 		];
+
+		/*
+		 * Only present when there is canary data to compare, so the shape of every
+		 * other comparison is unchanged and a consumer can tell "no canary findings"
+		 * from "these runs are not canary runs at all".
+		 */
+		if ( $this->has_canary_data() ) {
+			$comparison['canary'] = ( new CanaryComparison( $this->a, $this->b ) )->to_array();
+		}
+
+		return $comparison;
 	}
 
 	/**
@@ -270,6 +289,12 @@ class RunComparison {
 	 * Packages that emit structured, already-normalised data as annotations get
 	 * compared for free here, without this command knowing what the data means.
 	 *
+	 * The ecosystem canary's own annotations are the exception, and are left out
+	 * when its section is being built. A canary finding is not tied to the probe
+	 * that recorded it, so diffing it per test reports a finding that changed
+	 * probes as a regression and a fix at once - which is the whole reason
+	 * CanaryComparison exists.
+	 *
 	 * @return array{added:array<int,array<string,string>>,removed:array<int,array<string,string>>}
 	 */
 	private function compare_annotations(): array {
@@ -279,8 +304,8 @@ class RunComparison {
 		$keys = array_keys( $this->a->tests + $this->b->tests );
 
 		foreach ( $keys as $key ) {
-			$a_annotations = $this->a->tests[ $key ]['annotations'] ?? [];
-			$b_annotations = $this->b->tests[ $key ]['annotations'] ?? [];
+			$a_annotations = $this->generic_annotations( $this->a->tests[ $key ]['annotations'] ?? [] );
+			$b_annotations = $this->generic_annotations( $this->b->tests[ $key ]['annotations'] ?? [] );
 
 			foreach ( array_diff_key( $b_annotations, $a_annotations ) as $annotation ) {
 				$added[] = [
@@ -303,5 +328,32 @@ class RunComparison {
 			'added'   => $added,
 			'removed' => $removed,
 		];
+	}
+
+	/**
+	 * Drop the annotations the canary rules account for, so nothing is reported
+	 * twice and in two different ways. When neither run is a canary run there is
+	 * nothing to account for, and every annotation is compared generically.
+	 *
+	 * @param array<string,array{type:string,description:string}> $annotations
+	 *
+	 * @return array<string,array{type:string,description:string}>
+	 */
+	private function generic_annotations( array $annotations ): array {
+		if ( ! $this->has_canary_data() ) {
+			return $annotations;
+		}
+
+		return array_filter( $annotations, function ( array $annotation ): bool {
+			return ! in_array( $annotation['type'], CanaryComparison::HANDLED_ANNOTATIONS, true );
+		} );
+	}
+
+	private function has_canary_data(): bool {
+		if ( is_null( $this->canary ) ) {
+			$this->canary = CanaryComparison::present( $this->a, $this->b );
+		}
+
+		return $this->canary;
 	}
 }

--- a/src/src/Compare/RunComparison.php
+++ b/src/src/Compare/RunComparison.php
@@ -116,41 +116,22 @@ class RunComparison {
 	private function count_regressions(): int {
 		$tests       = $this->compare_tests();
 		$has_canary  = $this->has_canary_data();
-		$explained   = $has_canary ? $this->canary_comparison()->tests_explained_by_moves() : [];
+		$spoken_for  = $has_canary ? $this->canary_comparison()->tests_with_findings() : [];
 		$regressions = $has_canary ? $this->canary_comparison()->introduced_count() : 0;
 
 		foreach ( $tests['introduced'] as $test ) {
-			if ( ! isset( $explained[ $test['key'] ] ) && ! $this->recorded_findings( $test['key'] ) ) {
+			if ( ! isset( $spoken_for[ $test['key'] ] ) ) {
 				++$regressions;
 			}
 		}
 
 		foreach ( $tests['added'] as $test ) {
-			if ( $test['status'] === 'failed' && ! isset( $explained[ $test['key'] ] ) && ! $this->recorded_findings( $test['key'] ) ) {
+			if ( $test['status'] === 'failed' && ! isset( $spoken_for[ $test['key'] ] ) ) {
 				++$regressions;
 			}
 		}
 
 		return $regressions;
-	}
-
-	/**
-	 * True when the test carries canary findings in run B, so the canary buckets
-	 * have already spoken for it and counting its status change as well would
-	 * report the same thing twice.
-	 */
-	private function recorded_findings( string $key ): bool {
-		if ( ! $this->has_canary_data() ) {
-			return false;
-		}
-
-		foreach ( $this->b->tests[ $key ]['annotations'] ?? [] as $annotation ) {
-			if ( $annotation['type'] === CanaryComparison::FINDING_ANNOTATION ) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	/**

--- a/src/src/Compare/RunComparison.php
+++ b/src/src/Compare/RunComparison.php
@@ -126,9 +126,21 @@ class RunComparison {
 		}
 
 		foreach ( $tests['added'] as $test ) {
-			if ( $test['status'] === 'failed' && ! isset( $spoken_for[ $test['key'] ] ) ) {
-				++$regressions;
+			if ( $test['status'] !== 'failed' || isset( $spoken_for[ $test['key'] ] ) ) {
+				continue;
 			}
+
+			/*
+			 * A probe keeps its published id across a rename, but its CTRF test key is
+			 * its filename and description, so rewording one arrives here as a test
+			 * removed and a different one added. A probe that was failing before and is
+			 * failing now has not regressed, whatever it is called.
+			 */
+			if ( $has_canary && $this->canary_comparison()->failed_before( $test['key'] ) ) {
+				continue;
+			}
+
+			++$regressions;
 		}
 
 		return $regressions;
@@ -340,8 +352,8 @@ class RunComparison {
 		$keys = array_keys( $this->a->tests + $this->b->tests );
 
 		foreach ( $keys as $key ) {
-			$a_annotations = $this->generic_annotations( $this->a->tests[ $key ]['annotations'] ?? [] );
-			$b_annotations = $this->generic_annotations( $this->b->tests[ $key ]['annotations'] ?? [] );
+			$a_annotations = $this->generic_annotations( (string) $key, $this->a->tests[ $key ]['annotations'] ?? [] );
+			$b_annotations = $this->generic_annotations( (string) $key, $this->b->tests[ $key ]['annotations'] ?? [] );
 
 			foreach ( array_diff_key( $b_annotations, $a_annotations ) as $annotation ) {
 				$added[] = [
@@ -368,15 +380,20 @@ class RunComparison {
 
 	/**
 	 * Drop the annotations the canary rules account for, so nothing is reported
-	 * twice and in two different ways. When neither run is a canary run there is
-	 * nothing to account for, and every annotation is compared generically.
+	 * twice and in two different ways.
 	 *
+	 * Scoped to the tests that are canary probe results, not to the whole run. A
+	 * run can carry several packages, and `probe-id` is a generic enough name that
+	 * another one could emit it - dropping it everywhere would silently swallow a
+	 * change this comparison never looked at.
+	 *
+	 * @param string                                              $key
 	 * @param array<string,array{type:string,description:string}> $annotations
 	 *
 	 * @return array<string,array{type:string,description:string}>
 	 */
-	private function generic_annotations( array $annotations ): array {
-		if ( ! $this->has_canary_data() ) {
+	private function generic_annotations( string $key, array $annotations ): array {
+		if ( ! $this->has_canary_data() || ! isset( $this->canary_comparison()->canary_tests()[ $key ] ) ) {
 			return $annotations;
 		}
 

--- a/src/tests/unit/CompareCanaryTest.php
+++ b/src/tests/unit/CompareCanaryTest.php
@@ -1024,4 +1024,66 @@ class CompareCanaryTest extends \QIT_CLI_Tests\QITTestCase {
 			array_column( $result['annotations']['removed'], 'description' )
 		);
 	}
+
+	/**
+	 * Findings and leftover failures are counted separately in the summary, because
+	 * they are different things: a probe fails when it records anything, so its
+	 * findings are the finer statement, and a failure no finding accounts for
+	 * usually means the harness rather than the product.
+	 */
+	public function test_the_summary_separates_findings_from_unexplained_failures(): void {
+		$broken           = $this->probe( 'woo-canary.harness.smoke', 'incomplete' );
+		$broken['status'] = 'failed';
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete' ),
+				$this->probe( 'woo-canary.harness.smoke', 'complete' ),
+			] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [
+					$this->finding( 'fatal', 'Uncaught Error @ class-wc-cart.php' ),
+				] ),
+				$broken,
+			] ),
+		] );
+
+		$this->application_tester->run( [
+			'command' => 'compare',
+			'run_a'   => '1001',
+			'run_b'   => '1002',
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertStringContainsString(
+			'Run B introduced 1 canary finding(s) and 1 unexplained failure(s).',
+			$this->application_tester->getDisplay()
+		);
+	}
+
+	/**
+	 * A run whose regressions are all findings says so, rather than hedging between
+	 * the two.
+	 */
+	public function test_the_summary_names_findings_when_that_is_all_there_is(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $this->probe( 'woo-canary.checkout.custom-fields', 'complete' ) ] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [
+					$this->finding( 'fatal', 'Uncaught Error @ class-wc-cart.php' ),
+					$this->finding( 'http-error', '500 /?wc-ajax=checkout' ),
+				] ),
+			] ),
+		] );
+
+		$this->application_tester->run( [
+			'command' => 'compare',
+			'run_a'   => '1001',
+			'run_b'   => '1002',
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertStringContainsString(
+			'Run B introduced 2 canary finding(s).',
+			$this->application_tester->getDisplay()
+		);
+	}
 }

--- a/src/tests/unit/CompareCanaryTest.php
+++ b/src/tests/unit/CompareCanaryTest.php
@@ -238,14 +238,8 @@ class CompareCanaryTest extends \QIT_CLI_Tests\QITTestCase {
 		$moved = $result['canary']['findings']['moved'][0];
 
 		$this->assertSame( 'fatal:Uncaught Error: scheduled action failed @ class-wc-queue.php', $moved['signature'] );
-		$this->assertSame(
-			[ 'woo-canary.checkout.custom-fields - explores something' ],
-			array_column( $moved['from'], 'test' )
-		);
-		$this->assertSame(
-			[ 'woo-canary.pricing.drift - explores something' ],
-			array_column( $moved['to'], 'test' )
-		);
+		$this->assertSame( [ 'woo-canary.checkout.custom-fields' ], array_column( $moved['from'], 'probe' ) );
+		$this->assertSame( [ 'woo-canary.pricing.drift' ], array_column( $moved['to'], 'probe' ) );
 	}
 
 	/**
@@ -334,7 +328,7 @@ class CompareCanaryTest extends \QIT_CLI_Tests\QITTestCase {
 		$this->assertSame( 0, $result['canary']['totals']['resolved'] );
 		$this->assertSame( 'incomplete', $result['canary']['findings']['unverified'][0]['probe_state'] );
 		$this->assertSame(
-			[ [ 'test' => 'woo-canary.checkout.custom-fields - explores something', 'a' => 'complete', 'b' => 'incomplete' ] ],
+			[ [ 'probe' => 'woo-canary.checkout.custom-fields', 'a' => 'complete', 'b' => 'incomplete' ] ],
 			$result['canary']['probes']['changed']
 		);
 	}
@@ -510,5 +504,161 @@ class CompareCanaryTest extends \QIT_CLI_Tests\QITTestCase {
 		$this->assertStringContainsString( 'Resolved (0)', $display );
 		$this->assertStringContainsString( 'Probe state changes (1)', $display );
 		$this->assertStringContainsString( 'could not be judged', $display );
+	}
+
+	/**
+	 * A finding is not tied to the probe that recorded it, which is the premise of
+	 * the moved bucket. So a fatal the candidate's own probe did not see may simply
+	 * have landed during another probe's window, and a probe that did not finish
+	 * published nothing. Gating on the recording probe alone would call that a fix.
+	 */
+	public function test_another_unfinished_probe_blocks_a_resolution(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [
+					$this->finding( 'fatal', 'Uncaught Error @ class-wc-queue.php' ),
+				] ),
+				$this->probe( 'woo-canary.pricing.drift', 'complete' ),
+			] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete' ),
+				$this->probe( 'woo-canary.pricing.drift', 'truncated' ),
+			] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( 0, $result['canary']['totals']['resolved'], 'Another probe could have recorded it and did not finish' );
+		$this->assertSame( 1, $result['canary']['totals']['unverified'] );
+
+		$unverified = $result['canary']['findings']['unverified'][0];
+
+		$this->assertSame( 'complete', $unverified['probe_state'], 'The recording probe itself did finish' );
+		$this->assertStringContainsString( 'woo-canary.pricing.drift', $unverified['reason'] );
+	}
+
+	/**
+	 * The healthy case is unaffected by that stricter rule: every probe completed,
+	 * so an absence is an absence.
+	 */
+	public function test_a_fully_completed_candidate_run_still_resolves(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [
+					$this->finding( 'fatal', 'Uncaught Error @ class-wc-queue.php' ),
+				] ),
+				$this->probe( 'woo-canary.pricing.drift', 'complete' ),
+			] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete' ),
+				$this->probe( 'woo-canary.pricing.drift', 'complete' ),
+			] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( 1, $result['canary']['totals']['resolved'] );
+		$this->assertSame( 0, $result['canary']['totals']['unverified'] );
+	}
+
+	/**
+	 * A CTRF test key is the probe's filename and its human-readable description,
+	 * both of which are prose. The published probe id is the identity, so rewording
+	 * a description must not make a completed probe look absent.
+	 */
+	public function test_a_reworded_probe_description_does_not_lose_the_probe(): void {
+		$candidate         = $this->probe( 'woo-canary.checkout.custom-fields', 'complete' );
+		$candidate['name'] = 'woo-canary.checkout.custom-fields - now described differently';
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [
+					$this->finding( 'fatal', 'Uncaught Error @ class-wc-cart.php' ),
+				] ),
+			] ),
+			$this->make_run( 1002, [ $candidate ] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( 1, $result['canary']['totals']['resolved'], 'The probe is identified by its id, not its description' );
+		$this->assertSame( [], $result['canary']['probes']['changed'] );
+	}
+
+	/**
+	 * A probe fails when it records anything, so a finding that only changed probes
+	 * flips two results: one probe passes, another fails. The comparison has
+	 * already said that is neither a regression nor a fix, so it must not reach the
+	 * exit code as one.
+	 */
+	public function test_exit_code_does_not_gate_on_a_finding_that_only_moved(): void {
+		$fatal = $this->finding( 'fatal', 'Uncaught Error @ class-wc-queue.php' );
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [ $fatal ] ),
+				$this->probe( 'woo-canary.pricing.drift', 'complete' ),
+			] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete' ),
+				$this->probe( 'woo-canary.pricing.drift', 'complete', [ $fatal ] ),
+			] ),
+		] );
+
+		$exit_code = $this->application_tester->run( [
+			'command'     => 'compare',
+			'run_a'       => '1001',
+			'run_b'       => '1002',
+			'--exit-code' => true,
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertSame( Command::SUCCESS, $exit_code );
+	}
+
+	/**
+	 * A genuinely new finding still gates, so the reconciliation above cannot be
+	 * used to make a regression disappear.
+	 */
+	public function test_exit_code_still_gates_on_an_introduced_finding(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $this->probe( 'woo-canary.checkout.custom-fields', 'complete' ) ] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [
+					$this->finding( 'fatal', 'Uncaught Error @ class-wc-cart.php' ),
+				] ),
+			] ),
+		] );
+
+		$exit_code = $this->application_tester->run( [
+			'command'     => 'compare',
+			'run_a'       => '1001',
+			'run_b'       => '1002',
+			'--exit-code' => true,
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertSame( Command::FAILURE, $exit_code );
+	}
+
+	/**
+	 * A probe that failed while recording nothing failed for a reason that has
+	 * nothing to do with what it observed. That is the harness, and it gates.
+	 */
+	public function test_exit_code_gates_on_a_probe_that_failed_without_recording_anything(): void {
+		$broken           = $this->probe( 'woo-canary.checkout.custom-fields', 'incomplete' );
+		$broken['status'] = 'failed';
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $this->probe( 'woo-canary.checkout.custom-fields', 'complete' ) ] ),
+			$this->make_run( 1002, [ $broken ] ),
+		] );
+
+		$exit_code = $this->application_tester->run( [
+			'command'     => 'compare',
+			'run_a'       => '1001',
+			'run_b'       => '1002',
+			'--exit-code' => true,
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertSame( Command::FAILURE, $exit_code );
 	}
 }

--- a/src/tests/unit/CompareCanaryTest.php
+++ b/src/tests/unit/CompareCanaryTest.php
@@ -809,4 +809,97 @@ class CompareCanaryTest extends \QIT_CLI_Tests\QITTestCase {
 		);
 		$this->assertStringContainsString( 'every probe that could have recorded them', $result['canary']['warnings'][0] );
 	}
+
+	/**
+	 * An annotation nobody could read is not an absence. It may be the very finding
+	 * being judged, still present and merely unreadable, so calling it a fix is the
+	 * same invented improvement as reading a truncated probe's silence.
+	 */
+	public function test_an_unreadable_candidate_finding_blocks_a_resolution(): void {
+		$candidate = $this->probe( 'woo-canary.checkout.custom-fields', 'complete' );
+
+		$candidate['extra']['annotations'][] = [ 'type' => 'canary-finding', 'description' => 'not json at all' ];
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [
+					$this->finding( 'fatal', 'Uncaught Error @ class-wc-cart.php' ),
+				] ),
+			] ),
+			$this->make_run( 1002, [ $candidate ] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( 0, $result['canary']['totals']['resolved'], 'The unreadable annotation could be this finding' );
+		$this->assertSame( 1, $result['canary']['totals']['unverified'] );
+		$this->assertStringContainsString( 'could not be read', $result['canary']['findings']['unverified'][0]['reason'] );
+	}
+
+	/**
+	 * A probe that failed carrying an annotation nobody could parse has been
+	 * classified into no bucket at all, so its status change is the only evidence
+	 * left that something happened. Discarding it would let a run go green on a
+	 * finding the comparison silently dropped.
+	 */
+	public function test_exit_code_gates_on_a_probe_that_failed_with_an_unreadable_finding(): void {
+		$candidate           = $this->probe( 'woo-canary.checkout.custom-fields', 'complete' );
+		$candidate['status'] = 'failed';
+
+		$candidate['extra']['annotations'][] = [ 'type' => 'canary-finding', 'description' => '{"nope":true}' ];
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $this->probe( 'woo-canary.checkout.custom-fields', 'complete' ) ] ),
+			$this->make_run( 1002, [ $candidate ] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( 0, $result['canary']['totals']['introduced'], 'It could not be classified' );
+		$this->assertSame( 1, $result['totals']['regressions'], 'So the status change is the only evidence left' );
+
+		$exit_code = $this->application_tester->run( [
+			'command'     => 'compare',
+			'run_a'       => '1001',
+			'run_b'       => '1002',
+			'--exit-code' => true,
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertSame( Command::FAILURE, $exit_code );
+	}
+
+	/**
+	 * A probe that recorded findings but published no state is the one most likely
+	 * to have swallowed something, so it has to reach the completeness check even
+	 * though it is in neither state map.
+	 */
+	public function test_a_probe_with_findings_but_no_state_blocks_a_resolution(): void {
+		$stateless = $this->probe( 'woo-canary.pricing.drift', 'complete', [
+			$this->finding( 'monetary-drift', 'order total' ),
+		] );
+
+		$stateless['extra']['annotations'] = array_values( array_filter(
+			$stateless['extra']['annotations'],
+			function ( $annotation ) {
+				return $annotation['type'] !== 'canary-probe-state';
+			}
+		) );
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [
+					$this->finding( 'fatal', 'Uncaught Error @ class-wc-queue.php' ),
+				] ),
+			] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete' ),
+				$stateless,
+			] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( 0, $result['canary']['totals']['resolved'] );
+		$this->assertStringContainsString( 'woo-canary.pricing.drift', $result['canary']['findings']['unverified'][0]['reason'] );
+	}
 }

--- a/src/tests/unit/CompareCanaryTest.php
+++ b/src/tests/unit/CompareCanaryTest.php
@@ -661,4 +661,152 @@ class CompareCanaryTest extends \QIT_CLI_Tests\QITTestCase {
 
 		$this->assertSame( Command::FAILURE, $exit_code );
 	}
+
+	/**
+	 * A probe that was already failing stays failed when the candidate adds a
+	 * finding to it, so the status change says nothing. Reading the verdict off the
+	 * status alone would let a confirmed new observation pass CI silently.
+	 */
+	public function test_exit_code_gates_on_a_new_finding_on_an_already_failing_probe(): void {
+		$existing = $this->finding( 'fatal', 'Uncaught Error @ class-wc-cart.php' );
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [ $existing ] ),
+			] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [
+					$existing,
+					$this->finding( 'monetary-drift', 'order total' ),
+				] ),
+			] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( [], $result['tests']['introduced'], 'The probe was failing before and is failing now' );
+		$this->assertSame( 1, $result['canary']['totals']['introduced'] );
+		$this->assertSame( 1, $result['totals']['regressions'] );
+
+		$exit_code = $this->application_tester->run( [
+			'command'     => 'compare',
+			'run_a'       => '1001',
+			'run_b'       => '1002',
+			'--exit-code' => true,
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertSame( Command::FAILURE, $exit_code );
+	}
+
+	/**
+	 * The closing summary reports the number the exit code gates on, so a pure move
+	 * cannot be called a regression on the last line of a report that has just
+	 * called it a move.
+	 */
+	public function test_the_summary_does_not_call_a_move_a_regression(): void {
+		$fatal = $this->finding( 'fatal', 'Uncaught Error @ class-wc-queue.php' );
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [ $fatal ] ),
+				$this->probe( 'woo-canary.pricing.drift', 'complete' ),
+			] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete' ),
+				$this->probe( 'woo-canary.pricing.drift', 'complete', [ $fatal ] ),
+			] ),
+		] );
+
+		$this->application_tester->run( [
+			'command' => 'compare',
+			'run_a'   => '1001',
+			'run_b'   => '1002',
+		], [ 'capture_stderr_separately' => true ] );
+
+		$display = $this->application_tester->getDisplay();
+
+		$this->assertStringContainsString( 'Moved between probes (1)', $display );
+		$this->assertStringContainsString( 'No failures introduced by run B.', $display );
+	}
+
+	/**
+	 * Keying one run by its published probe ids and the other by test keys would
+	 * key the same probe two different ways, so the probe would look absent from
+	 * the candidate. Where either run lacks an id, both fall back to the test key.
+	 */
+	public function test_a_run_without_probe_ids_still_matches_one_that_has_them(): void {
+		$baseline = $this->probe( 'woo-canary.checkout.custom-fields', 'complete', [
+			$this->finding( 'fatal', 'Uncaught Error @ class-wc-cart.php' ),
+		] );
+
+		$baseline['extra']['annotations'] = array_values( array_filter(
+			$baseline['extra']['annotations'],
+			function ( $annotation ) {
+				return $annotation['type'] !== 'probe-id';
+			}
+		) );
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $baseline ] ),
+			$this->make_run( 1002, [ $this->probe( 'woo-canary.checkout.custom-fields', 'complete' ) ] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( 1, $result['canary']['totals']['resolved'] );
+		$this->assertSame( [], $result['canary']['probes']['changed'] );
+	}
+
+	/**
+	 * `probe-id` is read as the probe's identity, so the generic diff must not
+	 * report an unchanged id as removed from one test and added to another when a
+	 * probe is reworded.
+	 */
+	public function test_probe_ids_are_left_out_of_the_generic_annotation_diff(): void {
+		$candidate         = $this->probe( 'woo-canary.checkout.custom-fields', 'complete' );
+		$candidate['name'] = 'woo-canary.checkout.custom-fields - reworded';
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $this->probe( 'woo-canary.checkout.custom-fields', 'complete' ) ] ),
+			$this->make_run( 1002, [ $candidate ] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$types = array_merge(
+			array_column( $result['annotations']['added'], 'type' ),
+			array_column( $result['annotations']['removed'], 'type' )
+		);
+
+		$this->assertNotContains( 'probe-id', $types );
+	}
+
+	/**
+	 * The summary warning must not claim the recording probe failed to finish, now
+	 * that a finding can be unverified while its own probe completed.
+	 */
+	public function test_the_warning_does_not_blame_a_probe_that_completed(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [
+					$this->finding( 'fatal', 'Uncaught Error @ class-wc-queue.php' ),
+				] ),
+				$this->probe( 'woo-canary.pricing.drift', 'complete' ),
+			] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete' ),
+				$this->probe( 'woo-canary.pricing.drift', 'incomplete' ),
+			] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( 1, $result['canary']['totals']['unverified'] );
+		$this->assertStringNotContainsString(
+			'the probe that recorded them',
+			$result['canary']['warnings'][0],
+			'The recording probe completed, so the warning must not say otherwise'
+		);
+		$this->assertStringContainsString( 'every probe that could have recorded them', $result['canary']['warnings'][0] );
+	}
 }

--- a/src/tests/unit/CompareCanaryTest.php
+++ b/src/tests/unit/CompareCanaryTest.php
@@ -902,4 +902,126 @@ class CompareCanaryTest extends \QIT_CLI_Tests\QITTestCase {
 		$this->assertSame( 0, $result['canary']['totals']['resolved'] );
 		$this->assertStringContainsString( 'woo-canary.pricing.drift', $result['canary']['findings']['unverified'][0]['reason'] );
 	}
+
+	/**
+	 * The test buckets are about probe results and the canary section is about
+	 * findings, so a move legitimately appears in both, saying different things. A
+	 * reader who has just been told the finding moved needs to know why the section
+	 * above disagrees.
+	 */
+	public function test_the_report_reconciles_a_move_with_the_test_buckets(): void {
+		$fatal = $this->finding( 'fatal', 'Uncaught Error @ class-wc-queue.php' );
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [ $fatal ] ),
+				$this->probe( 'woo-canary.pricing.drift', 'complete' ),
+			] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete' ),
+				$this->probe( 'woo-canary.pricing.drift', 'complete', [ $fatal ] ),
+			] ),
+		] );
+
+		$this->application_tester->run( [
+			'command' => 'compare',
+			'run_a'   => '1001',
+			'run_b'   => '1002',
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertStringContainsString(
+			'Neither is a change in what the build does',
+			$this->application_tester->getDisplay()
+		);
+	}
+
+	/**
+	 * A probe keeps its published id across a rename, but its CTRF test key is its
+	 * filename and description. A probe that was failing before and is failing now
+	 * has not regressed, whatever it is called.
+	 */
+	public function test_renaming_an_already_failing_probe_does_not_gate(): void {
+		$before           = $this->probe( 'woo-canary.checkout.custom-fields', 'incomplete' );
+		$before['status'] = 'failed';
+
+		$after           = $this->probe( 'woo-canary.checkout.custom-fields', 'incomplete' );
+		$after['status'] = 'failed';
+		$after['name']   = 'woo-canary.checkout.custom-fields - reworded';
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $before ] ),
+			$this->make_run( 1002, [ $after ] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( [ 'woo-canary.checkout.custom-fields - reworded' ], array_column( $result['tests']['added'], 'key' ) );
+		$this->assertSame( 0, $result['totals']['regressions'], 'It was failing before the rename too' );
+
+		$exit_code = $this->application_tester->run( [
+			'command'     => 'compare',
+			'run_a'       => '1001',
+			'run_b'       => '1002',
+			'--exit-code' => true,
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertSame( Command::SUCCESS, $exit_code );
+	}
+
+	/**
+	 * A renamed probe that was passing and now fails is still a regression, so the
+	 * carry-over above cannot be used to hide one behind a rename.
+	 */
+	public function test_renaming_a_newly_failing_probe_still_gates(): void {
+		$after           = $this->probe( 'woo-canary.checkout.custom-fields', 'incomplete' );
+		$after['status'] = 'failed';
+		$after['name']   = 'woo-canary.checkout.custom-fields - reworded';
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $this->probe( 'woo-canary.checkout.custom-fields', 'complete' ) ] ),
+			$this->make_run( 1002, [ $after ] ),
+		] );
+
+		$exit_code = $this->application_tester->run( [
+			'command'     => 'compare',
+			'run_a'       => '1001',
+			'run_b'       => '1002',
+			'--exit-code' => true,
+		], [ 'capture_stderr_separately' => true ] );
+
+		$this->assertSame( Command::FAILURE, $exit_code );
+	}
+
+	/**
+	 * A run can carry several packages, and `probe-id` is a generic enough name
+	 * that another one could emit it. Suppressing it run-wide would swallow a
+	 * change this comparison never looked at.
+	 */
+	public function test_a_non_canary_test_keeps_its_annotations(): void {
+		$other_a = [
+			'name'     => 'some other package test',
+			'status'   => 'passed',
+			'duration' => 1000,
+			'extra'    => [ 'annotations' => [ [ 'type' => 'probe-id', 'description' => 'unrelated-one' ] ] ],
+		];
+
+		$other_b            = $other_a;
+		$other_b['extra']['annotations'] = [ [ 'type' => 'probe-id', 'description' => 'unrelated-two' ] ];
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $this->probe( 'woo-canary.checkout.custom-fields', 'complete' ), $other_a ] ),
+			$this->make_run( 1002, [ $this->probe( 'woo-canary.checkout.custom-fields', 'complete' ), $other_b ] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame(
+			[ 'unrelated-two' ],
+			array_column( $result['annotations']['added'], 'description' )
+		);
+		$this->assertSame(
+			[ 'unrelated-one' ],
+			array_column( $result['annotations']['removed'], 'description' )
+		);
+	}
 }

--- a/src/tests/unit/CompareCanaryTest.php
+++ b/src/tests/unit/CompareCanaryTest.php
@@ -1,0 +1,514 @@
+<?php
+
+use QIT_CLI\App;
+use Symfony\Component\Console\Command\Command;
+use function QIT_CLI\get_manager_url;
+
+/**
+ * The two domain rules `qit compare` applies to runs of the WooCommerce ecosystem
+ * canary package, which a generic annotation diff gets wrong:
+ *
+ * 1. A finding that changed probes moved. It is not a regression, and the
+ *    baseline's copy of it is not a fix.
+ * 2. A finding missing from a probe that did not run to completion was never
+ *    looked for, so its absence is not a fix either.
+ *
+ * Both shipped once already in the prototype with the bug in them, which is why
+ * they are tested rather than only implemented.
+ */
+class CompareCanaryTest extends \QIT_CLI_Tests\QITTestCase {
+	/** @var \Symfony\Component\Console\Tester\ApplicationTester */
+	protected $application_tester;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->application_tester = $this->make_application_tester();
+	}
+
+	/**
+	 * One probe result, as the canary package publishes it: a CTRF test carrying a
+	 * `canary-probe-state` annotation and one `canary-finding` annotation per
+	 * finding, each a JSON object with the two identities the rules read.
+	 *
+	 * @param array<int,array<string,string>> $findings
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function probe( string $probe_id, string $state, array $findings = [] ): array {
+		$annotations = [
+			[ 'type' => 'probe-id', 'description' => $probe_id ],
+			[ 'type' => 'canary-probe-state', 'description' => $state ],
+		];
+
+		foreach ( $findings as $finding ) {
+			// The two identities are built here the way the package builds them, so a
+			// fixture cannot accidentally agree with the comparison on a shape neither
+			// of them would see in a real run.
+			$annotations[] = [
+				'type'        => 'canary-finding',
+				'description' => (string) json_encode( [
+					'key'       => sprintf( '%s:%s:%s', $finding['type'], $probe_id, $finding['signature'] ),
+					'signature' => sprintf( '%s:%s', $finding['type'], $finding['signature'] ),
+					'type'      => $finding['type'],
+					'surface'   => $finding['surface'],
+					'profile'   => $finding['profile'],
+					'fixtures'  => [],
+				] ),
+			];
+		}
+
+		return [
+			'name'     => $probe_id . ' - explores something',
+			'status'   => empty( $findings ) ? 'passed' : 'failed',
+			'duration' => 1000,
+			'extra'    => [ 'annotations' => $annotations ],
+		];
+	}
+
+	/**
+	 * @param array<string,string> $overrides
+	 *
+	 * @return array<string,string>
+	 */
+	private function finding( string $type, string $signature, array $overrides = [] ): array {
+		return array_merge( [
+			'type'      => $type,
+			'signature' => $signature,
+			'surface'   => 'classic-checkout',
+			'profile'   => 'synthetic',
+		], $overrides );
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $probes
+	 * @param array<string,mixed>            $overrides
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function make_run( int $id, array $probes, array $overrides = [] ): array {
+		$failed = count( array_filter( $probes, function ( $probe ) {
+			return $probe['status'] === 'failed';
+		} ) );
+
+		$run = [
+			'test_run_id'              => $id,
+			'test_type'                => 'e2e',
+			'wordpress_version'        => '6.7',
+			'woocommerce_version'      => '11.0.0-rc.1',
+			'php_version'              => '8.2',
+			'extension_set'            => '',
+			'version'                  => '1.0.0',
+			'status'                   => $failed > 0 ? 'failed' : 'success',
+			'woo_extension'            => [ 'name' => 'WooCommerce' ],
+			'test_results_manager_url' => sprintf( 'https://qit.woo.com/results/%d.abc', $id ),
+			'created_at'               => '2025-01-15 10:30:00',
+			'update_complete'          => true,
+			'test_result_json'         => '',
+			'ctrf_json'                => (string) json_encode( [
+				'reportFormat' => 'CTRF',
+				'results'      => [
+					'tool'    => [ 'name' => 'playwright' ],
+					'summary' => [
+						'tests'   => count( $probes ),
+						'passed'  => count( $probes ) - $failed,
+						'failed'  => $failed,
+						'pending' => 0,
+						'skipped' => 0,
+						'other'   => 0,
+					],
+					'tests'   => $probes,
+				],
+			] ),
+		];
+
+		return array_merge( $run, $overrides );
+	}
+
+	/**
+	 * @param array<int,array<string,mixed>> $runs
+	 */
+	private function mock_runs( array $runs ): void {
+		$keyed = [];
+
+		foreach ( $runs as $run ) {
+			$keyed[ (string) $run['test_run_id'] ] = $run;
+		}
+
+		App::setVar(
+			sprintf( 'mock_%s%s', get_manager_url(), '/wp-json/cd/v1/get-multiple' ),
+			(string) json_encode( $keyed )
+		);
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function run_compare_json(): array {
+		$this->application_tester->run( [
+			'command'  => 'compare',
+			'run_a'    => '1001',
+			'run_b'    => '1002',
+			'--format' => 'json',
+		], [ 'capture_stderr_separately' => true ] );
+
+		$decoded = json_decode( $this->application_tester->getDisplay(), true );
+
+		$this->assertIsArray( $decoded, 'Output must be valid JSON. Got: ' . $this->application_tester->getDisplay() );
+
+		return $decoded;
+	}
+
+	/**
+	 * The motivating case, and the shape of the reproduction in QIT-1074: a
+	 * candidate build that introduced findings the baseline did not have.
+	 */
+	public function test_canary_reports_what_the_candidate_introduced(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete' ),
+			], [ 'woocommerce_version' => '10.9.4' ] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [
+					$this->finding( 'fatal', 'Uncaught Error: Call to a member function get_country() @ class-wc-customer.php' ),
+					$this->finding( 'http-error', '500 /?wc-ajax=checkout' ),
+				] ),
+			] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( 2, $result['canary']['totals']['introduced'] );
+		$this->assertSame( 0, $result['canary']['totals']['resolved'] );
+		$this->assertSame( 0, $result['canary']['totals']['moved'] );
+		$this->assertSame( 0, $result['canary']['totals']['unverified'] );
+		$this->assertSame( [], $result['canary']['warnings'] );
+	}
+
+	/**
+	 * The other half of the reproduction: the fix. Every baseline finding has to
+	 * come back as resolved, which is the proof that the fingerprints survived a
+	 * version bump - had normalisation leaked a path or a line number, the same
+	 * findings would arrive as introduced and resolved at once.
+	 */
+	public function test_canary_reports_resolved_findings_against_a_completed_probe(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [
+					$this->finding( 'fatal', 'Uncaught Error @ class-wc-customer.php' ),
+					$this->finding( 'monetary-drift', 'order total' ),
+				] ),
+			] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete' ),
+			], [ 'woocommerce_version' => '11.0.0-rc.3' ] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( 2, $result['canary']['totals']['resolved'] );
+		$this->assertSame( 0, $result['canary']['totals']['introduced'] );
+		$this->assertSame( 0, $result['canary']['totals']['unverified'] );
+	}
+
+	/**
+	 * Rule 1. A fatal raised by a loopback request or a scheduled action lands
+	 * under whichever probe happened to be running. Diffed per test that reads as a
+	 * regression on one probe and a fix on the other, and both are wrong.
+	 */
+	public function test_a_finding_that_changed_probes_is_moved_rather_than_introduced_and_resolved(): void {
+		$fatal = $this->finding( 'fatal', 'Uncaught Error: scheduled action failed @ class-wc-queue.php' );
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [ $fatal ] ),
+				$this->probe( 'woo-canary.pricing.drift', 'complete' ),
+			] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete' ),
+				$this->probe( 'woo-canary.pricing.drift', 'complete', [ $fatal ] ),
+			] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( 0, $result['canary']['totals']['introduced'], 'A relocated finding is not a regression' );
+		$this->assertSame( 0, $result['canary']['totals']['resolved'], 'The baseline copy of a relocated finding is not a fix' );
+		$this->assertSame( 1, $result['canary']['totals']['moved'] );
+
+		$moved = $result['canary']['findings']['moved'][0];
+
+		$this->assertSame( 'fatal:Uncaught Error: scheduled action failed @ class-wc-queue.php', $moved['signature'] );
+		$this->assertSame(
+			[ 'woo-canary.checkout.custom-fields - explores something' ],
+			array_column( $moved['from'], 'test' )
+		);
+		$this->assertSame(
+			[ 'woo-canary.pricing.drift - explores something' ],
+			array_column( $moved['to'], 'test' )
+		);
+	}
+
+	/**
+	 * A signature the baseline still records under its original probe has not moved
+	 * anywhere. It also happened somewhere new, and calling that a move would hide
+	 * a finding the candidate introduced.
+	 */
+	public function test_a_signature_that_stayed_put_and_also_appeared_elsewhere_is_introduced(): void {
+		$fatal = $this->finding( 'fatal', 'Uncaught Error @ class-wc-queue.php' );
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [ $fatal ] ),
+				$this->probe( 'woo-canary.pricing.drift', 'complete' ),
+			] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [ $fatal ] ),
+				$this->probe( 'woo-canary.pricing.drift', 'complete', [ $fatal ] ),
+			] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( 0, $result['canary']['totals']['moved'] );
+		$this->assertSame( 1, $result['canary']['totals']['pre_existing'] );
+		$this->assertSame(
+			[ 'fatal:woo-canary.pricing.drift:Uncaught Error @ class-wc-queue.php' ],
+			array_column( $result['canary']['findings']['introduced'], 'key' )
+		);
+	}
+
+	/**
+	 * Rule 2, and the failure mode the whole comparison exists to avoid: a
+	 * candidate whose probe stops earlier than the baseline's never looked for the
+	 * findings that come after the stopping point, so reporting them as fixed is an
+	 * improvement that did not happen.
+	 */
+	public function test_a_truncated_probe_does_not_turn_baseline_findings_into_fixes(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [
+					$this->finding( 'monetary-drift', 'order total' ),
+				] ),
+			] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'truncated', [
+					$this->finding( 'workflow-failure', 'the Store API refused adding to the cart' ),
+				] ),
+			] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( 0, $result['canary']['totals']['resolved'], 'A probe that stopped early did not fix anything' );
+		$this->assertSame( 1, $result['canary']['totals']['unverified'] );
+		$this->assertSame( 1, $result['canary']['totals']['introduced'] );
+
+		$unverified = $result['canary']['findings']['unverified'][0];
+
+		$this->assertSame( 'monetary-drift:woo-canary.checkout.custom-fields:order total', $unverified['key'] );
+		$this->assertSame( 'truncated', $unverified['probe_state'] );
+		$this->assertStringContainsString( 'never looked for', $unverified['reason'] );
+
+		$this->assertCount( 1, $result['canary']['warnings'] );
+		$this->assertStringContainsString( 'could not be judged', $result['canary']['warnings'][0] );
+	}
+
+	/**
+	 * A probe that broke publishes nothing, so the same caveat applies more
+	 * strongly: its silence says nothing about the product.
+	 */
+	public function test_an_incomplete_probe_does_not_turn_baseline_findings_into_fixes(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [
+					$this->finding( 'fatal', 'Uncaught Error @ class-wc-cart.php' ),
+				] ),
+			] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'incomplete' ),
+			] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( 0, $result['canary']['totals']['resolved'] );
+		$this->assertSame( 'incomplete', $result['canary']['findings']['unverified'][0]['probe_state'] );
+		$this->assertSame(
+			[ [ 'test' => 'woo-canary.checkout.custom-fields - explores something', 'a' => 'complete', 'b' => 'incomplete' ] ],
+			$result['canary']['probes']['changed']
+		);
+	}
+
+	/**
+	 * A probe the candidate does not have at all cannot have looked either. The
+	 * absence has to read the same way as a probe that broke.
+	 */
+	public function test_a_probe_missing_from_the_candidate_does_not_resolve_anything(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [
+					$this->finding( 'fatal', 'Uncaught Error @ class-wc-cart.php' ),
+				] ),
+			] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.pricing.drift', 'complete' ),
+			] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( 0, $result['canary']['totals']['resolved'] );
+		$this->assertSame( 'unknown', $result['canary']['findings']['unverified'][0]['probe_state'] );
+	}
+
+	/**
+	 * A finding on both sides is how WooCommerce already behaves, and is the bulk
+	 * of a healthy comparison rather than something to report as a change.
+	 */
+	public function test_a_finding_present_in_both_runs_is_pre_existing(): void {
+		$fatal = $this->finding( 'fatal', 'Uncaught Error @ class-wc-cart.php' );
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $this->probe( 'woo-canary.checkout.custom-fields', 'complete', [ $fatal ] ) ] ),
+			$this->make_run( 1002, [ $this->probe( 'woo-canary.checkout.custom-fields', 'complete', [ $fatal ] ) ] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( 1, $result['canary']['totals']['pre_existing'] );
+		$this->assertSame( 0, $result['canary']['totals']['introduced'] );
+		$this->assertSame( 0, $result['canary']['totals']['resolved'] );
+	}
+
+	/**
+	 * An introduced finding on a probe the baseline never finished may be
+	 * pre-existing. It stays reported - under-reporting a regression is the worse
+	 * error for an advisory package - but says what the baseline probe did.
+	 */
+	public function test_an_introduced_finding_says_when_the_baseline_probe_did_not_finish(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'truncated' ),
+			] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [
+					$this->finding( 'fatal', 'Uncaught Error @ class-wc-cart.php' ),
+				] ),
+			] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( 1, $result['canary']['totals']['introduced'] );
+		$this->assertSame( 'truncated', $result['canary']['findings']['introduced'][0]['baseline_probe_state'] );
+		$this->assertStringContainsString( 'may be pre-existing', $result['canary']['warnings'][0] );
+	}
+
+	/**
+	 * The canary annotations are reported by the rules that understand them and
+	 * nowhere else: left in the generic diff, one moved finding would arrive there
+	 * as an annotation added and another removed, which is the bug in the first
+	 * place.
+	 */
+	public function test_canary_annotations_are_left_out_of_the_generic_annotation_diff(): void {
+		$fatal = $this->finding( 'fatal', 'Uncaught Error @ class-wc-queue.php' );
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [ $fatal ] ),
+				$this->probe( 'woo-canary.pricing.drift', 'complete' ),
+			] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'truncated' ),
+				$this->probe( 'woo-canary.pricing.drift', 'complete', [ $fatal ] ),
+			] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$types = array_merge(
+			array_column( $result['annotations']['added'], 'type' ),
+			array_column( $result['annotations']['removed'], 'type' )
+		);
+
+		$this->assertNotContains( 'canary-finding', $types );
+		$this->assertNotContains( 'canary-probe-state', $types );
+		$this->assertSame( 1, $result['canary']['totals']['moved'] );
+	}
+
+	/**
+	 * A finding annotation that cannot be read is counted rather than dropped: a
+	 * finding that silently disappears from one side reads as an improvement.
+	 */
+	public function test_an_unreadable_finding_annotation_is_reported_rather_than_dropped(): void {
+		$probe             = $this->probe( 'woo-canary.checkout.custom-fields', 'complete' );
+		$probe['extra']['annotations'][] = [ 'type' => 'canary-finding', 'description' => 'not json at all' ];
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [ $probe ] ),
+			$this->make_run( 1002, [ $this->probe( 'woo-canary.checkout.custom-fields', 'complete' ) ] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertSame( 0, $result['canary']['totals']['resolved'] );
+		$this->assertStringContainsString( 'could not be read', $result['canary']['warnings'][0] );
+		$this->assertStringContainsString( 'run A', $result['canary']['warnings'][0] );
+	}
+
+	/**
+	 * Runs that carry no canary data get no canary section at all, so a consumer
+	 * can tell "this canary run found nothing" from "these are not canary runs".
+	 */
+	public function test_a_run_without_canary_data_gets_no_canary_section(): void {
+		$this->mock_runs( [
+			$this->make_run( 1001, [ [ 'name' => 'checkout', 'status' => 'passed', 'duration' => 1000 ] ] ),
+			$this->make_run( 1002, [ [ 'name' => 'checkout', 'status' => 'passed', 'duration' => 1000 ] ] ),
+		] );
+
+		$result = $this->run_compare_json();
+
+		$this->assertArrayNotHasKey( 'canary', $result );
+	}
+
+	/**
+	 * The human output carries the same buckets as the JSON, since a reader
+	 * skimming a terminal is the likelier consumer of an advisory result.
+	 */
+	public function test_canary_human_output_names_every_bucket(): void {
+		$moved = $this->finding( 'fatal', 'Uncaught Error @ class-wc-queue.php' );
+
+		$this->mock_runs( [
+			$this->make_run( 1001, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'complete', [
+					$moved,
+					$this->finding( 'monetary-drift', 'order total' ),
+				] ),
+				$this->probe( 'woo-canary.pricing.drift', 'complete' ),
+			] ),
+			$this->make_run( 1002, [
+				$this->probe( 'woo-canary.checkout.custom-fields', 'truncated', [
+					$this->finding( 'workflow-failure', 'the Store API refused adding to the cart' ),
+				] ),
+				$this->probe( 'woo-canary.pricing.drift', 'complete', [ $moved ] ),
+			] ),
+		] );
+
+		$exit_code = $this->application_tester->run( [
+			'command' => 'compare',
+			'run_a'   => '1001',
+			'run_b'   => '1002',
+		], [ 'capture_stderr_separately' => true ] );
+
+		$display = $this->application_tester->getDisplay();
+
+		$this->assertSame( Command::SUCCESS, $exit_code );
+		$this->assertStringContainsString( 'Ecosystem canary findings', $display );
+		$this->assertStringContainsString( 'Introduced (1)', $display );
+		$this->assertStringContainsString( 'Moved between probes (1)', $display );
+		$this->assertStringContainsString( 'Not looked for in run B (1)', $display );
+		$this->assertStringContainsString( 'Resolved (0)', $display );
+		$this->assertStringContainsString( 'Probe state changes (1)', $display );
+		$this->assertStringContainsString( 'could not be judged', $display );
+	}
+}


### PR DESCRIPTION
## What changed

`qit compare` applies two rules to ecosystem canary runs that a generic annotation diff gets wrong.

A fatal from a loopback request or a scheduled action lands under whichever probe was running, which is not stable between runs. Diffed per test, one relocated finding came out as a regression and a fix at once. Findings already carry a `key` scoped to the probe and a `signature` for the problem alone, so a signature that changed probes is now reported as moved.

Probes also publish `complete`, `truncated` or `incomplete`. A baseline finding missing from a probe that stopped early was never looked for, so it goes to `unverified` instead of `resolved`.

Buckets are introduced, resolved, moved, unverified and pre-existing, with probe state changes and warnings alongside. Runs with no canary data get no section.

## Why

A candidate whose checkout probe stops earlier than the baseline's reports every later baseline finding as fixed. Inventing that improvement is what the comparison exists to prevent.

## How it works

A signature counts as moved only if it left a probe and arrived at one. One still recorded under its original probe in both runs, and also showing up under a new one, has not moved. It happened somewhere new, and calling it a move would hide it.

The directions are asymmetric on purpose. An introduced finding whose baseline probe never completed stays introduced, with that state and a warning. Nothing gates on this package, so an advisory line a human dismisses is cheaper than an improvement that never happened.

`canary-finding` and `canary-probe-state` leave the generic annotation diff when canary data is present. Leaving them in is how one moved finding reads as two changes.

## Validation

Reproduced against real canary runs on WooCommerce 11.0.0-rc.1 (5113057) and 11.0.1 (5113054), AutomateWoo as SUT, everything but the WooCommerce build held constant:

- rc.1 as baseline: 0 introduced, **exactly 5 resolved**, 0 pre-existing.
- Reversed: **5 introduced**, 0 resolved.

Same five identities both ways, which is what proves the fingerprints survive a version bump. Had normalisation leaked a path or a line number, the two runs would not have matched and it would report 5 introduced and 5 resolved at once. The five are the ones Automattic/compatibility-dashboard#1808 found on rc.1: the `WC_Customer::get_order_country()` fatal, the HTTP 500 on `?wc-ajax=checkout`, a checkout that placed no order, and drift on cart total and cart tax.

rc.1 truncates its checkout probe, so both directions report the probe state change. In the resolving direction the candidate's copy of that probe is complete, so the absences are judged rather than parked in `unverified`, and all five land in `resolved`.

Clean pairs stay clean: 10.9.4, 11.0.1 and 11.1.0-rc.2 against each other report no findings and no phantom buckets.

- 482 tests, 1397 assertions, no failures. 31 of them cover this, including both rules in both directions, a signature that stayed put and also appeared elsewhere, a probe missing from the candidate, unreadable annotations on either side, a reworded probe, and every path the exit code takes.
- `make phpcs`, `make phpstan` and `make phan` clean. Compare and canary tests green on PHP 7.4.
- `moved` and `unverified` are covered by unit tests only. Neither fires on these builds, since nothing relocates between probes and the truncation falls on the baseline side.

Four rounds of review followed the first commit, and the later commits are worth reading on their own. Everything they found was the same mistake: a verdict stated more confidently than the data supported. An absence judged against one probe when a finding can be recorded by any of them. An annotation nobody could parse treated as an annotation that was not there. A probe identified by its description rather than its published id. Each fix is a separate commit with its reasoning.

Annotation shapes read off `Automattic/compatibility-dashboard` trunk (`src/canary/probe.ts`, `observe.ts`, `observations.ts`).

## Known limitation

`canary-environment` still goes through the generic annotation diff, where it prints the full environment JSON twice per probe on every canary comparison, since the WooCommerce version is the variable under test. Left alone here to keep this PR to the two rules. Either suppress it the way the two canary types are suppressed, or use it for a guard check, which is what the package emits it for.

Refs QIT-1074.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
